### PR TITLE
Refactor: centralize agent registry

### DIFF
--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -1,0 +1,40 @@
+import { IAgent } from './IAgent';
+import { CopilotAgent } from './CopilotAgent';
+import { ClaudeAgent } from './ClaudeAgent';
+import { CodexCliAgent } from './CodexCliAgent';
+import { CursorAgent } from './CursorAgent';
+import { WindsurfAgent } from './WindsurfAgent';
+import { ClineAgent } from './ClineAgent';
+import { AiderAgent } from './AiderAgent';
+import { FirebaseAgent } from './FirebaseAgent';
+import { OpenHandsAgent } from './OpenHandsAgent';
+import { GeminiCliAgent } from './GeminiCliAgent';
+import { JulesAgent } from './JulesAgent';
+import { JunieAgent } from './JunieAgent';
+import { AugmentCodeAgent } from './AugmentCodeAgent';
+import { KiloCodeAgent } from './KiloCodeAgent';
+import { OpenCodeAgent } from './OpenCodeAgent';
+import { CrushAgent } from './CrushAgent';
+import { GooseAgent } from './GooseAgent';
+import { AmpAgent } from './AmpAgent';
+
+export const allAgents: IAgent[] = [
+  new CopilotAgent(),
+  new ClaudeAgent(),
+  new CodexCliAgent(),
+  new CursorAgent(),
+  new WindsurfAgent(),
+  new ClineAgent(),
+  new AiderAgent(),
+  new FirebaseAgent(),
+  new OpenHandsAgent(),
+  new GeminiCliAgent(),
+  new JulesAgent(),
+  new JunieAgent(),
+  new AugmentCodeAgent(),
+  new KiloCodeAgent(),
+  new OpenCodeAgent(),
+  new GooseAgent(),
+  new CrushAgent(),
+  new AmpAgent(),
+];

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,22 +1,5 @@
 import { IAgent } from './agents/IAgent';
-import { CopilotAgent } from './agents/CopilotAgent';
-import { ClaudeAgent } from './agents/ClaudeAgent';
-import { CodexCliAgent } from './agents/CodexCliAgent';
-import { CursorAgent } from './agents/CursorAgent';
-import { WindsurfAgent } from './agents/WindsurfAgent';
-import { ClineAgent } from './agents/ClineAgent';
-import { AiderAgent } from './agents/AiderAgent';
-import { FirebaseAgent } from './agents/FirebaseAgent';
-import { OpenHandsAgent } from './agents/OpenHandsAgent';
-import { GeminiCliAgent } from './agents/GeminiCliAgent';
-import { JulesAgent } from './agents/JulesAgent';
-import { JunieAgent } from './agents/JunieAgent';
-import { AugmentCodeAgent } from './agents/AugmentCodeAgent';
-import { KiloCodeAgent } from './agents/KiloCodeAgent';
-import { OpenCodeAgent } from './agents/OpenCodeAgent';
-import { CrushAgent } from './agents/CrushAgent';
-import { GooseAgent } from './agents/GooseAgent';
-import { AmpAgent } from './agents/AmpAgent';
+import { allAgents } from './agents';
 import { McpStrategy } from './types';
 import { logVerbose } from './constants';
 import {
@@ -26,26 +9,9 @@ import {
   updateGitignore,
 } from './core/apply-engine';
 
-const agents: IAgent[] = [
-  new CopilotAgent(),
-  new ClaudeAgent(),
-  new CodexCliAgent(),
-  new CursorAgent(),
-  new WindsurfAgent(),
-  new ClineAgent(),
-  new AiderAgent(),
-  new FirebaseAgent(),
-  new OpenHandsAgent(),
-  new GeminiCliAgent(),
-  new JulesAgent(),
-  new JunieAgent(),
-  new AugmentCodeAgent(),
-  new KiloCodeAgent(),
-  new OpenCodeAgent(),
-  new GooseAgent(),
-  new CrushAgent(),
-  new AmpAgent(),
-];
+const agents: IAgent[] = allAgents;
+
+export { allAgents };
 
 /**
  * Applies ruler configurations for all supported AI agents.

--- a/src/revert.ts
+++ b/src/revert.ts
@@ -3,48 +3,16 @@ import { promises as fs } from 'fs';
 import * as FileSystemUtils from './core/FileSystemUtils';
 import { loadConfig } from './core/ConfigLoader';
 import { IAgent } from './agents/IAgent';
-import { CopilotAgent } from './agents/CopilotAgent';
-import { ClaudeAgent } from './agents/ClaudeAgent';
-import { CodexCliAgent } from './agents/CodexCliAgent';
-import { CursorAgent } from './agents/CursorAgent';
-import { WindsurfAgent } from './agents/WindsurfAgent';
-import * as ClineAgent from './agents/ClineAgent';
-import { AiderAgent } from './agents/AiderAgent';
-import { FirebaseAgent } from './agents/FirebaseAgent';
-import { OpenHandsAgent } from './agents/OpenHandsAgent';
-import { GeminiCliAgent } from './agents/GeminiCliAgent';
-import { JulesAgent } from './agents/JulesAgent';
-import { JunieAgent } from './agents/JunieAgent';
-import { AugmentCodeAgent } from './agents/AugmentCodeAgent';
-import { KiloCodeAgent } from './agents/KiloCodeAgent';
-import { OpenCodeAgent } from './agents/OpenCodeAgent';
-import { GooseAgent } from './agents/GooseAgent';
-import { AmpAgent } from './agents/AmpAgent';
+import { allAgents } from './agents';
 import { createRulerError, logVerbose } from './constants';
 import {
   revertAgentConfiguration,
   cleanUpAuxiliaryFiles,
 } from './core/revert-engine';
 
-const agents: IAgent[] = [
-  new CopilotAgent(),
-  new ClaudeAgent(),
-  new CodexCliAgent(),
-  new CursorAgent(),
-  new WindsurfAgent(),
-  new ClineAgent.ClineAgent(),
-  new AiderAgent(),
-  new FirebaseAgent(),
-  new OpenHandsAgent(),
-  new GeminiCliAgent(),
-  new JulesAgent(),
-  new JunieAgent(),
-  new AugmentCodeAgent(),
-  new KiloCodeAgent(),
-  new OpenCodeAgent(),
-  new GooseAgent(),
-  new AmpAgent(),
-];
+const agents: IAgent[] = allAgents;
+
+export { allAgents };
 
 /**
  * Reverts ruler configurations for selected AI agents.

--- a/tests/unit/agents/AgentRegistry.test.ts
+++ b/tests/unit/agents/AgentRegistry.test.ts
@@ -1,0 +1,23 @@
+import { allAgents as libAgents } from '../../../src/lib';
+import { allAgents as revertAgents } from '../../../src/revert';
+import { CrushAgent } from '../../../src/agents/CrushAgent';
+import { IAgent } from '../../../src/agents/IAgent';
+
+describe('Agent Registry', () => {
+  it('should have the same agents in lib.ts and revert.ts', () => {
+    const libAgentIdentifiers = libAgents
+      .map((agent: IAgent) => agent.getIdentifier())
+      .sort();
+    const revertAgentIdentifiers = revertAgents
+      .map((agent: IAgent) => agent.getIdentifier())
+      .sort();
+    expect(libAgentIdentifiers).toEqual(revertAgentIdentifiers);
+  });
+
+  it('revert.ts should include CrushAgent', () => {
+    const hasCrushAgent = revertAgents.some(
+      (agent: IAgent) => agent instanceof CrushAgent,
+    );
+    expect(hasCrushAgent).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- centralize agent definitions under `src/agents/index.ts`
- use shared `allAgents` list in `lib` and `revert`
- add tests ensuring both modules share identical agents and include `CrushAgent`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1af135f74832e8886c110caec6bef