### PR TITLE
XDG_CONFIG_HOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,13 +79,20 @@ npx @intellectronica/ruler apply
    - `.ruler/ruler.toml`: The main configuration file for Ruler
    - `.ruler/mcp.json`: An example MCP server configuration
 
+Additionally, you can create a global configuration to use when no local `.ruler/` directory is found:
+```bash
+ruler init --global
+```
+
+The global configuration will be created to `$XDG_CONFIG_HOME/ruler` (default: `~/.config/ruler`).
+
 ## Core Concepts
 
 ### The `.ruler/` Directory
 
 This is your central hub for all AI agent instructions:
 
-- **Rule Files (`*.md`)**: Discovered recursively from `.ruler/` and alphabetically concatenated
+- **Rule Files (`*.md`)**: Discovered recursively from `.ruler/` or `$XDG_CONFIG_HOME/ruler` and alphabetically concatenated
 - **Concatenation Marker**: Each file's content is prepended with `--- Source: <relative_path_to_md_file> ---` for traceability
 - **`ruler.toml`**: Master configuration for Ruler's behavior, agent selection, and output paths
 - **`mcp.json`**: Shared MCP server settings
@@ -129,6 +136,8 @@ This is your central hub for all AI agent instructions:
 ruler apply [options]
 ```
 
+The `apply` command looks for `.ruler/` in the current directory tree, reading the first match. If no such directory is found, it will look for a global configuration in `$XDG_CONFIG_HOME/ruler`.
+
 ### Options
 
 | Option                         | Description                                               |
@@ -141,6 +150,7 @@ ruler apply [options]
 | `--mcp-overwrite`              | Overwrite native MCP config entirely instead of merging   |
 | `--gitignore`                  | Enable automatic .gitignore updates (default: true)       |
 | `--no-gitignore`               | Disable automatic .gitignore updates                      |
+| `--local-only`                 | Do not look for configuration in `$XDG_CONFIG_HOME`       |
 | `--verbose` / `-v`             | Display detailed output during execution                  |
 
 ### Common Examples

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@intellectronica/ruler",
-  "version": "0.2.3",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@intellectronica/ruler",
-      "version": "0.2.3",
+      "version": "0.2.5",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^2.2.5",

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -58,6 +58,12 @@ export function run(): void {
           description: 'Preview changes without writing files',
           default: false,
         });
+        y.option('local-only', {
+          type: 'boolean',
+          description:
+            'Only search for local .ruler directories, ignore global config',
+          default: false,
+        });
       },
       async (argv) => {
         const projectRoot = argv['project-root'] as string;
@@ -71,6 +77,7 @@ export function run(): void {
           : undefined;
         const verbose = argv.verbose as boolean;
         const dryRun = argv['dry-run'] as boolean;
+        const localOnly = argv['local-only'] as boolean;
 
         // Determine gitignore preference: CLI > TOML > Default (enabled)
         // yargs handles --no-gitignore by setting gitignore to false
@@ -90,6 +97,7 @@ export function run(): void {
             gitignorePreference,
             verbose,
             dryRun,
+            localOnly,
           );
           console.log('Ruler apply completed successfully.');
         } catch (err: unknown) {

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -2,6 +2,7 @@ import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import { applyAllAgentConfigs } from '../lib';
 import * as path from 'path';
+import * as os from 'os';
 import { promises as fs } from 'fs';
 import { ERROR_PREFIX } from '../constants';
 
@@ -106,11 +107,23 @@ export function run(): void {
           type: 'string',
           description: 'Project root directory',
           default: process.cwd(),
+        }).option('global', {
+          type: 'boolean',
+          description:
+            'Initialize in global config directory (XDG_CONFIG_HOME/ruler)',
+          default: false,
         });
       },
       async (argv) => {
         const projectRoot = argv['project-root'] as string;
-        const rulerDir = path.join(projectRoot, '.ruler');
+        const isGlobal = argv['global'] as boolean;
+
+        const rulerDir = isGlobal
+          ? path.join(
+              process.env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config'),
+              'ruler',
+            )
+          : path.join(projectRoot, '.ruler');
         await fs.mkdir(rulerDir, { recursive: true });
         const instructionsPath = path.join(rulerDir, 'instructions.md');
         const tomlPath = path.join(rulerDir, 'ruler.toml');

--- a/src/core/FileSystemUtils.ts
+++ b/src/core/FileSystemUtils.ts
@@ -11,10 +11,13 @@ function getXdgConfigDir(): string {
 
 /**
  * Searches upwards from startPath to find a directory named .ruler.
- * If not found locally, checks for global config at XDG_CONFIG_HOME/ruler.
+ * If not found locally and checkGlobal is true, checks for global config at XDG_CONFIG_HOME/ruler.
  * Returns the path to the .ruler directory, or null if not found.
  */
-export async function findRulerDir(startPath: string): Promise<string | null> {
+export async function findRulerDir(
+  startPath: string,
+  checkGlobal: boolean = true,
+): Promise<string | null> {
   // First, search upwards from startPath for local .ruler directory
   let current = startPath;
   while (current) {
@@ -34,15 +37,20 @@ export async function findRulerDir(startPath: string): Promise<string | null> {
     current = parent;
   }
 
-  // If no local .ruler found, check global config directory
-  const globalConfigDir = path.join(getXdgConfigDir(), 'ruler');
-  try {
-    const stat = await fs.stat(globalConfigDir);
-    if (stat.isDirectory()) {
-      return globalConfigDir;
+  // If no local .ruler found and checkGlobal is true, check global config directory
+  if (checkGlobal) {
+    const globalConfigDir = path.join(getXdgConfigDir(), 'ruler');
+    try {
+      const stat = await fs.stat(globalConfigDir);
+      if (stat.isDirectory()) {
+        return globalConfigDir;
+      }
+    } catch (err) {
+      console.error(
+        `[ruler] Error checking global config directory ${globalConfigDir}:`,
+        err,
+      );
     }
-  } catch {
-    // ignore errors when checking for global config directory
   }
 
   return null;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -100,6 +100,7 @@ export async function applyAllAgentConfigs(
   cliGitignoreEnabled?: boolean,
   verbose = false,
   dryRun = false,
+  localOnly = false,
 ): Promise<void> {
   // Load configuration (default_agents, per-agent overrides, CLI filters)
   logVerbose(
@@ -136,7 +137,7 @@ export async function applyAllAgentConfigs(
   }
   config.agentConfigs = mappedConfigs;
 
-  const rulerDir = await FileSystemUtils.findRulerDir(projectRoot);
+  const rulerDir = await FileSystemUtils.findRulerDir(projectRoot, !localOnly);
   if (!rulerDir) {
     throw createRulerError(
       `.ruler directory not found`,

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -147,7 +147,7 @@ export async function applyAllAgentConfigs(
 
   const files = await FileSystemUtils.readMarkdownFiles(rulerDir);
   logVerbose(
-    `Found ${files.length} markdown files in .ruler directory`,
+    `Found ${files.length} markdown files in ruler configuration directory`,
     verbose,
   );
   const concatenated = concatenateRules(files);

--- a/tests/unit/core/FileSystemUtils.test.ts
+++ b/tests/unit/core/FileSystemUtils.test.ts
@@ -26,7 +26,7 @@ describe('FileSystemUtils', () => {
     it('returns null if .ruler is not found', async () => {
       const someDir = path.join(tmpDir, 'nofile');
       await fs.mkdir(someDir, { recursive: true });
-      const found = await findRulerDir(someDir);
+      const found = await findRulerDir(someDir, false); // Don't check global config
       expect(found).toBeNull();
     });
   });


### PR DESCRIPTION
- Add support for `XDG_CONFIG_HOME` directory for defining a global Ruler config
- Looks for `ruler/` directory in the global config home, as is convention in CLI tools.

See https://specifications.freedesktop.org/basedir-spec/latest/ for common base directory definitions.

It does not merge local and global configs now, as that seemed to be the existing behavior if config files were present on many levels in directory tree.

So local config is always preferred in it's entirety.

Adds two command line switches.

Create a global config to `XDG_CONFIG_HOME` 
```
ruler init --global`
```

Only look for local config files when applying config
```
ruler apply --local-only
```