### PR TITLE
Fix issue #78: Validate agent names in apply command

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -194,12 +194,17 @@ export async function applyAllAgentConfigs(
     const filters = config.cliAgents.map((n) => n.toLowerCase());
     
     // Check if any of the specified agents don't exist
-    const validAgentIdentifiers = new Set(agents.map(agent => agent.getIdentifier()));
-    const validAgentNames = new Set(agents.map(agent => agent.getName().toLowerCase()));
+    const validAgentIdentifiers = new Set(
+      agents.map((agent) => agent.getIdentifier()),
+    );
+    const validAgentNames = new Set(
+      agents.map((agent) => agent.getName().toLowerCase()),
+    );
     
-    const invalidAgents = filters.filter(filter => 
-      !validAgentIdentifiers.has(filter) && 
-      ![...validAgentNames].some(name => name.includes(filter))
+    const invalidAgents = filters.filter(
+      (filter) =>
+        !validAgentIdentifiers.has(filter) &&
+        ![...validAgentNames].some((name) => name.includes(filter)),
     );
     
     if (invalidAgents.length > 0) {
@@ -224,12 +229,17 @@ export async function applyAllAgentConfigs(
     const defaults = config.defaultAgents.map((n) => n.toLowerCase());
     
     // Check if any of the default agents don't exist
-    const validAgentIdentifiers = new Set(agents.map(agent => agent.getIdentifier()));
-    const validAgentNames = new Set(agents.map(agent => agent.getName().toLowerCase()));
+    const validAgentIdentifiers = new Set(
+      agents.map((agent) => agent.getIdentifier()),
+    );
+    const validAgentNames = new Set(
+      agents.map((agent) => agent.getName().toLowerCase()),
+    );
     
-    const invalidAgents = defaults.filter(filter => 
-      !validAgentIdentifiers.has(filter) && 
-      ![...validAgentNames].some(name => name.includes(filter))
+    const invalidAgents = defaults.filter(
+      (filter) =>
+        !validAgentIdentifiers.has(filter) &&
+        ![...validAgentNames].some((name) => name.includes(filter)),
     );
     
     if (invalidAgents.length > 0) {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -192,6 +192,23 @@ export async function applyAllAgentConfigs(
   let selected = agents;
   if (config.cliAgents && config.cliAgents.length > 0) {
     const filters = config.cliAgents.map((n) => n.toLowerCase());
+    
+    // Check if any of the specified agents don't exist
+    const validAgentIdentifiers = new Set(agents.map(agent => agent.getIdentifier()));
+    const validAgentNames = new Set(agents.map(agent => agent.getName().toLowerCase()));
+    
+    const invalidAgents = filters.filter(filter => 
+      !validAgentIdentifiers.has(filter) && 
+      ![...validAgentNames].some(name => name.includes(filter))
+    );
+    
+    if (invalidAgents.length > 0) {
+      throw createRulerError(
+        `Invalid agent specified: ${invalidAgents.join(', ')}`,
+        `Valid agents are: ${[...validAgentIdentifiers].join(', ')}`
+      );
+    }
+    
     selected = agents.filter((agent) =>
       filters.some(
         (f) =>
@@ -205,6 +222,23 @@ export async function applyAllAgentConfigs(
     );
   } else if (config.defaultAgents && config.defaultAgents.length > 0) {
     const defaults = config.defaultAgents.map((n) => n.toLowerCase());
+    
+    // Check if any of the default agents don't exist
+    const validAgentIdentifiers = new Set(agents.map(agent => agent.getIdentifier()));
+    const validAgentNames = new Set(agents.map(agent => agent.getName().toLowerCase()));
+    
+    const invalidAgents = defaults.filter(filter => 
+      !validAgentIdentifiers.has(filter) && 
+      ![...validAgentNames].some(name => name.includes(filter))
+    );
+    
+    if (invalidAgents.length > 0) {
+      throw createRulerError(
+        `Invalid agent specified in default_agents: ${invalidAgents.join(', ')}`,
+        `Valid agents are: ${[...validAgentIdentifiers].join(', ')}`
+      );
+    }
+    
     selected = agents.filter((agent) => {
       const identifier = agent.getIdentifier();
       const override = config.agentConfigs[identifier]?.enabled;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -192,7 +192,7 @@ export async function applyAllAgentConfigs(
   let selected = agents;
   if (config.cliAgents && config.cliAgents.length > 0) {
     const filters = config.cliAgents.map((n) => n.toLowerCase());
-    
+
     // Check if any of the specified agents don't exist
     const validAgentIdentifiers = new Set(
       agents.map((agent) => agent.getIdentifier()),
@@ -200,20 +200,20 @@ export async function applyAllAgentConfigs(
     const validAgentNames = new Set(
       agents.map((agent) => agent.getName().toLowerCase()),
     );
-    
+
     const invalidAgents = filters.filter(
       (filter) =>
         !validAgentIdentifiers.has(filter) &&
         ![...validAgentNames].some((name) => name.includes(filter)),
     );
-    
+
     if (invalidAgents.length > 0) {
       throw createRulerError(
         `Invalid agent specified: ${invalidAgents.join(', ')}`,
-        `Valid agents are: ${[...validAgentIdentifiers].join(', ')}`
+        `Valid agents are: ${[...validAgentIdentifiers].join(', ')}`,
       );
     }
-    
+
     selected = agents.filter((agent) =>
       filters.some(
         (f) =>
@@ -227,7 +227,7 @@ export async function applyAllAgentConfigs(
     );
   } else if (config.defaultAgents && config.defaultAgents.length > 0) {
     const defaults = config.defaultAgents.map((n) => n.toLowerCase());
-    
+
     // Check if any of the default agents don't exist
     const validAgentIdentifiers = new Set(
       agents.map((agent) => agent.getIdentifier()),
@@ -235,20 +235,20 @@ export async function applyAllAgentConfigs(
     const validAgentNames = new Set(
       agents.map((agent) => agent.getName().toLowerCase()),
     );
-    
+
     const invalidAgents = defaults.filter(
       (filter) =>
         !validAgentIdentifiers.has(filter) &&
         ![...validAgentNames].some((name) => name.includes(filter)),
     );
-    
+
     if (invalidAgents.length > 0) {
       throw createRulerError(
         `Invalid agent specified in default_agents: ${invalidAgents.join(', ')}`,
-        `Valid agents are: ${[...validAgentIdentifiers].join(', ')}`
+        `Valid agents are: ${[...validAgentIdentifiers].join(', ')}`,
       );
     }
-    
+
     selected = agents.filter((agent) => {
       const identifier = agent.getIdentifier();
       const override = config.agentConfigs[identifier]?.enabled;

--- a/tests/unit/invalid-agent.test.ts
+++ b/tests/unit/invalid-agent.test.ts
@@ -1,0 +1,75 @@
+import { applyAllAgentConfigs } from '../../src/lib';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as os from 'os';
+
+jest.mock('fs', () => {
+  const originalFs = jest.requireActual('fs');
+  return {
+    ...originalFs,
+    promises: {
+      ...originalFs.promises,
+      writeFile: jest.fn().mockResolvedValue(undefined),
+      readFile: jest.fn().mockImplementation((path, encoding) => {
+        if (path.includes('mcp.json')) {
+          return Promise.resolve('{"mcpServers": {}}');
+        }
+        if (path.includes('instructions.md')) {
+          return Promise.resolve('# Test Instructions');
+        }
+        if (path.includes('ruler.toml')) {
+          return Promise.resolve('# Test TOML config');
+        }
+        return Promise.reject(new Error(`File not found: ${path}`));
+      }),
+      mkdir: jest.fn().mockResolvedValue(undefined),
+      access: jest.fn().mockImplementation((path) => {
+        if (path.includes('.ruler')) {
+          return Promise.resolve();
+        }
+        return Promise.reject(new Error('File not found'));
+      }),
+      readdir: jest.fn().mockImplementation((dir) => {
+        if (dir.includes('.ruler')) {
+          return Promise.resolve(['instructions.md', 'mcp.json', 'ruler.toml']);
+        }
+        return Promise.resolve([]);
+      }),
+      stat: jest.fn().mockImplementation((path) => {
+        return Promise.resolve({
+          isDirectory: () => path.includes('.ruler'),
+          isFile: () => !path.includes('.ruler'),
+        });
+      }),
+    },
+  };
+});
+
+jest.mock('../../src/core/FileSystemUtils', () => ({
+  findRulerDir: jest.fn().mockResolvedValue('/test/.ruler'),
+  readMarkdownFiles: jest.fn().mockResolvedValue([
+    {
+      path: '/test/.ruler/instructions.md',
+      content: '# Test Instructions',
+    },
+  ]),
+}));
+
+jest.mock('../../src/core/GitignoreUtils', () => ({
+  updateGitignore: jest.fn().mockResolvedValue(undefined),
+}));
+
+describe('Invalid Agent Handling', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    console.log = jest.fn();
+    console.error = jest.fn();
+  });
+
+  it('should throw an error when an invalid agent is specified', async () => {
+    // This test should fail initially, then pass after our fix
+    await expect(
+      applyAllAgentConfigs('/test', ['nonexistentAgent'])
+    ).rejects.toThrow('Invalid agent specified: nonexistentagent');
+  });
+});


### PR DESCRIPTION
This PR fixes issue #78 by adding validation for agent names in the `apply` command.

## Problem
When a non-existent agent is specified in the `--agents` parameter for the `apply` command, the command reports success even though it didn't do anything.

## Solution
Added validation for agent names in the `applyAllAgentConfigs` function. The function now checks if the specified agents exist before proceeding and throws an error if any of them don't exist.

The solution is flexible and extendible as it:
1. Collects the set of all allowed agents from the Agent implementation
2. Validates both CLI-specified agents and config-specified default agents
3. Provides a helpful error message listing all valid agents

## Testing
Added a unit test that verifies the behavior when an invalid agent is specified.

Fixes #78