### PR TITLE
Add support for JetBrains Junie

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Ruler solves this by providing a **single source of truth** for all your AI agen
 | Firebase Studio  | `.idx/airules.md`                                             |
 | Open Hands       | `.openhands/microagents/repo.md` and `.openhands/config.toml` |
 | Gemini CLI       | `GEMINI.md` and `.gemini/settings.json`                       |
+| Junie            | `.junie/guidelines.md`                                        |
 
 ## Getting Started
 
@@ -143,7 +144,7 @@ The `apply` command looks for `.ruler/` in the current directory tree, reading t
 | Option                         | Description                                               |
 | ------------------------------ | --------------------------------------------------------- |
 | `--project-root <path>`        | Path to your project's root (default: current directory)  |
-| `--agents <agent1,agent2,...>` | Comma-separated list of agent names to target             |
+| `--agents <agent1,agent2,...>` | Comma-separated list of agent names to target (copilot, claude, codex, cursor, windsurf, cline, aider, firebase, gemini-cli, junie) |
 | `--config <path>`              | Path to a custom `ruler.toml` configuration file          |
 | `--mcp` / `--with-mcp`         | Enable applying MCP server configurations (default: true) |
 | `--no-mcp`                     | Disable applying MCP server configurations                |
@@ -239,6 +240,10 @@ enabled = true
 
 [agents.jules]
 enabled = true
+
+[agents.junie]
+enabled = true
+output_path = ".junie/guidelines.md"
 
 # Agent-specific MCP configuration
 [agents.cursor.mcp]

--- a/src/agents/JunieAgent.ts
+++ b/src/agents/JunieAgent.ts
@@ -1,0 +1,40 @@
+import * as path from 'path';
+import { IAgent, IAgentConfig } from './IAgent';
+import {
+  backupFile,
+  writeGeneratedFile,
+  ensureDirExists,
+} from '../core/FileSystemUtils';
+
+/**
+ * JetBrains Junie agent adapter.
+ */
+export class JunieAgent implements IAgent {
+  getIdentifier(): string {
+    return 'junie';
+  }
+
+  getName(): string {
+    return 'Junie';
+  }
+
+  async applyRulerConfig(
+    concatenatedRules: string,
+    projectRoot: string,
+    rulerMcpJson: Record<string, unknown> | null, // eslint-disable-line @typescript-eslint/no-unused-vars
+    agentConfig?: IAgentConfig,
+  ): Promise<void> {
+    const output =
+      agentConfig?.outputPath ?? this.getDefaultOutputPath(projectRoot);
+    await ensureDirExists(path.dirname(output));
+    await backupFile(output);
+    await writeGeneratedFile(output, concatenatedRules);
+  }
+  getDefaultOutputPath(projectRoot: string): string {
+    return path.join(
+      projectRoot,
+      '.junie',
+      'guidelines.md',
+    );
+  }
+}

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -25,7 +25,7 @@ export function run(): void {
         y.option('agents', {
           type: 'string',
           description:
-            'Comma-separated list of agent identifiers: copilot, claude, codex, cursor, windsurf, cline, aider, firebase, gemini-cli',
+            'Comma-separated list of agent identifiers: copilot, claude, codex, cursor, windsurf, cline, aider, firebase, gemini-cli, junie',
         });
         y.option('config', {
           type: 'string',

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -16,6 +16,7 @@ import { FirebaseAgent } from './agents/FirebaseAgent';
 import { OpenHandsAgent } from './agents/OpenHandsAgent';
 import { GeminiCliAgent } from './agents/GeminiCliAgent';
 import { JulesAgent } from './agents/JulesAgent';
+import { JunieAgent } from './agents/JunieAgent';
 import { mergeMcp } from './mcp/merge';
 import { validateMcp } from './mcp/validate';
 import { getNativeMcpPath, readNativeMcp, writeNativeMcp } from './paths/mcp';
@@ -80,6 +81,7 @@ const agents: IAgent[] = [
   new OpenHandsAgent(),
   new GeminiCliAgent(),
   new JulesAgent(),
+  new JunieAgent(),
 ];
 
 /**

--- a/tests/unit/agents/AgentAdapters.test.ts
+++ b/tests/unit/agents/AgentAdapters.test.ts
@@ -11,6 +11,7 @@ import { WindsurfAgent } from '../../../src/agents/WindsurfAgent';
 import { ClineAgent } from '../../../src/agents/ClineAgent';
 import { AiderAgent } from '../../../src/agents/AiderAgent';
 import { FirebaseAgent } from '../../../src/agents/FirebaseAgent';
+import { JunieAgent } from '../../../src/agents/JunieAgent';
 
 describe('Agent Adapters', () => {
   let tmpDir: string;
@@ -190,5 +191,25 @@ describe('Agent Adapters', () => {
     await fs.mkdir(path.dirname(custom), { recursive: true });
     await agent.applyRulerConfig('firebase rules', tmpDir, null, { outputPath: custom });
     expect(await fs.readFile(custom, 'utf8')).toBe('firebase rules');
+  });
+
+  describe('JunieAgent', () => {
+  it('backs up and writes .junie/guidelines.md', async () => {
+      const agent = new JunieAgent();
+      const junieDir = path.join(tmpDir, '.junie');
+      await fs.mkdir(junieDir, { recursive: true });
+      const target = path.join(junieDir, 'guidelines.md');
+      await fs.writeFile(target, 'old junie');
+      await agent.applyRulerConfig('new junie', tmpDir, null);
+      expect(await fs.readFile(`${target}.bak`, 'utf8')).toBe('old junie');
+      expect(await fs.readFile(target, 'utf8')).toBe('new junie');
+    });
+  });
+  it('uses custom outputPath when provided', async () => {
+    const agent = new JunieAgent();
+    const custom = path.join(tmpDir, 'custom_junie.md');
+    await fs.mkdir(path.dirname(custom), { recursive: true });
+    await agent.applyRulerConfig('junie rules', tmpDir, null, { outputPath: custom });
+    expect(await fs.readFile(custom, 'utf8')).toBe('junie rules');
   });
 });

--- a/tests/unit/agents/JunieAgent.test.ts
+++ b/tests/unit/agents/JunieAgent.test.ts
@@ -1,0 +1,49 @@
+import { JunieAgent } from '../../../src/agents/JunieAgent';
+import * as FileSystemUtils from '../../../src/core/FileSystemUtils';
+
+jest.mock('../../../src/core/FileSystemUtils');
+
+describe('JunieAgent', () => {
+  let agent: JunieAgent;
+
+  beforeEach(() => {
+    agent = new JunieAgent();
+    jest.clearAllMocks();
+  });
+
+  it('should return the correct identifier', () => {
+    expect(agent.getIdentifier()).toBe('junie');
+  });
+
+  it('should return the correct name', () => {
+    expect(agent.getName()).toBe('Junie');
+  });
+
+  it('should return the correct default output path', () => {
+    expect(agent.getDefaultOutputPath('/root')).toBe('/root/.junie/guidelines.md');
+  });
+
+  it('should apply ruler config to the default output path', async () => {
+    const ensureDirExists = jest.spyOn(FileSystemUtils, 'ensureDirExists');
+    const backupFile = jest.spyOn(FileSystemUtils, 'backupFile');
+    const writeGeneratedFile = jest.spyOn(FileSystemUtils, 'writeGeneratedFile');
+
+    await agent.applyRulerConfig('rules', '/root', null);
+
+    expect(ensureDirExists).toHaveBeenCalledWith('/root/.junie');
+    expect(backupFile).toHaveBeenCalledWith('/root/.junie/guidelines.md');
+    expect(writeGeneratedFile).toHaveBeenCalledWith('/root/.junie/guidelines.md', 'rules');
+  });
+
+  it('should apply ruler config to a custom output path', async () => {
+    const ensureDirExists = jest.spyOn(FileSystemUtils, 'ensureDirExists');
+    const backupFile = jest.spyOn(FileSystemUtils, 'backupFile');
+    const writeGeneratedFile = jest.spyOn(FileSystemUtils, 'writeGeneratedFile');
+
+    await agent.applyRulerConfig('rules', '/root', null, { outputPath: '/custom/path/guidelines.md' });
+
+    expect(ensureDirExists).toHaveBeenCalledWith('/custom/path');
+    expect(backupFile).toHaveBeenCalledWith('/custom/path/guidelines.md');
+    expect(writeGeneratedFile).toHaveBeenCalledWith('/custom/path/guidelines.md', 'rules');
+  });
+});


### PR DESCRIPTION
This PR adds support for JetBrains Junie, which uses `.junie/guidelines.md` files.

https://www.jetbrains.com/help/junie/customize-guidelines.html