### PR TITLE
Augment VSCode July 8 Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,21 +35,21 @@ Ruler solves this by providing a **single source of truth** for all your AI agen
 
 ## Supported AI Agents
 
-| Agent            | File(s) Created/Updated                                       |
-| ---------------- | ------------------------------------------------------------- |
-| GitHub Copilot   | `.github/copilot-instructions.md`                             |
-| Claude Code      | `CLAUDE.md`                                                   |
-| OpenAI Codex CLI | `AGENTS.md`                                                   |
-| Jules            | `AGENTS.md`                                                   |
-| Cursor           | `.cursor/rules/ruler_cursor_instructions.mdc`                 |
-| Windsurf         | `.windsurf/rules/ruler_windsurf_instructions.md`              |
-| Cline            | `.clinerules`                                                 |
-| Aider            | `ruler_aider_instructions.md` and `.aider.conf.yml`           |
-| Firebase Studio  | `.idx/airules.md`                                             |
-| Open Hands       | `.openhands/microagents/repo.md` and `.openhands/config.toml` |
-| Gemini CLI       | `GEMINI.md` and `.gemini/settings.json`                       |
-| Junie            | `.junie/guidelines.md`                                        |
-| AugmentCode      | `.augment-guidelines` and `.augmentcode/config.json`         |
+| Agent            | Rules File(s)                                    | MCP Configuration                                |
+| ---------------- | ------------------------------------------------ | ------------------------------------------------ |
+| GitHub Copilot   | `.github/copilot-instructions.md`                | `.vscode/mcp.json`                               |
+| Claude Code      | `CLAUDE.md`                                      | `claude_desktop_config.json`                     |
+| OpenAI Codex CLI | `AGENTS.md`                                      | `~/.codex/config.json`                           |
+| Jules            | `AGENTS.md`                                      | -                                                |
+| Cursor           | `.cursor/rules/ruler_cursor_instructions.mdc`    | `.cursor/mcp.json`, `~/.cursor/mcp.json`         |
+| Windsurf         | `.windsurf/rules/ruler_windsurf_instructions.md` | `~/.codeium/windsurf/mcp_config.json`            |
+| Cline            | `.clinerules`                                    | -                                                |
+| Aider            | `ruler_aider_instructions.md`, `.aider.conf.yml` | `.mcp.json`                                      |
+| Firebase Studio  | `.idx/airules.md`                                | -                                                |
+| Open Hands       | `.openhands/microagents/repo.md`                 | `.openhands/config.toml`                         |
+| Gemini CLI       | `GEMINI.md`                                      | `.gemini/settings.json`                          |
+| Junie            | `.junie/guidelines.md`                           | -                                                |
+| AugmentCode      | `.augment/rules/ruler_augment_instructions.md`   | `.vscode/settings.json`                          |
 
 ## Getting Started
 

--- a/src/paths/mcp.ts
+++ b/src/paths/mcp.ts
@@ -43,8 +43,7 @@ export async function getNativeMcpPath(
       candidates.push(path.join(projectRoot, '.gemini', 'settings.json'));
       break;
     case 'AugmentCode':
-      candidates.push(path.join(projectRoot, '.augmentcode', 'config.json'));
-      candidates.push(path.join(home, '.augmentcode', 'config.json'));
+      candidates.push(path.join(projectRoot, '.vscode', 'settings.json'));
       break;
     default:
       return null;

--- a/src/vscode/settings.ts
+++ b/src/vscode/settings.ts
@@ -1,0 +1,134 @@
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import { McpStrategy } from '../types';
+
+/**
+ * VSCode settings.json structure for Augment MCP configuration
+ */
+interface VSCodeSettings {
+  'augment.advanced'?: {
+    mcpServers?: AugmentMcpServer[];
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+/**
+ * Augment MCP server configuration format
+ */
+interface AugmentMcpServer {
+  name: string;
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+}
+
+/**
+ * Read VSCode settings.json file
+ */
+export async function readVSCodeSettings(
+  settingsPath: string,
+): Promise<VSCodeSettings> {
+  try {
+    const content = await fs.readFile(settingsPath, 'utf8');
+    return JSON.parse(content) as VSCodeSettings;
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return {};
+    }
+    throw error;
+  }
+}
+
+/**
+ * Write VSCode settings.json file
+ */
+export async function writeVSCodeSettings(
+  settingsPath: string,
+  settings: VSCodeSettings,
+): Promise<void> {
+  await fs.mkdir(path.dirname(settingsPath), { recursive: true });
+  await fs.writeFile(settingsPath, JSON.stringify(settings, null, 4));
+}
+
+/**
+ * Transform ruler MCP config to Augment MCP server array format
+ */
+export function transformRulerToAugmentMcp(
+  rulerMcpJson: Record<string, unknown>,
+): AugmentMcpServer[] {
+  const servers: AugmentMcpServer[] = [];
+
+  if (rulerMcpJson.mcpServers && typeof rulerMcpJson.mcpServers === 'object') {
+    const mcpServers = rulerMcpJson.mcpServers as Record<
+      string,
+      {
+        command: string;
+        args?: string[];
+        env?: Record<string, string>;
+      }
+    >;
+
+    for (const [name, serverConfig] of Object.entries(mcpServers)) {
+      const augmentServer: AugmentMcpServer = {
+        name,
+        command: serverConfig.command,
+      };
+
+      if (serverConfig.args) {
+        augmentServer.args = serverConfig.args;
+      }
+
+      if (serverConfig.env) {
+        augmentServer.env = serverConfig.env;
+      }
+
+      servers.push(augmentServer);
+    }
+  }
+
+  return servers;
+}
+
+/**
+ * Merge MCP servers into VSCode settings using the specified strategy
+ */
+export function mergeAugmentMcpServers(
+  existingSettings: VSCodeSettings,
+  newServers: AugmentMcpServer[],
+  strategy: McpStrategy,
+): VSCodeSettings {
+  const result = { ...existingSettings };
+
+  if (!result['augment.advanced']) {
+    result['augment.advanced'] = {};
+  }
+
+  if (strategy === 'overwrite') {
+    result['augment.advanced'].mcpServers = newServers;
+  } else {
+    const existingServers = result['augment.advanced'].mcpServers || [];
+    const existingServerMap = new Map<string, AugmentMcpServer>();
+
+    for (const server of existingServers) {
+      existingServerMap.set(server.name, server);
+    }
+
+    for (const newServer of newServers) {
+      existingServerMap.set(newServer.name, newServer);
+    }
+
+    result['augment.advanced'].mcpServers = Array.from(
+      existingServerMap.values(),
+    );
+  }
+
+  return result;
+}
+
+/**
+ * Get the VSCode settings.json path for a project (local)
+ */
+export function getVSCodeSettingsPath(projectRoot: string): string {
+  return path.join(projectRoot, '.vscode', 'settings.json');
+}

--- a/tests/unit/agents/AgentAdapters.test.ts
+++ b/tests/unit/agents/AgentAdapters.test.ts
@@ -215,9 +215,10 @@ describe('Agent Adapters', () => {
   });
 
   describe('AugmentCodeAgent', () => {
-    it('backs up and writes .augment-guidelines', async () => {
+    it('backs up and writes ruler_augment_instructions.md', async () => {
       const agent = new AugmentCodeAgent();
-      const target = path.join(tmpDir, '.augment-guidelines');
+      const target = path.join(tmpDir, '.augment', 'rules', 'ruler_augment_instructions.md');
+      await fs.mkdir(path.dirname(target), { recursive: true });
       await fs.writeFile(target, 'old augment');
       await agent.applyRulerConfig('new augment', tmpDir, null);
       expect(await fs.readFile(`${target}.bak`, 'utf8')).toBe('old augment');


### PR DESCRIPTION
### Changes

*Multiple Access Points*: Find Rules settings in the settings panel or create a `.augment/rules` folder to get started immediately.

MCP are now managed via vscode local project settings. And revert is able to clean it up as well.

This essentially allows ruler to create a new file for instructions and not overstepping on other rules which already exists. Safer and future proof.
