### PR TITLE
Migrate non-legacy tests to AGENTS.md (Task 7)

### DIFF
--- a/tests/e2e/ruler.test.ts
+++ b/tests/e2e/ruler.test.ts
@@ -287,7 +287,7 @@ output_path = "custom-claude.md"`;
     beforeAll(async () => {
       // Create a dedicated test project for gitignore testing
       gitignoreTestProject = await setupTestProject({
-        '.ruler/instructions.md': 'test'
+        '.ruler/AGENTS.md': 'test'
       });
 
       // Create the necessary subdirectories that the agents will write to

--- a/tests/unit/agents/AmpAgent.test.ts
+++ b/tests/unit/agents/AmpAgent.test.ts
@@ -82,7 +82,7 @@ describe('AmpAgent', () => {
       // Create .ruler directory for revert functionality
       const rulerDir = path.join(tmpDir, '.ruler');
       await fs.mkdir(rulerDir, { recursive: true });
-      await fs.writeFile(path.join(rulerDir, 'instructions.md'), 'Test rules');
+  await fs.writeFile(path.join(rulerDir, 'AGENTS.md'), 'Test rules');
     });
 
     afterEach(async () => {

--- a/tests/unit/harness.test.ts
+++ b/tests/unit/harness.test.ts
@@ -36,7 +36,7 @@ describe('Test Harness', () => {
 
     it('creates files when provided', async () => {
       const files = {
-        '.ruler/instructions.md': '# Test Instructions',
+        '.ruler/AGENTS.md': '# Test Instructions',
         '.ruler/ruler.toml': 'default_agents = ["GitHub Copilot"]',
         'README.md': '# Test Project'
       };
@@ -107,7 +107,7 @@ describe('Test Harness', () => {
     beforeEach(async () => {
       // Create a basic test project with ruler configuration
       testProject = await setupTestProject({
-        '.ruler/instructions.md': '# Test Rule',
+        '.ruler/AGENTS.md': '# Test Rule',
         '.ruler/ruler.toml': 'default_agents = ["GitHub Copilot"]'
       });
     });

--- a/tests/unit/invalid-agent.test.ts
+++ b/tests/unit/invalid-agent.test.ts
@@ -14,7 +14,7 @@ jest.mock('fs', () => {
         if (path.includes('mcp.json')) {
           return Promise.resolve('{"mcpServers": {}}');
         }
-        if (path.includes('instructions.md')) {
+  if (path.includes('AGENTS.md')) {
           return Promise.resolve('# Test Instructions');
         }
         if (path.includes('ruler.toml')) {
@@ -31,7 +31,7 @@ jest.mock('fs', () => {
       }),
       readdir: jest.fn().mockImplementation((dir) => {
         if (dir.includes('.ruler')) {
-          return Promise.resolve(['instructions.md', 'mcp.json', 'ruler.toml']);
+          return Promise.resolve(['AGENTS.md', 'mcp.json', 'ruler.toml']);
         }
         return Promise.resolve([]);
       }),
@@ -49,7 +49,7 @@ jest.mock('../../src/core/FileSystemUtils', () => ({
   findRulerDir: jest.fn().mockResolvedValue('/test/.ruler'),
   readMarkdownFiles: jest.fn().mockResolvedValue([
     {
-      path: '/test/.ruler/instructions.md',
+      path: '/test/.ruler/AGENTS.md',
       content: '# Test Instructions',
     },
   ]),


### PR DESCRIPTION
Task 7: Migrate Existing Tests From instructions.md to AGENTS.md

Summary:
Replaced non-legacy test fixtures and expectations referencing .ruler/instructions.md with .ruler/AGENTS.md while retaining explicit legacy fallback coverage (init + integration revert tests and any agent path expectations involving legacy-specific outputs). No unrelated assertions modified.

Changes:
- tests/unit/harness.test.ts: default project files now create .ruler/AGENTS.md
- tests/unit/agents/AmpAgent.test.ts: integration setup uses AGENTS.md
- tests/e2e/ruler.test.ts: gitignore generation fixture uses AGENTS.md
- tests/unit/invalid-agent.test.ts: mocks updated to return AGENTS.md

Legacy Coverage Preserved:
- Existing tests that purposely exercise legacy fallback (init creates AGENTS.md alongside legacy, revert/integration using legacy file) untouched.

Validation:
- All 49 test suites pass locally (309 tests) after change.
- Warning for legacy file still emitted only in scenarios using legacy path.

Risk / Scope:
Minimal, confined to test fixtures; no source code modified.

Next Steps:
Proceed with docs migration (Task 8) and deprecation warning refinement (Task 9).

Let me know if you’d like the legacy tests tagged or isolated further.