### PR TITLE
feat: warn on legacy .ruler/mcp.json usage

### DIFF
--- a/src/core/UnifiedConfigLoader.ts
+++ b/src/core/UnifiedConfigLoader.ts
@@ -243,6 +243,11 @@ export async function loadUnifiedConfig(
       file: mcpFile,
     });
 
+    // Console warning mirroring legacy instructions.md style
+    console.warn(
+      '[ruler] Warning: Using legacy .ruler/mcp.json. Please migrate to ruler.toml. This fallback will be removed in a future release.',
+    );
+
     const parsedObj = parsed as Record<string, unknown>;
     const serversRaw =
       (parsedObj.mcpServers as unknown) || (parsedObj.servers as unknown) || {};

--- a/tests/unified-config.mcp-json-warning.test.ts
+++ b/tests/unified-config.mcp-json-warning.test.ts
@@ -1,0 +1,43 @@
+import * as path from 'path';
+import { setupTestProject, teardownTestProject } from './harness';
+
+/**
+ * Verifies that using legacy .ruler/mcp.json emits a console warning instructing migration
+ * to ruler.toml, matching the style of the legacy instructions.md warning.
+ */
+describe('legacy mcp.json warning', () => {
+  let testProject: { projectRoot: string };
+  const warningRegex = /\[ruler] Warning: Using legacy \.ruler\/mcp\.json\./;
+
+  let originalWarn: (...args: any[]) => void;
+  let captured: string[];
+
+  beforeEach(async () => {
+    originalWarn = console.warn;
+    captured = [];
+    console.warn = (...args: any[]) => {
+      captured.push(args.join(' '));
+      originalWarn.apply(console, args);
+    };
+
+    const toml = `[mcp]\nenabled = true\n\n[mcp_servers.local]\ncommand = "echo"\nargs = ["hi"]\n`;
+    const json = { mcpServers: { legacy: { command: 'echo', args: ['old'] } } };
+
+    testProject = await setupTestProject({
+      '.ruler/ruler.toml': toml,
+      '.ruler/mcp.json': JSON.stringify(json, null, 2)
+    });
+  });
+
+  afterEach(async () => {
+    console.warn = originalWarn;
+    await teardownTestProject(testProject.projectRoot);
+  });
+
+  it('emits console warning for legacy mcp.json', async () => {
+    const { projectRoot } = testProject;
+    const { loadUnifiedConfig } = require('../dist/core/UnifiedConfigLoader');
+    await loadUnifiedConfig({ projectRoot });
+    expect(captured.some(l => warningRegex.test(l))).toBeTruthy();
+  });
+});


### PR DESCRIPTION
### Summary
Adds a console warning when `.ruler/mcp.json` is detected, matching the existing style used for legacy `.ruler/instructions.md`.

Message:
```
[ruler] Warning: Using legacy .ruler/mcp.json. Please migrate to ruler.toml. This fallback will be removed in a future release.
```

### Details
- Emits `console.warn` in `UnifiedConfigLoader` when reading legacy `mcp.json`.
- Keeps existing diagnostic (`MCP_JSON_DEPRECATED`) for structured tooling warnings.
- Adds new test `unified-config.mcp-json-warning.test.ts` to verify the console warning is emitted.

### Rationale
Encourages users to migrate MCP server definitions into `ruler.toml` under `[mcp_servers.*]` sections, unifying configuration surface.

### Testing
- Added unit test capturing `console.warn` output.
- Ran related MCP integration tests; all pass.

### Next Steps (optional)
- Consider documenting the migration path in README / docs.
- Eventually remove fallback loading of `mcp.json` in a major release.
