### PR TITLE
Fix: Correct .gitignore paths when using relative project roots

### DIFF
--- a/src/core/GitignoreUtils.ts
+++ b/src/core/GitignoreUtils.ts
@@ -29,7 +29,24 @@ export async function updateGitignore(
 
   // Convert paths to relative POSIX format
   const relativePaths = paths.map((p) => {
-    const relative = path.isAbsolute(p) ? path.relative(projectRoot, p) : p;
+    let relative: string;
+    if (path.isAbsolute(p)) {
+      relative = path.relative(projectRoot, p);
+    } else {
+      // Handle relative paths that might include the project root prefix
+      const normalizedProjectRoot = path.normalize(projectRoot);
+      const normalizedPath = path.normalize(p);
+
+      // Get the basename of the project root to match against path prefixes
+      const projectBasename = path.basename(normalizedProjectRoot);
+
+      // If the path starts with the project basename, remove it
+      if (normalizedPath.startsWith(projectBasename + path.sep)) {
+        relative = normalizedPath.substring(projectBasename.length + 1);
+      } else {
+        relative = normalizedPath;
+      }
+    }
     return relative.replace(/\\/g, '/'); // Convert to POSIX format
   });
 


### PR DESCRIPTION
## Summary
- Fixes incorrect .gitignore path generation when using relative project roots
- Normalizes path handling to support both relative and absolute project root specifications

## Changes
- Modified updateGitignore() in src/core/GitignoreUtils.ts to properly handle relative paths that include the project root prefix
- Added logic to detect and strip project root basename from relative paths
- Maintains backward compatibility with absolute project root paths

## Test Plan
- ✅ Test with relative project root (./test-project)
- ✅ Test with absolute project root (/full/path/to/test-project)  
- ✅ Test running from within project directory
- ✅ All existing tests pass (64/64)
- ✅ Linting and formatting checks pass

## Before
```gitignore
# START Ruler Generated Files
test-project/.aider.conf.yml
test-project/CLAUDE.md
# END Ruler Generated Files
```

## After
```gitignore
# START Ruler Generated Files
.aider.conf.yml
CLAUDE.md
# END Ruler Generated Files
```

Fixes #15

🤖 Generated with [Claude Code](https://claude.ai/code)