### PR TITLE
feat: Add Support for Kilo Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Ruler solves this by providing a **single source of truth** for all your AI agen
 | Gemini CLI       | `GEMINI.md`                                      | `.gemini/settings.json`                          |
 | Junie            | `.junie/guidelines.md`                           | -                                                |
 | AugmentCode      | `.augment/rules/ruler_augment_instructions.md`   | `.vscode/settings.json`                          |
+| Kilo Code        | `.kilocode/rules/ruler_kilocode_instructions.md` | `.kilocode/mcp.json`                             |
 
 ## Getting Started
 
@@ -145,7 +146,7 @@ The `apply` command looks for `.ruler/` in the current directory tree, reading t
 | Option                         | Description                                               |
 | ------------------------------ | --------------------------------------------------------- |
 | `--project-root <path>`        | Path to your project's root (default: current directory)  |
-| `--agents <agent1,agent2,...>` | Comma-separated list of agent names to target (copilot, claude, codex, cursor, windsurf, cline, aider, firebase, gemini-cli, junie, augmentcode) |
+| `--agents <agent1,agent2,...>` | Comma-separated list of agent names to target (copilot, claude, codex, cursor, windsurf, cline, aider, firebase, gemini-cli, junie, augmentcode, kilocode) |
 | `--config <path>`              | Path to a custom `ruler.toml` configuration file          |
 | `--mcp` / `--with-mcp`         | Enable applying MCP server configurations (default: true) |
 | `--no-mcp`                     | Disable applying MCP server configurations                |
@@ -216,7 +217,7 @@ ruler revert [options]
 | Option                         | Description                                               |
 | ------------------------------ | --------------------------------------------------------- |
 | `--project-root <path>`        | Path to your project's root (default: current directory)  |
-| `--agents <agent1,agent2,...>` | Comma-separated list of agent names to revert (copilot, claude, codex, cursor, windsurf, cline, aider, firebase, gemini-cli, junie) |
+| `--agents <agent1,agent2,...>` | Comma-separated list of agent names to revert (copilot, claude, codex, cursor, windsurf, cline, aider, firebase, gemini-cli, junie, kilocode) |
 | `--config <path>`              | Path to a custom `ruler.toml` configuration file          |
 | `--keep-backups`               | Keep backup files (.bak) after restoration (default: false) |
 | `--dry-run`                    | Preview changes without actually reverting files          |
@@ -316,6 +317,10 @@ merge_strategy = "merge"
 # Disable specific agents
 [agents.windsurf]
 enabled = false
+
+[agents.kilocode]
+enabled = true
+output_path = ".kilocode/rules/ruler_kilocode_instructions.md"
 ```
 
 ### Configuration Precedence

--- a/src/agents/KiloCodeAgent.ts
+++ b/src/agents/KiloCodeAgent.ts
@@ -1,0 +1,47 @@
+import * as path from 'path';
+import { IAgent, IAgentConfig } from './IAgent';
+import {
+  backupFile,
+  writeGeneratedFile,
+  ensureDirExists,
+} from '../core/FileSystemUtils';
+
+/**
+ * Kilo Code agent adapter.
+ * Generates ruler_kilocode_instructions.md configuration file in .kilocode/rules/ directory.
+ */
+export class KiloCodeAgent implements IAgent {
+  getIdentifier(): string {
+    return 'kilocode';
+  }
+
+  getName(): string {
+    return 'Kilo Code';
+  }
+
+  async applyRulerConfig(
+    concatenatedRules: string,
+    projectRoot: string,
+    rulerMcpJson: Record<string, unknown> | null, // eslint-disable-line @typescript-eslint/no-unused-vars
+    agentConfig?: IAgentConfig,
+  ): Promise<void> {
+    const output =
+      agentConfig?.outputPath ?? this.getDefaultOutputPath(projectRoot);
+    await ensureDirExists(path.dirname(output));
+    await backupFile(output);
+    await writeGeneratedFile(output, concatenatedRules);
+  }
+
+  getDefaultOutputPath(projectRoot: string): string {
+    return path.join(
+      projectRoot,
+      '.kilocode',
+      'rules',
+      'ruler_kilocode_instructions.md',
+    );
+  }
+
+  getMcpServerKey(): string {
+    return 'mcpServers';
+  }
+}

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -26,7 +26,7 @@ export function run(): void {
         y.option('agents', {
           type: 'string',
           description:
-            'Comma-separated list of agent identifiers: copilot, claude, codex, cursor, windsurf, cline, aider, firebase, gemini-cli, junie',
+            'Comma-separated list of agent identifiers: copilot, claude, codex, cursor, windsurf, cline, aider, firebase, gemini-cli, junie, kilocode',
         });
         y.option('config', {
           type: 'string',
@@ -161,7 +161,7 @@ and apply them to your configured AI coding agents.
 
 # --- Agent Specific Configurations ---
 # You can enable/disable agents and override their default output paths here.
-# Use lowercase agent identifiers: copilot, claude, codex, cursor, windsurf, cline, aider
+# Use lowercase agent identifiers: copilot, claude, codex, cursor, windsurf, cline, aider, kilocode
 
 # [agents.copilot]
 # enabled = true
@@ -198,6 +198,10 @@ and apply them to your configured AI coding agents.
 
 # [agents.gemini-cli]
 # enabled = true
+
+# [agents.kilocode]
+# enabled = true
+# output_path = ".kilocode/rules/ruler_kilocode_instructions.md"
 `;
         if (!(await exists(instructionsPath))) {
           await fs.writeFile(instructionsPath, DEFAULT_INSTRUCTIONS);
@@ -239,7 +243,7 @@ and apply them to your configured AI coding agents.
         y.option('agents', {
           type: 'string',
           description:
-            'Comma-separated list of agent identifiers: copilot, claude, codex, cursor, windsurf, cline, aider, firebase, gemini-cli, junie',
+            'Comma-separated list of agent identifiers: copilot, claude, codex, cursor, windsurf, cline, aider, firebase, gemini-cli, junie, kilocode',
         });
         y.option('config', {
           type: 'string',

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -18,6 +18,7 @@ import { GeminiCliAgent } from './agents/GeminiCliAgent';
 import { JulesAgent } from './agents/JulesAgent';
 import { JunieAgent } from './agents/JunieAgent';
 import { AugmentCodeAgent } from './agents/AugmentCodeAgent';
+import { KiloCodeAgent } from './agents/KiloCodeAgent';
 import { mergeMcp } from './mcp/merge';
 import { validateMcp } from './mcp/validate';
 import { getNativeMcpPath, readNativeMcp, writeNativeMcp } from './paths/mcp';
@@ -84,6 +85,7 @@ const agents: IAgent[] = [
   new JulesAgent(),
   new JunieAgent(),
   new AugmentCodeAgent(),
+  new KiloCodeAgent(),
 ];
 
 /**

--- a/src/paths/mcp.ts
+++ b/src/paths/mcp.ts
@@ -45,6 +45,9 @@ export async function getNativeMcpPath(
     case 'AugmentCode':
       candidates.push(path.join(projectRoot, '.vscode', 'settings.json'));
       break;
+    case 'Kilo Code':
+      candidates.push(path.join(projectRoot, '.kilocode', 'mcp.json'));
+      break;
     default:
       return null;
   }

--- a/src/revert.ts
+++ b/src/revert.ts
@@ -16,6 +16,7 @@ import { GeminiCliAgent } from './agents/GeminiCliAgent';
 import { JulesAgent } from './agents/JulesAgent';
 import { JunieAgent } from './agents/JunieAgent';
 import { AugmentCodeAgent } from './agents/AugmentCodeAgent';
+import { KiloCodeAgent } from './agents/KiloCodeAgent';
 import { getNativeMcpPath } from './paths/mcp';
 import { IAgentConfig } from './agents/IAgent';
 import { createRulerError, logVerbose } from './constants';
@@ -39,6 +40,7 @@ const agents: IAgent[] = [
   new JulesAgent(),
   new JunieAgent(),
   new AugmentCodeAgent(),
+  new KiloCodeAgent(),
 ];
 
 /**
@@ -340,6 +342,7 @@ async function removeEmptyDirectories(
     '.gemini',
     '.vscode',
     '.augmentcode',
+    '.kilocode',
   ];
 
   let directoriesRemoved = 0;
@@ -377,6 +380,7 @@ async function removeAdditionalAgentFiles(
     '.mcp.json',
     '.vscode/mcp.json',
     '.cursor/mcp.json',
+    '.kilocode/mcp.json',
     '.openhands/config.toml',
   ];
 

--- a/tests/e2e/ruler.test.ts
+++ b/tests/e2e/ruler.test.ts
@@ -44,6 +44,7 @@ describe('End-to-End Ruler CLI', () => {
     await fs.rm(path.join(tmpDir, '.ruler', 'ruler.toml'), { force: true });
     // Clean up Open Hands agent files
     await fs.rm(path.join(tmpDir, '.openhands'), { recursive: true, force: true });
+    await fs.rm(path.join(tmpDir, '.kilocode'), { recursive: true, force: true });
   });
 
   it('generates configuration files for all agents', () => {
@@ -74,6 +75,12 @@ describe('End-to-End Ruler CLI', () => {
       'config.toml',
     );
     const juniePath = path.join(tmpDir, '.junie', 'guidelines.md');
+    const kilocodePath = path.join(
+      tmpDir,
+      '.kilocode',
+      'rules',
+      'ruler_kilocode_instructions.md',
+    );
 
     return Promise.all([
       expect(fs.readFile(copilotPath, 'utf8')).resolves.toContain('Rule A'),
@@ -89,6 +96,7 @@ describe('End-to-End Ruler CLI', () => {
         fs.readFile(openHandsInstructionsPath, 'utf8'),
       ).resolves.toContain('Rule A'),
       expect(fs.readFile(juniePath, 'utf8')).resolves.toContain('Rule B'),
+      expect(fs.readFile(kilocodePath, 'utf8')).resolves.toContain('Rule A')
     ])
       .then(async () => {
         const ohToml = await fs.readFile(openHandsConfigPath, 'utf8');

--- a/tests/integration/revert-agents.test.ts
+++ b/tests/integration/revert-agents.test.ts
@@ -51,6 +51,17 @@ describe('Revert Agent Integration', () => {
       await expect(fs.access(path.join(tmpDir, 'ruler_aider_instructions.md'))).rejects.toThrow();
       await expect(fs.access(path.join(tmpDir, '.aider.conf.yml'))).rejects.toThrow();
     });
+
+    it('should handle KiloCode agent files and directories', async () => {
+      // Create KiloCode directory structure
+      await fs.mkdir(path.join(tmpDir, '.kilocode', 'rules'), { recursive: true });
+      await fs.writeFile(path.join(tmpDir, '.kilocode', 'rules', 'ruler_kilocode_instructions.md'), 'KiloCode instructions');
+      await fs.writeFile(path.join(tmpDir, '.kilocode', 'mcp.json'), '{"mcpServers": {}}');
+
+      await revertAllAgentConfigs(tmpDir, ['kilocode'], undefined, false, false, false);
+
+      await expect(fs.access(path.join(tmpDir, '.kilocode'))).rejects.toThrow();
+    });
   });
 
   describe('Directory Cleanup', () => {

--- a/tests/unit/agents/KiloCodeAgent.test.ts
+++ b/tests/unit/agents/KiloCodeAgent.test.ts
@@ -1,0 +1,109 @@
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import os from 'os';
+
+import { KiloCodeAgent } from '../../../src/agents/KiloCodeAgent';
+
+describe('KiloCodeAgent', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ruler-kilocode-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('Basic Agent Interface', () => {
+    it('returns correct identifier', () => {
+      const agent = new KiloCodeAgent();
+      expect(agent.getIdentifier()).toBe('kilocode');
+    });
+
+    it('returns correct display name', () => {
+      const agent = new KiloCodeAgent();
+      expect(agent.getName()).toBe('Kilo Code');
+    });
+
+    it('returns correct default output path', () => {
+      const agent = new KiloCodeAgent();
+      const expected = path.join(
+        tmpDir,
+        '.kilocode',
+        'rules',
+        'ruler_kilocode_instructions.md',
+      );
+      expect(agent.getDefaultOutputPath(tmpDir)).toBe(expected);
+    });
+  });
+
+  describe('File Operations', () => {
+    it('backs up and writes ruler_kilocode_instructions.md', async () => {
+      const agent = new KiloCodeAgent();
+      const rulesDir = path.join(tmpDir, '.kilocode', 'rules');
+      await fs.mkdir(rulesDir, { recursive: true });
+      const target = path.join(rulesDir, 'ruler_kilocode_instructions.md');
+
+      // Create existing file
+      await fs.writeFile(target, 'old kilocode rules');
+
+      // Apply new configuration
+      await agent.applyRulerConfig('new kilocode rules', tmpDir, null);
+
+      // Verify backup was created
+      expect(await fs.readFile(`${target}.bak`, 'utf8')).toBe(
+        'old kilocode rules',
+      );
+
+      // Verify new content was written
+      expect(await fs.readFile(target, 'utf8')).toBe('new kilocode rules');
+    });
+
+    it('creates directory structure if it does not exist', async () => {
+      const agent = new KiloCodeAgent();
+      const target = path.join(
+        tmpDir,
+        '.kilocode',
+        'rules',
+        'ruler_kilocode_instructions.md',
+      );
+
+      // Apply configuration without creating directory first
+      await agent.applyRulerConfig('kilocode content', tmpDir, null);
+
+      // Verify file was created with correct content
+      expect(await fs.readFile(target, 'utf8')).toBe('kilocode content');
+    });
+
+    it('uses custom outputPath when provided', async () => {
+      const agent = new KiloCodeAgent();
+      const custom = path.join(tmpDir, 'custom_kilocode.md');
+      await fs.mkdir(path.dirname(custom), { recursive: true });
+
+      await agent.applyRulerConfig('custom kilocode data', tmpDir, null, {
+        outputPath: custom,
+      });
+
+      expect(await fs.readFile(custom, 'utf8')).toBe('custom kilocode data');
+    });
+  });
+
+  describe('Configuration Overrides', () => {
+    it('respects custom output path in agent config', async () => {
+      const agent = new KiloCodeAgent();
+      const customPath = path.join(tmpDir, 'custom', 'kilocode_rules.md');
+
+      await agent.applyRulerConfig('custom path content', tmpDir, null, {
+        outputPath: customPath,
+      });
+
+      expect(await fs.readFile(customPath, 'utf8')).toBe('custom path content');
+    });
+
+    it('returns correct MCP server key', () => {
+      const agent = new KiloCodeAgent();
+      expect(agent.getMcpServerKey()).toBe('mcpServers');
+    });
+  });
+});

--- a/tests/unit/agents/LowercaseIdentifiers.test.ts
+++ b/tests/unit/agents/LowercaseIdentifiers.test.ts
@@ -5,6 +5,7 @@ import { CursorAgent } from '../../../src/agents/CursorAgent';
 import { WindsurfAgent } from '../../../src/agents/WindsurfAgent';
 import { ClineAgent } from '../../../src/agents/ClineAgent';
 import { AiderAgent } from '../../../src/agents/AiderAgent';
+import { KiloCodeAgent } from '../../../src/agents/KiloCodeAgent';
 
 describe('Agent Lowercase Identifiers', () => {
   const expectedIdentifiers = {
@@ -15,6 +16,7 @@ describe('Agent Lowercase Identifiers', () => {
     windsurf: WindsurfAgent,
     cline: ClineAgent,
     aider: AiderAgent,
+    kilocode: KiloCodeAgent,
   };
 
   describe('Agent.getIdentifier() returns lowercase identifiers', () => {
@@ -35,6 +37,7 @@ describe('Agent Lowercase Identifiers', () => {
       windsurf: 'Windsurf',
       cline: 'Cline',
       aider: 'Aider',
+      kilocode: 'Kilo Code'
     };
 
     Object.entries(expectedIdentifiers).forEach(([identifier, AgentClass]) => {

--- a/tests/unit/mcp/KiloCodeMcp.test.ts
+++ b/tests/unit/mcp/KiloCodeMcp.test.ts
@@ -1,0 +1,198 @@
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import os from 'os';
+import {
+  getNativeMcpPath,
+  readNativeMcp,
+  writeNativeMcp,
+} from '../../../src/paths/mcp';
+import { mergeMcp } from '../../../src/mcp/merge';
+
+interface McpConfig {
+  mcpServers: Record<string, { command: string; args?: string[] }>;
+  [key: string]: unknown;
+}
+
+describe('KiloCode MCP Integration', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ruler-kilocode-mcp-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('MCP Path Resolution', () => {
+    it('resolves correct MCP path for Kilo Code', async () => {
+      const mcpPath = await getNativeMcpPath('Kilo Code', tmpDir);
+      expect(mcpPath).toBe(path.join(tmpDir, '.kilocode', 'mcp.json'));
+    });
+
+    it('returns first candidate path when file does not exist', async () => {
+      const mcpPath = await getNativeMcpPath('Kilo Code', tmpDir);
+      expect(mcpPath).toBe(path.join(tmpDir, '.kilocode', 'mcp.json'));
+    });
+  });
+
+  describe('MCP Configuration Handling', () => {
+    it('creates new MCP configuration file', async () => {
+      const mcpPath = path.join(tmpDir, '.kilocode', 'mcp.json');
+      const mcpConfig = {
+        mcpServers: {
+          filesystem: {
+            command: 'npx',
+            args: ['-y', '@modelcontextprotocol/server-filesystem', tmpDir],
+          },
+        },
+      };
+
+      await writeNativeMcp(mcpPath, mcpConfig);
+
+      // Verify file was created
+      await expect(fs.access(mcpPath)).resolves.toBeUndefined();
+
+      const content = JSON.parse(await fs.readFile(mcpPath, 'utf8'));
+      expect(content.mcpServers.filesystem.command).toBe('npx');
+      expect(content.mcpServers.filesystem.args).toEqual([
+        '-y',
+        '@modelcontextprotocol/server-filesystem',
+        tmpDir,
+      ]);
+    });
+
+    it('reads existing MCP configuration', async () => {
+      const mcpPath = path.join(tmpDir, '.kilocode', 'mcp.json');
+      const existingConfig = {
+        mcpServers: {
+          existing: {
+            command: 'existing-command',
+            args: ['existing-arg'],
+          },
+        },
+      };
+
+      await fs.mkdir(path.dirname(mcpPath), { recursive: true });
+      await fs.writeFile(mcpPath, JSON.stringify(existingConfig, null, 2));
+
+      const readConfig = await readNativeMcp(mcpPath);
+      expect(readConfig).toEqual(existingConfig);
+    });
+
+    it('returns empty object for non-existent MCP file', async () => {
+      const mcpPath = path.join(tmpDir, '.kilocode', 'nonexistent.json');
+      const config = await readNativeMcp(mcpPath);
+      expect(config).toEqual({});
+    });
+
+    it('merges MCP configurations correctly', async () => {
+      const existing = {
+        mcpServers: {
+          existing: { command: 'existing-cmd', args: ['existing-arg'] },
+        },
+      };
+
+      const newConfig = {
+        mcpServers: {
+          filesystem: { command: 'npx', args: ['mcp-filesystem'] },
+        },
+      };
+
+      const merged = mergeMcp(
+        existing,
+        newConfig,
+        'merge',
+        'mcpServers',
+      ) as McpConfig;
+
+      expect(merged.mcpServers.existing).toEqual({
+        command: 'existing-cmd',
+        args: ['existing-arg'],
+      });
+      expect(merged.mcpServers.filesystem).toEqual({
+        command: 'npx',
+        args: ['mcp-filesystem'],
+      });
+    });
+
+    it('overwrites MCP configurations with overwrite strategy', async () => {
+      const existing = {
+        mcpServers: {
+          existing: { command: 'existing-cmd' },
+        },
+      };
+
+      const newConfig = {
+        mcpServers: {
+          filesystem: { command: 'npx', args: ['mcp-filesystem'] },
+        },
+      };
+
+      const merged = mergeMcp(
+        existing,
+        newConfig,
+        'overwrite',
+        'mcpServers',
+      ) as McpConfig;
+
+      expect(merged.mcpServers.existing).toBeUndefined();
+      expect(merged.mcpServers.filesystem).toEqual({
+        command: 'npx',
+        args: ['mcp-filesystem'],
+      });
+    });
+
+    it('overwrites servers with same name during merge', async () => {
+      const existing = {
+        mcpServers: {
+          filesystem: { command: 'old-command', args: ['old-arg'] },
+        },
+      };
+
+      const newConfig = {
+        mcpServers: {
+          filesystem: { command: 'new-command', args: ['new-arg'] },
+        },
+      };
+
+      const merged = mergeMcp(
+        existing,
+        newConfig,
+        'merge',
+        'mcpServers',
+      ) as McpConfig;
+
+      expect(merged.mcpServers.filesystem).toEqual({
+        command: 'new-command',
+        args: ['new-arg'],
+      });
+    });
+
+    it('preserves non-MCP properties during merge', async () => {
+      const existing = {
+        mcpServers: {
+          existing: { command: 'existing-cmd' },
+        },
+        otherProperty: 'preserved',
+      };
+
+      const newConfig = {
+        mcpServers: {
+          filesystem: { command: 'npx' },
+        },
+      };
+
+      const merged = mergeMcp(
+        existing,
+        newConfig,
+        'merge',
+        'mcpServers',
+      ) as McpConfig;
+
+      expect(merged.otherProperty).toBe('preserved');
+      expect(merged.mcpServers.existing).toEqual({ command: 'existing-cmd' });
+      expect(merged.mcpServers.filesystem).toEqual({ command: 'npx' });
+    });
+  });
+});


### PR DESCRIPTION
# Add Support for Kilo Code

Kilo Code [Website](https://kilocode.ai/)

Kilo Code [rules docs](https://kilocode.ai/docs/advanced-usage/custom-rules#project-rules:~:text=Custom%20rules%20are%20primarily%20loaded%20from%20the%20.kilocode/rules/%20directory.)

Kilo Code [MCP docs](https://kilocode.ai/docs/features/mcp/using-mcp-in-kilo-code#troubleshooting-mcp-servers:~:text=Project%2Dlevel%20Configuration%3A%20Defined%20in%20a%20.kilocode/mcp.json%20file%20within%20your%20project%27s%20root%20directory.)