### PR TITLE
fix(tests): quote paths in e2e tests

### DIFF
--- a/src/agents/JunieAgent.ts
+++ b/src/agents/JunieAgent.ts
@@ -31,10 +31,6 @@ export class JunieAgent implements IAgent {
     await writeGeneratedFile(output, concatenatedRules);
   }
   getDefaultOutputPath(projectRoot: string): string {
-    return path.join(
-      projectRoot,
-      '.junie',
-      'guidelines.md',
-    );
+    return path.join(projectRoot, '.junie', 'guidelines.md');
   }
 }

--- a/tests/e2e/ruler.test.ts
+++ b/tests/e2e/ruler.test.ts
@@ -314,7 +314,7 @@ output_path = "custom-claude.md"`;
       await fs.writeFile(path.join(rulerDir, 'instructions.md'), 'test');
 
       // Run the command that is being tested
-      execSync(`node ${path.resolve(__dirname, '..', '..', 'dist', 'cli', 'index.js')} apply --project-root ${testDir}`, { stdio: 'inherit' });
+      execSync(`node "${path.resolve(__dirname, '..', '..', 'dist', 'cli', 'index.js')}" apply --project-root "${testDir}"`, { stdio: 'inherit' });
 
       // Read the generated .gitignore
       gitignorePath = path.join(testDir, '.gitignore');


### PR DESCRIPTION
This PR fixes a bug in the e2e tests where paths with spaces were not being handled correctly.