### PR TITLE
Fix OpenCode MCP configuration format (fixes #66)

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -25,6 +25,7 @@ import { validateMcp } from './mcp/validate';
 import { getNativeMcpPath, readNativeMcp, writeNativeMcp } from './paths/mcp';
 import { McpStrategy } from './types';
 import { propagateMcpToOpenHands } from './mcp/propagateOpenHandsMcp';
+import { propagateMcpToOpenCode } from './mcp/propagateOpenCodeMcp';
 import { IAgentConfig } from './agents/IAgent';
 import { createRulerError, logVerbose } from './constants';
 
@@ -321,6 +322,16 @@ export async function applyAllAgentConfigs(
             `DRY RUN: AugmentCode MCP config handled internally via VSCode settings`,
             verbose,
           );
+        }
+      } else if (agent.getIdentifier() === 'opencode') {
+        // *** Special handling for OpenCode ***
+        if (dryRun) {
+          logVerbose(
+            `DRY RUN: Would apply MCP config by updating OpenCode config file: ${dest}`,
+            verbose,
+          );
+        } else {
+          await propagateMcpToOpenCode(rulerMcpFile, dest);
         }
       } else {
         if (rulerMcpJson) {

--- a/src/mcp/propagateOpenCodeMcp.ts
+++ b/src/mcp/propagateOpenCodeMcp.ts
@@ -1,0 +1,110 @@
+import * as fs from 'fs/promises';
+import { ensureDirExists } from '../core/FileSystemUtils';
+import * as path from 'path';
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+interface OpenCodeMcpServer {
+  type: 'local' | 'remote';
+  command?: string[];
+  url?: string;
+  enabled: boolean;
+  environment?: Record<string, string>;
+  headers?: Record<string, string>;
+}
+
+interface OpenCodeConfig {
+  $schema: string;
+  mcp: Record<string, OpenCodeMcpServer>;
+}
+
+/**
+ * Transform ruler MCP configuration to OpenCode's specific format
+ */
+function transformToOpenCodeFormat(
+  rulerMcp: Record<string, unknown>,
+): OpenCodeConfig {
+  const rulerServers = rulerMcp.mcpServers || {};
+  const openCodeServers: Record<string, OpenCodeMcpServer> = {};
+
+  for (const [name, serverDef] of Object.entries(rulerServers)) {
+    const server = serverDef as any;
+
+    // Determine if this is a local or remote server
+    const isRemote = !!server.url;
+
+    const openCodeServer: OpenCodeMcpServer = {
+      type: isRemote ? 'remote' : 'local',
+      enabled: true, // Always true as per the issue requirements
+    };
+
+    if (isRemote) {
+      // Remote server configuration
+      openCodeServer.url = server.url;
+      if (server.headers) {
+        openCodeServer.headers = server.headers;
+      }
+    } else {
+      // Local server configuration
+      if (server.command) {
+        // Combine command and args into a single array
+        const command = Array.isArray(server.command)
+          ? server.command
+          : [server.command];
+        const args = server.args || [];
+        openCodeServer.command = [...command, ...args];
+      }
+
+      if (server.env) {
+        openCodeServer.environment = server.env;
+      }
+    }
+
+    openCodeServers[name] = openCodeServer;
+  }
+
+  return {
+    $schema: 'https://opencode.ai/config.json',
+    mcp: openCodeServers,
+  };
+}
+
+export async function propagateMcpToOpenCode(
+  rulerMcpPath: string,
+  openCodeConfigPath: string,
+): Promise<void> {
+  let rulerMcp;
+  try {
+    const rulerJsonContent = await fs.readFile(rulerMcpPath, 'utf8');
+    rulerMcp = JSON.parse(rulerJsonContent);
+  } catch {
+    return;
+  }
+
+  // Read existing OpenCode config if it exists
+  let existingConfig: any = {};
+  try {
+    const existingContent = await fs.readFile(openCodeConfigPath, 'utf8');
+    existingConfig = JSON.parse(existingContent);
+  } catch {
+    // File doesn't exist, we'll create it
+  }
+
+  // Transform ruler MCP to OpenCode format
+  const transformedConfig = transformToOpenCodeFormat(rulerMcp);
+
+  // Merge with existing config, preserving non-MCP settings
+  const finalConfig = {
+    ...existingConfig,
+    $schema: transformedConfig.$schema,
+    mcp: {
+      ...existingConfig.mcp,
+      ...transformedConfig.mcp,
+    },
+  };
+
+  await ensureDirExists(path.dirname(openCodeConfigPath));
+  await fs.writeFile(
+    openCodeConfigPath,
+    JSON.stringify(finalConfig, null, 2) + '\n',
+  );
+}


### PR DESCRIPTION
## Summary
- Transform ruler MCP configuration to OpenCode's specific format as described in issue #66
- Add special handling for OpenCode similar to OpenHands and AugmentCode
- Implement proper format transformation with type field, command array merging, and schema reference

## Changes Made
- Created propagateOpenCodeMcp.ts to handle OpenCode-specific MCP format transformation
- Updated lib.ts to use special handling for OpenCode agent (similar to OpenHands)
- Enhanced tests to verify the new transformation logic for both local and remote servers
- Ensured existing OpenCode configuration is preserved during merge

## Test Plan
- [x] Added comprehensive tests for local server transformation
- [x] Added tests for remote server transformation  
- [x] Added tests for merging with existing OpenCode configuration
- [x] All existing tests continue to pass
- [x] Verified OpenCode gets proper format: type, command array, enabled=true, schema

🤖 Generated with [opencode](https://opencode.ai)