### PR TITLE
feat: HTML comment source markers (2 blank lines before, 1 after)

### DIFF
--- a/src/core/RuleProcessor.ts
+++ b/src/core/RuleProcessor.ts
@@ -13,9 +13,16 @@ export function concatenateRules(
     const rel = path.relative(base, filePath);
     // Normalize path separators to forward slashes for consistent output across platforms
     const normalizedRel = rel.replace(/\\/g, '/');
-    return ['---', `Source: ${normalizedRel}`, '---', content.trim(), ''].join(
-      '\n',
-    );
+    // New format: two leading blank lines, HTML comment with source, one blank line, then content, then trailing newline
+    // We intentionally trim content to avoid cascading blank lines, then ensure a final newline via join logic
+    return [
+      '', // first leading blank line
+      '', // second leading blank line
+      `<!-- Source: ${normalizedRel} -->`,
+      '', // single blank line after the comment
+      content.trim(),
+      '', // ensure file section ends with newline
+    ].join('\n');
   });
   return sections.join('\n');
 }

--- a/tests/integration/root-agents-detection.test.ts
+++ b/tests/integration/root-agents-detection.test.ts
@@ -43,8 +43,8 @@ describe('Root AGENTS.md detection', () => {
     expect(innerIndex).toBeGreaterThan(rootIndex);
 
     // Verify source annotations reflect correct relative paths
-  expect(codexOutput).toMatch(/Source: AGENTS.md/);
-  expect(codexOutput).toMatch(/Source: \.ruler\/AGENTS.md/);
+  expect(codexOutput).toMatch(/<!-- Source: AGENTS.md -->/);
+  expect(codexOutput).toMatch(/<!-- Source: \.ruler\/AGENTS.md -->/);
   });
 
   it('uses only .ruler files when root AGENTS.md missing', async () => {
@@ -56,6 +56,6 @@ describe('Root AGENTS.md detection', () => {
     expect(codexOutput).toContain('Inner rules file');
     expect(codexOutput).toContain('Extra inner file');
     // Should NOT include a Source section for root AGENTS.md
-  expect(codexOutput).not.toMatch(/Source: AGENTS.md$/m);
+  expect(codexOutput).not.toMatch(/<!-- Source: AGENTS.md -->$/m);
   });
 });

--- a/tests/unit/core/RuleProcessor.test.js
+++ b/tests/unit/core/RuleProcessor.test.js
@@ -9,9 +9,9 @@ describe('RuleProcessor', () => {
         ];
         jest.spyOn(process, 'cwd').mockReturnValue('/project');
         const result = (0, RuleProcessor_1.concatenateRules)(files);
-        expect(result).toContain('Source: .ruler/a.md');
+        expect(result).toContain('<!-- Source: .ruler/a.md -->');
         expect(result).toContain('A rule');
-        expect(result).toContain('Source: .ruler/b.md');
+        expect(result).toContain('<!-- Source: .ruler/b.md -->');
         expect(result).toContain('B rule');
     });
 });

--- a/tests/unit/core/RuleProcessor.test.ts
+++ b/tests/unit/core/RuleProcessor.test.ts
@@ -8,10 +8,21 @@ describe('RuleProcessor', () => {
       { path: '/project/.ruler/b.md', content: 'B rule' },
     ];
   const result = concatenateRules(files, '/project');
-    expect(result).toContain('Source: .ruler/a.md');
+    expect(result).toContain('<!-- Source: .ruler/a.md -->');
     expect(result).toContain('A rule');
-    expect(result).toContain('Source: .ruler/b.md');
+    expect(result).toContain('<!-- Source: .ruler/b.md -->');
     expect(result).toContain('B rule');
+
+    // Whitespace checks: two blank lines before, one after marker before content
+    const markerIndex = result.indexOf('<!-- Source: .ruler/a.md -->');
+    const prefix = result.slice(0, markerIndex);
+    // Expect prefix ends with two newlines (i.e., there is an empty line immediately before marker and another one before that)
+    expect(/\n\n$/.test(prefix)).toBe(true);
+    const afterMarker = result.slice(markerIndex + '<!-- Source: .ruler/a.md -->'.length);
+    // After marker should start with a single blank line then content (i.e., exactly two leading newlines before first char of content relative to start of marker suffix)
+    expect(afterMarker.startsWith('\n\nA rule')).toBe(true);
+    // And not three newlines
+    expect(afterMarker.startsWith('\n\n\n')).toBe(false);
   });
 
   it('normalizes path separators to forward slashes for cross-platform consistency', () => {
@@ -22,8 +33,8 @@ describe('RuleProcessor', () => {
     const result = concatenateRules(files, '/project');
     
     // Should always use forward slashes in source markers, regardless of OS
-    expect(result).toContain('Source: .ruler/subfolder/windows-style.md');
-    expect(result).toContain('Source: .ruler/unix-style.md');
+    expect(result).toContain('<!-- Source: .ruler/subfolder/windows-style.md -->');
+    expect(result).toContain('<!-- Source: .ruler/unix-style.md -->');
     expect(result).not.toContain('\\'); // Should not contain any backslashes
   });
 });

--- a/tests/unit/core/unified-config-loader.test.ts
+++ b/tests/unit/core/unified-config-loader.test.ts
@@ -26,6 +26,6 @@ describe('UnifiedConfigLoader (basic)', () => {
     expect(unified.rules.files[0].relativePath).toMatch(/AGENTS\.md$/);
   const rels = unified.rules.files.map((f) => f.relativePath);
     expect(rels).toEqual(['AGENTS.md', 'extra.md']);
-  expect(unified.rules.concatenated).toMatch(/Source: \.ruler\/AGENTS.md[\s\S]*Source: \.ruler\/extra.md/);
+  expect(unified.rules.concatenated).toMatch(/<!-- Source: \.ruler\/AGENTS.md -->[\s\S]*<!-- Source: \.ruler\/extra.md -->/);
   });
 });


### PR DESCRIPTION
This PR updates rule concatenation formatting:

Changes:
- Replace previous '--- / Source: <file> / ---' markers with HTML comment markers.
- New spacing: two blank lines before the comment, one blank line after comment before content.
- Updated all affected tests (unit + integration) to match new format.
- Added whitespace-specific assertions in RuleProcessor tests to guard spacing contract.

Rationale:
HTML comment markers are less visually noisy inside rendered markdown while still machine-parseable. Spacing choice improves readability separation between sections.

Validation:
- All Jest tests pass locally: 78 suites, 407 tests.
- Added explicit whitespace verification around first marker.

Let me know if you'd like a follow-up to document this in README or expose a formatting option.
