### PR TITLE
Fix cursorrules agent to use mdc

### DIFF
--- a/src/agents/CursorAgent.ts
+++ b/src/agents/CursorAgent.ts
@@ -1,10 +1,17 @@
 import * as path from 'path';
-import { IAgent, IAgentConfig } from './IAgent';
 import {
   backupFile,
-  writeGeneratedFile,
   ensureDirExists,
+  writeGeneratedFile,
 } from '../core/FileSystemUtils';
+import { IAgent, IAgentConfig } from './IAgent';
+
+const CURSOR_RULES_PREFIX = `
+---
+alwaysApply: true
+---
+
+`;
 
 /**
  * Cursor agent adapter (stub implementation).
@@ -23,18 +30,20 @@ export class CursorAgent implements IAgent {
     projectRoot: string,
     agentConfig?: IAgentConfig,
   ): Promise<void> {
+
+
     const output =
       agentConfig?.outputPath ?? this.getDefaultOutputPath(projectRoot);
     await ensureDirExists(path.dirname(output));
     await backupFile(output);
-    await writeGeneratedFile(output, concatenatedRules);
+    await writeGeneratedFile(output, CURSOR_RULES_PREFIX + concatenatedRules);
   }
   getDefaultOutputPath(projectRoot: string): string {
     return path.join(
       projectRoot,
       '.cursor',
       'rules',
-      'ruler_cursor_instructions.md',
+      'ruler_cursor_instructions.mdc',
     );
   }
 }


### PR DESCRIPTION
The current cursorrules agent didn't work for me. It needs the rules file to be a .mdc file with some frontmatter
