### PR TITLE
feat: introduce DEFAULT_RULES_FILENAME constant (Task 1 of AGENTS.md migration)

### DIFF
--- a/src/cli/handlers.ts
+++ b/src/cli/handlers.ts
@@ -3,7 +3,7 @@ import { revertAllAgentConfigs } from '../revert';
 import * as path from 'path';
 import * as os from 'os';
 import * as fs from 'fs/promises';
-import { ERROR_PREFIX } from '../constants';
+import { ERROR_PREFIX, DEFAULT_RULES_FILENAME } from '../constants';
 import { McpStrategy } from '../types';
 
 export interface ApplyArgs {
@@ -93,7 +93,7 @@ export async function initHandler(argv: InitArgs): Promise<void> {
       )
     : path.join(projectRoot, '.ruler');
   await fs.mkdir(rulerDir, { recursive: true });
-  const instructionsPath = path.join(rulerDir, 'instructions.md');
+  const instructionsPath = path.join(rulerDir, DEFAULT_RULES_FILENAME);
   const tomlPath = path.join(rulerDir, 'ruler.toml');
   const exists = async (p: string) => {
     try {
@@ -166,7 +166,7 @@ and apply them to your configured AI coding agents.
     await fs.writeFile(instructionsPath, DEFAULT_INSTRUCTIONS);
     console.log(`[ruler] Created ${instructionsPath}`);
   } else {
-    console.log(`[ruler] instructions.md already exists, skipping`);
+    console.log(`[ruler] ${DEFAULT_RULES_FILENAME} already exists, skipping`);
   }
   if (!(await exists(tomlPath))) {
     await fs.writeFile(tomlPath, DEFAULT_TOML);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,7 @@
 export const ERROR_PREFIX = '[ruler]';
+// Centralized default rules filename. Initially points to legacy 'instructions.md'.
+// Future tasks will flip this to 'AGENTS.md' while preserving backward compatibility.
+export const DEFAULT_RULES_FILENAME = 'instructions.md';
 
 export function createRulerError(message: string, context?: string): Error {
   const fullMessage = context

--- a/tests/unit/agents/AmpAgent.test.ts
+++ b/tests/unit/agents/AmpAgent.test.ts
@@ -32,7 +32,8 @@ describe('AmpAgent', () => {
   });
 
   it('should return the correct default output path', () => {
-    expect(agent.getDefaultOutputPath('/root')).toBe('/root/AGENT.md');
+    const base = path.join(os.tmpdir(), 'amp-agent-path-test');
+    expect(agent.getDefaultOutputPath(base)).toBe(path.join(base, 'AGENT.md'));
   });
 
   it('should apply ruler config to the default output path', async () => {
@@ -41,11 +42,11 @@ describe('AmpAgent', () => {
       FileSystemUtils,
       'writeGeneratedFile',
     );
-
-    await agent.applyRulerConfig('rules', '/root', null);
-
-    expect(backupFile).toHaveBeenCalledWith('/root/AGENT.md');
-    expect(writeGeneratedFile).toHaveBeenCalledWith('/root/AGENT.md', 'rules');
+    const base = await fs.mkdtemp(path.join(os.tmpdir(), 'amp-agent-default-'));
+    await agent.applyRulerConfig('rules', base, null);
+    const expected = path.join(base, 'AGENT.md');
+    expect(backupFile).toHaveBeenCalledWith(expected);
+    expect(writeGeneratedFile).toHaveBeenCalledWith(expected, 'rules');
   });
 
   it('should apply ruler config to a custom output path', async () => {
@@ -54,13 +55,11 @@ describe('AmpAgent', () => {
       FileSystemUtils,
       'writeGeneratedFile',
     );
-
-    await agent.applyRulerConfig('rules', '/root', null, {
-      outputPath: 'CUSTOM.md',
-    });
-
-    expect(backupFile).toHaveBeenCalledWith('/root/CUSTOM.md');
-    expect(writeGeneratedFile).toHaveBeenCalledWith('/root/CUSTOM.md', 'rules');
+    const base = await fs.mkdtemp(path.join(os.tmpdir(), 'amp-agent-custom-'));
+    await agent.applyRulerConfig('rules', base, null, { outputPath: 'CUSTOM.md' });
+    const expected = path.join(base, 'CUSTOM.md');
+    expect(backupFile).toHaveBeenCalledWith(expected);
+    expect(writeGeneratedFile).toHaveBeenCalledWith(expected, 'rules');
   });
 
   describe('integration with backup and revert functionality', () => {

--- a/tests/unit/constants.test.ts
+++ b/tests/unit/constants.test.ts
@@ -1,0 +1,7 @@
+import { DEFAULT_RULES_FILENAME } from '../../src/constants';
+
+describe('constants', () => {
+  it('exports DEFAULT_RULES_FILENAME as instructions.md (legacy default)', () => {
+    expect(DEFAULT_RULES_FILENAME).toBe('instructions.md');
+  });
+});


### PR DESCRIPTION
Implements Task 1 of the AGENTS.md migration plan (#119):

- Added DEFAULT_RULES_FILENAME constant (currently 'instructions.md') in src/constants.ts
- Refactored init handler to use the constant instead of hard-coded string
- Added unit test asserting constant value (tests/unit/constants.test.ts)
- Adjusted AmpAgent tests to avoid non-writable /root path (uses temp dir) to keep CI green

No behavioral change intended yet; runtime still uses legacy 'instructions.md'. All tests pass locally (302 tests).

Next Task (planned): Flip constant to AGENTS.md with backward-compatible fallback.

Please review; minimal diff as per plan.