### PR TITLE
feat: remove legacy instructions.md warning

### DIFF
--- a/src/cli/handlers.ts
+++ b/src/cli/handlers.ts
@@ -94,7 +94,6 @@ export async function initHandler(argv: InitArgs): Promise<void> {
     : path.join(projectRoot, '.ruler');
   await fs.mkdir(rulerDir, { recursive: true });
   const instructionsPath = path.join(rulerDir, DEFAULT_RULES_FILENAME); // .ruler/AGENTS.md
-  const legacyPath = path.join(rulerDir, 'instructions.md');
   const tomlPath = path.join(rulerDir, 'ruler.toml');
   const exists = async (p: string) => {
     try {
@@ -174,11 +173,6 @@ export async function initHandler(argv: InitArgs): Promise<void> {
     // Create new AGENTS.md regardless of legacy presence.
     await fs.writeFile(instructionsPath, DEFAULT_INSTRUCTIONS);
     console.log(`[ruler] Created ${instructionsPath}`);
-    if (await exists(legacyPath)) {
-      console.log(
-        '[ruler] Legacy instructions.md detected (kept for backward compatibility).',
-      );
-    }
   } else {
     console.log(`[ruler] ${DEFAULT_RULES_FILENAME} already exists, skipping`);
   }

--- a/src/core/FileSystemUtils.ts
+++ b/src/core/FileSystemUtils.ts
@@ -2,16 +2,6 @@ import { promises as fs } from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 
-// Internal flag to ensure we only emit the legacy warning once per process.
-let legacyWarningEmitted = false;
-/**
- * TEST-ONLY: resets the legacy warning emission flag so unit tests can assert
- * behavior in isolation. Not documented for public use.
- */
-export function __resetLegacyWarningForTests() {
-  legacyWarningEmitted = false;
-}
-
 /**
  * Gets the XDG config directory path, falling back to ~/.config if XDG_CONFIG_HOME is not set.
  */
@@ -92,7 +82,7 @@ export async function readMarkdownFiles(
 
   // Prioritisation logic:
   // 1. Prefer top-level AGENTS.md if present.
-  // 2. If AGENTS.md absent but legacy instructions.md present, use it (emit one-time warning).
+  // 2. If AGENTS.md absent but legacy instructions.md present, use it (no longer emits a warning; legacy accepted silently).
   // 3. Include any remaining .md files (excluding whichever of the above was used if present) in
   //    sorted order AFTER the preferred primary file so that new concatenation priority starts with AGENTS.md.
   const topLevelAgents = path.join(rulerDir, 'AGENTS.md');
@@ -111,12 +101,6 @@ export async function readMarkdownFiles(
     for (const f of mdFiles) {
       if (f.path === topLevelLegacy) {
         primaryFile = f;
-        if (!legacyWarningEmitted) {
-          console.warn(
-            '[ruler] Warning: Using legacy .ruler/instructions.md. Please migrate to AGENTS.md. This fallback will be removed in a future release.',
-          );
-          legacyWarningEmitted = true;
-        }
         break;
       }
     }

--- a/tests/unit/cli/handlers.test.ts
+++ b/tests/unit/cli/handlers.test.ts
@@ -279,7 +279,7 @@ describe('CLI Handlers', () => {
       expect(fs.writeFile).not.toHaveBeenCalled();
     });
 
-    it('should create AGENTS.md when legacy instructions.md exists (legacy preserved)', async () => {
+  it('should create AGENTS.md when legacy instructions.md exists (legacy preserved silently)', async () => {
       // access sequence: AGENTS.md (fail), legacy instructions.md (exists), ruler.toml (fail)
       (fs.access as jest.Mock)
         .mockRejectedValueOnce(new Error('AGENTS missing'))
@@ -295,7 +295,8 @@ describe('CLI Handlers', () => {
         expect.stringContaining('# AGENTS.md'),
       );
       // Expect a notice about legacy detection once implementation added
-      expect(logSpy.mock.calls.some(c => /legacy instructions\.md detected/i.test(c[0]))).toBe(true);
+  // No legacy notice expected anymore
+  expect(logSpy.mock.calls.some(c => /legacy instructions\.md detected/i.test(c[0]))).toBe(false);
       logSpy.mockRestore();
     });
   });


### PR DESCRIPTION
### Summary
Removes the legacy warning emitted when `.ruler/instructions.md` is used instead of `AGENTS.md`. The legacy file is now accepted silently as a fallback primary rules file when `AGENTS.md` is absent.

### Changes
- Removed legacy warning logic and state from `readMarkdownFiles` in `FileSystemUtils.ts`.
- Updated prioritization comment to reflect silent fallback.
- Removed legacy detection notice in `init` handler (no message logged if `instructions.md` exists).
- Adjusted unit tests:
  - Updated `AgentsMdFallback.test.ts` to assert absence of warning and removed single-warning emission test.
  - Updated handlers unit test to no longer expect legacy notice log.
- Left MCP JSON deprecation warnings untouched.

### Rationale
Users may still rely on `instructions.md`; removing the warning reduces noise while keeping backward compatibility. Migration to `AGENTS.md` remains encouraged via docs, not runtime warnings.

### Testing
All Jest test suites pass (`361` tests). Updated tests reflect the new silent behavior.

### Follow-ups (Optional)
- Consider unifying rule loading paths so `UnifiedConfigLoader` uses the recursive reader for consistent ordering.
- Update README / docs to clarify that `instructions.md` is an accepted silent fallback.

