### PR TITLE
Fix: always generate Codex .codex/config.toml when requested

### DIFF
--- a/src/core/apply-engine.ts
+++ b/src/core/apply-engine.ts
@@ -220,7 +220,6 @@ export async function applyConfigurationsToAgents(
     } else {
       if (
         agent.getIdentifier() === 'jules' ||
-        agent.getIdentifier() === 'codex' ||
         agent.getIdentifier() === 'agentsmd'
       ) {
         if (agentsMdWritten) {

--- a/tests/integration/codex-multi-agent.test.ts
+++ b/tests/integration/codex-multi-agent.test.ts
@@ -1,0 +1,45 @@
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { setupTestProject, teardownTestProject, runRulerWithInheritedStdio } from '../harness';
+
+describe('Codex config generation with multiple AGENTS.md writers', () => {
+  let project: { projectRoot: string };
+
+  beforeAll(async () => {
+    project = await setupTestProject({
+      '.ruler/a.md': 'Rule A',
+      '.ruler/b.md': 'Rule B',
+      // Provide MCP servers so Codex has something to write into config.toml
+      '.ruler/mcp.json': JSON.stringify({
+        mcpServers: {
+          example_server: { command: 'uvx', args: ['example-mcp'] }
+        }
+      })
+    });
+  });
+
+  afterAll(async () => {
+    await teardownTestProject(project.projectRoot);
+  });
+
+  beforeEach(async () => {
+    // Clean previous outputs
+    await fs.rm(path.join(project.projectRoot, 'AGENTS.md'), { force: true });
+    await fs.rm(path.join(project.projectRoot, '.codex'), { recursive: true, force: true });
+  });
+
+  it('writes .codex/config.toml when running jules,codex', async () => {
+    runRulerWithInheritedStdio('apply --agents jules,codex', project.projectRoot);
+    const codexToml = path.join(project.projectRoot, '.codex', 'config.toml');
+    const content = await fs.readFile(codexToml, 'utf8');
+    expect(content).toMatch(/\[mcp_servers\.example_server\]/);
+  });
+
+  it('writes .codex/config.toml when running codex,jules', async () => {
+    runRulerWithInheritedStdio('apply --agents codex,jules', project.projectRoot);
+    const codexToml = path.join(project.projectRoot, '.codex', 'config.toml');
+    const content = await fs.readFile(codexToml, 'utf8');
+    expect(content).toMatch(/\[mcp_servers\.example_server\]/);
+  });
+});
+


### PR DESCRIPTION
Problem: When running with multiple AGENTS.md-producing agents (e.g. jules,codex), the dedup guard in apply-engine skipped Codex entirely if AGENTS.md had already been written, preventing .codex/config.toml generation.\n\nChange: Remove 'codex' from the AGENTS.md dedup guard so Codex.applyRulerConfig always runs. This preserves single-write optimization for agentsmd/jules while letting Codex generate its TOML config.\n\nTests: Add integration tests to verify .codex/config.toml is produced for both orders: jules,codex and codex,jules. Full test suite passes locally.\n\nNotes: Keeps change minimal without refactor; maintains idempotency and existing backup semantics.