### PR TITLE
Feature/nested rules

### DIFF
--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -65,7 +65,7 @@ export function run(): void {
           .option('nested', {
             type: 'boolean',
             description:
-              'Enable nested rule loading from nested .ruler directories',
+              'Enable nested rule loading from nested .ruler directories (default: disabled)',
             default: false,
           });
       },

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -62,10 +62,10 @@ export function run(): void {
               'Only search for local .ruler directories, ignore global config',
             default: false,
           })
-          .option('hierarchical', {
+          .option('nested', {
             type: 'boolean',
             description:
-              'Enable hierarchical rule loading from nested .ruler directories',
+              'Enable nested rule loading from nested .ruler directories',
             default: false,
           });
       },

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -61,6 +61,12 @@ export function run(): void {
             description:
               'Only search for local .ruler directories, ignore global config',
             default: false,
+          })
+          .option('hierarchical', {
+            type: 'boolean',
+            description:
+              'Enable hierarchical rule loading from nested .ruler directories',
+            default: false,
           });
       },
       applyHandler,
@@ -123,6 +129,12 @@ export function run(): void {
             type: 'boolean',
             description:
               'Only search for local .ruler directories, ignore global config',
+            default: false,
+          })
+          .option('hierarchical', {
+            type: 'boolean',
+            description:
+              'Enable hierarchical rule loading from nested .ruler directories',
             default: false,
           });
       },

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -130,12 +130,6 @@ export function run(): void {
             description:
               'Only search for local .ruler directories, ignore global config',
             default: false,
-          })
-          .option('hierarchical', {
-            type: 'boolean',
-            description:
-              'Enable hierarchical rule loading from nested .ruler directories',
-            default: false,
           });
       },
       revertHandler,

--- a/src/cli/handlers.ts
+++ b/src/cli/handlers.ts
@@ -16,6 +16,7 @@ export interface ApplyArgs {
   verbose: boolean;
   'dry-run': boolean;
   'local-only': boolean;
+  hierarchical: boolean;
 }
 
 export interface InitArgs {
@@ -31,6 +32,7 @@ export interface RevertArgs {
   verbose: boolean;
   'dry-run': boolean;
   'local-only': boolean;
+  hierarchical: boolean;
 }
 
 /**
@@ -49,6 +51,7 @@ export async function applyHandler(argv: ApplyArgs): Promise<void> {
   const verbose = argv.verbose;
   const dryRun = argv['dry-run'];
   const localOnly = argv['local-only'];
+  const hierarchical = argv.hierarchical;
 
   // Determine gitignore preference: CLI > TOML > Default (enabled)
   // yargs handles --no-gitignore by setting gitignore to false
@@ -70,6 +73,7 @@ export async function applyHandler(argv: ApplyArgs): Promise<void> {
       verbose,
       dryRun,
       localOnly,
+      hierarchical,
     );
     console.log('Ruler apply completed successfully.');
   } catch (err: unknown) {
@@ -197,6 +201,7 @@ export async function revertHandler(argv: RevertArgs): Promise<void> {
   const verbose = argv.verbose;
   const dryRun = argv['dry-run'];
   const localOnly = argv['local-only'];
+  const hierarchical = argv.hierarchical;
 
   try {
     await revertAllAgentConfigs(
@@ -207,6 +212,7 @@ export async function revertHandler(argv: RevertArgs): Promise<void> {
       verbose,
       dryRun,
       localOnly,
+      hierarchical,
     );
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);

--- a/src/cli/handlers.ts
+++ b/src/cli/handlers.ts
@@ -32,7 +32,6 @@ export interface RevertArgs {
   verbose: boolean;
   'dry-run': boolean;
   'local-only': boolean;
-  hierarchical: boolean;
 }
 
 /**

--- a/src/cli/handlers.ts
+++ b/src/cli/handlers.ts
@@ -114,6 +114,10 @@ export async function initHandler(argv: InitArgs): Promise<void> {
 # uncomment and populate the following line. If omitted, all agents are active.
 # default_agents = ["copilot", "claude"]
 
+# Enable nested rule loading from nested .ruler directories
+# When enabled, ruler will search for and process .ruler directories throughout the project hierarchy
+# nested = false
+
 # --- Agent Specific Configurations ---
 # You can enable/disable agents and override their default output paths here.
 # Use lowercase agent identifiers: amp, copilot, claude, codex, cursor, windsurf, cline, aider, kilocode

--- a/src/cli/handlers.ts
+++ b/src/cli/handlers.ts
@@ -16,7 +16,7 @@ export interface ApplyArgs {
   verbose: boolean;
   'dry-run': boolean;
   'local-only': boolean;
-  hierarchical: boolean;
+  nested: boolean;
 }
 
 export interface InitArgs {
@@ -50,7 +50,7 @@ export async function applyHandler(argv: ApplyArgs): Promise<void> {
   const verbose = argv.verbose;
   const dryRun = argv['dry-run'];
   const localOnly = argv['local-only'];
-  const hierarchical = argv.hierarchical;
+  const nested = argv.nested;
 
   // Determine gitignore preference: CLI > TOML > Default (enabled)
   // yargs handles --no-gitignore by setting gitignore to false
@@ -72,7 +72,7 @@ export async function applyHandler(argv: ApplyArgs): Promise<void> {
       verbose,
       dryRun,
       localOnly,
-      hierarchical,
+      nested,
     );
     console.log('Ruler apply completed successfully.');
   } catch (err: unknown) {

--- a/src/cli/handlers.ts
+++ b/src/cli/handlers.ts
@@ -201,7 +201,6 @@ export async function revertHandler(argv: RevertArgs): Promise<void> {
   const verbose = argv.verbose;
   const dryRun = argv['dry-run'];
   const localOnly = argv['local-only'];
-  const hierarchical = argv.hierarchical;
 
   try {
     await revertAllAgentConfigs(
@@ -212,7 +211,6 @@ export async function revertHandler(argv: RevertArgs): Promise<void> {
       verbose,
       dryRun,
       localOnly,
-      hierarchical,
     );
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);

--- a/src/core/ConfigLoader.ts
+++ b/src/core/ConfigLoader.ts
@@ -41,6 +41,7 @@ const rulerConfigSchema = z.object({
       enabled: z.boolean().optional(),
     })
     .optional(),
+  nested: z.boolean().optional(),
 });
 
 /**
@@ -69,6 +70,8 @@ export interface LoadedConfig {
   mcp?: GlobalMcpConfig;
   /** Gitignore configuration section. */
   gitignore?: GitignoreConfig;
+  /** Whether to enable nested rule loading from nested .ruler directories. */
+  nested?: boolean;
 }
 
 /**
@@ -207,11 +210,14 @@ export async function loadConfig(
     gitignoreConfig.enabled = rawGitignoreSection.enabled;
   }
 
+  const nested = typeof raw.nested === 'boolean' ? raw.nested : undefined;
+
   return {
     defaultAgents,
     agentConfigs,
     cliAgents,
     mcp: globalMcpConfig,
     gitignore: gitignoreConfig,
+    nested,
   };
 }

--- a/src/core/ConfigLoader.ts
+++ b/src/core/ConfigLoader.ts
@@ -210,7 +210,7 @@ export async function loadConfig(
     gitignoreConfig.enabled = rawGitignoreSection.enabled;
   }
 
-  const nested = typeof raw.nested === 'boolean' ? raw.nested : undefined;
+  const nested = typeof raw.nested === 'boolean' ? raw.nested : false;
 
   return {
     defaultAgents,

--- a/src/core/UnifiedConfigLoader.ts
+++ b/src/core/UnifiedConfigLoader.ts
@@ -72,11 +72,22 @@ export async function loadUnifiedConfig(
       (tomlRaw as Record<string, unknown>).default_agents as unknown[]
     ).map((a) => String(a));
   }
+
+  let nested: boolean | undefined;
+  if (
+    tomlRaw &&
+    typeof tomlRaw === 'object' &&
+    typeof (tomlRaw as Record<string, unknown>).nested === 'boolean'
+  ) {
+    nested = (tomlRaw as Record<string, unknown>).nested as boolean;
+  }
+
   const toml: TomlConfig = {
     raw: tomlRaw,
     schemaVersion: 1,
     agents: {},
     defaultAgents,
+    nested,
   };
 
   // Collect rule markdown files

--- a/src/core/UnifiedConfigLoader.ts
+++ b/src/core/UnifiedConfigLoader.ts
@@ -73,7 +73,7 @@ export async function loadUnifiedConfig(
     ).map((a) => String(a));
   }
 
-  let nested: boolean | undefined;
+  let nested = false;
   if (
     tomlRaw &&
     typeof tomlRaw === 'object' &&

--- a/src/core/UnifiedConfigTypes.ts
+++ b/src/core/UnifiedConfigTypes.ts
@@ -27,6 +27,7 @@ export interface TomlConfig {
   mcp?: McpToggleConfig;
   mcpServers?: Record<string, McpServerDef>;
   gitignore?: GitignoreConfig;
+  nested?: boolean;
 }
 
 export type McpToggleConfig = McpConfig;

--- a/src/core/apply-engine.ts
+++ b/src/core/apply-engine.ts
@@ -40,16 +40,12 @@ export async function loadRulerConfiguration(
   projectRoot: string,
   configPath: string | undefined,
   localOnly: boolean,
-  hierarchical: boolean = false,
+  nested?: boolean,
 ): Promise<RulerConfiguration | HierarchicalRulerConfiguration[]> {
-  if (hierarchical) {
-    return await loadHierarchicalConfigurations(
-      projectRoot,
-      configPath,
-      localOnly,
-    );
+  if (nested) {
+    return loadHierarchicalConfigurations(projectRoot, configPath, localOnly);
   } else {
-    return await loadSingleConfiguration(projectRoot, configPath, localOnly);
+    return loadSingleConfiguration(projectRoot, configPath, localOnly);
   }
 }
 

--- a/src/core/apply-engine.ts
+++ b/src/core/apply-engine.ts
@@ -413,7 +413,7 @@ export async function processSingleConfiguration(
  * @param dryRun Whether to perform a dry run
  * @returns Promise resolving to array of generated file paths
  */
-async function applyConfigurationsToAgents(
+export async function applyConfigurationsToAgents(
   agents: IAgent[],
   concatenatedRules: string,
   rulerMcpJson: Record<string, unknown> | null,

--- a/src/core/apply-engine.ts
+++ b/src/core/apply-engine.ts
@@ -552,6 +552,7 @@ async function handleMcpConfiguration(
     dest,
     agentConfig,
     config,
+    projectRoot,
     cliMcpStrategy,
     dryRun,
     verbose,
@@ -576,6 +577,7 @@ async function applyMcpConfiguration(
   dest: string,
   agentConfig: IAgentConfig | undefined,
   config: LoadedConfig,
+  projectRoot: string,
   cliMcpStrategy: McpStrategy | undefined,
   dryRun: boolean,
   verbose: boolean,
@@ -648,37 +650,6 @@ async function applyOpenCodeMcpConfiguration(
     );
   } else {
     await propagateMcpToOpenCode(filteredMcpJson, dest);
-  }
-}
-
-async function applyStandardMcpConfiguration(
-  agent: IAgent,
-  filteredMcpJson: Record<string, unknown>,
-  dest: string,
-  agentConfig: IAgentConfig | undefined,
-  config: LoadedConfig,
-  cliMcpStrategy: McpStrategy | undefined,
-  dryRun: boolean,
-  verbose: boolean,
-): Promise<void> {
-  const strategy =
-    cliMcpStrategy ??
-    agentConfig?.mcp?.strategy ??
-    config.mcp?.strategy ??
-    'merge';
-  const serverKey = agent.getMcpServerKey?.() ?? 'mcpServers';
-
-  logVerbose(
-    `Applying filtered MCP config for ${agent.getName()} with strategy: ${strategy} and key: ${serverKey}`,
-    verbose,
-  );
-
-  if (dryRun) {
-    logVerbose(`DRY RUN: Would apply MCP config to: ${dest}`, verbose);
-  } else {
-    const existing = await readNativeMcp(dest);
-    const merged = mergeMcp(existing, filteredMcpJson, strategy, serverKey);
-    await writeNativeMcp(dest, merged);
   }
 }
 

--- a/src/core/apply-engine.ts
+++ b/src/core/apply-engine.ts
@@ -43,7 +43,7 @@ export async function loadRulerConfiguration(
   nested?: boolean,
 ): Promise<RulerConfiguration | HierarchicalRulerConfiguration[]> {
   if (nested) {
-    return loadHierarchicalConfigurations(projectRoot, configPath, localOnly);
+    return loadNestedConfigurations(projectRoot, configPath, localOnly);
   } else {
     return loadSingleConfiguration(projectRoot, configPath, localOnly);
   }
@@ -57,7 +57,7 @@ export /**
  * @param localOnly Whether to search only locally for .ruler directories
  * @returns Promise resolving to array of hierarchical configurations
  */
-async function loadHierarchicalConfigurations(
+async function loadNestedConfigurations(
   projectRoot: string,
   configPath: string | undefined,
   localOnly: boolean,

--- a/src/core/apply-engine.ts
+++ b/src/core/apply-engine.ts
@@ -53,7 +53,15 @@ export async function loadRulerConfiguration(
   }
 }
 
-export async function loadHierarchicalConfigurations(
+export /**
+ * Loads configurations for all .ruler directories in hierarchical mode.
+ * Each .ruler directory gets its own independent configuration with separate rules.
+ * @param projectRoot Root directory of the project
+ * @param configPath Optional custom config path
+ * @param localOnly Whether to search only locally for .ruler directories
+ * @returns Promise resolving to array of hierarchical configurations
+ */
+async function loadHierarchicalConfigurations(
   projectRoot: string,
   configPath: string | undefined,
   localOnly: boolean,
@@ -178,7 +186,15 @@ async function warnAboutLegacyMcpJson(rulerDir: string): Promise<void> {
 /**
  * Loads configuration for single-directory mode (existing behavior).
  */
-export async function loadSingleConfiguration(
+export /**
+ * Loads configuration for a single .ruler directory.
+ * All rules from the directory are concatenated into a single configuration.
+ * @param projectRoot Root directory of the project
+ * @param configPath Optional custom config path
+ * @param localOnly Whether to search only locally for .ruler directory
+ * @returns Promise resolving to the loaded configuration
+ */
+async function loadSingleConfiguration(
   projectRoot: string,
   configPath: string | undefined,
   localOnly: boolean,
@@ -312,48 +328,17 @@ export function selectAgentsToRun(
 }
 
 /**
- * Applies configurations to agents, handling both single and hierarchical modes.
+ * Processes hierarchical configurations by applying rules to each .ruler directory independently.
+ * Each directory gets its own set of rules and generates its own agent files.
  * @param agents Array of agents to process
- * @param configuration Either a single RulerConfiguration or array of HierarchicalRulerConfiguration
- * @param projectRoot Root directory of the project
+ * @param configurations Array of hierarchical configurations for each .ruler directory
  * @param verbose Whether to enable verbose logging
  * @param dryRun Whether to perform a dry run
  * @param cliMcpEnabled Whether MCP is enabled via CLI
  * @param cliMcpStrategy MCP strategy from CLI
  * @returns Promise resolving to array of generated file paths
  */
-export async function applyConfigurations(
-  agents: IAgent[],
-  configuration: RulerConfiguration | HierarchicalRulerConfiguration[],
-  projectRoot: string,
-  verbose: boolean,
-  dryRun: boolean,
-  cliMcpEnabled = true,
-  cliMcpStrategy?: McpStrategy,
-): Promise<string[]> {
-  if (Array.isArray(configuration)) {
-    return await processHierarchicalConfigurations(
-      agents,
-      configuration,
-      verbose,
-      dryRun,
-      cliMcpEnabled,
-      cliMcpStrategy,
-    );
-  } else {
-    return await processSingleConfiguration(
-      agents,
-      configuration,
-      projectRoot,
-      verbose,
-      dryRun,
-      cliMcpEnabled,
-      cliMcpStrategy,
-    );
-  }
-}
-
-async function processHierarchicalConfigurations(
+export async function processHierarchicalConfigurations(
   agents: IAgent[],
   configurations: HierarchicalRulerConfiguration[],
   verbose: boolean,
@@ -383,7 +368,19 @@ async function processHierarchicalConfigurations(
   return allGeneratedPaths;
 }
 
-async function processSingleConfiguration(
+/**
+ * Processes a single configuration by applying rules to all selected agents.
+ * All rules are concatenated and applied to generate agent files in the project root.
+ * @param agents Array of agents to process
+ * @param configuration Single ruler configuration with concatenated rules
+ * @param projectRoot Root directory of the project
+ * @param verbose Whether to enable verbose logging
+ * @param dryRun Whether to perform a dry run
+ * @param cliMcpEnabled Whether MCP is enabled via CLI
+ * @param cliMcpStrategy MCP strategy from CLI
+ * @returns Promise resolving to array of generated file paths
+ */
+export async function processSingleConfiguration(
   agents: IAgent[],
   configuration: RulerConfiguration,
   projectRoot: string,

--- a/src/core/apply-engine.ts
+++ b/src/core/apply-engine.ts
@@ -29,26 +29,6 @@ export interface HierarchicalRulerConfiguration extends RulerConfiguration {
   rulerDir: string;
 }
 
-/**
- * Loads all necessary configurations for ruler operation.
- * @param projectRoot Root directory of the project
- * @param configPath Optional custom config path
- * @param localOnly Whether to search only locally for .ruler directory
- * @returns Promise resolving to the loaded configuration(s)
- */
-export async function loadRulerConfiguration(
-  projectRoot: string,
-  configPath: string | undefined,
-  localOnly: boolean,
-  nested?: boolean,
-): Promise<RulerConfiguration | HierarchicalRulerConfiguration[]> {
-  if (nested) {
-    return loadNestedConfigurations(projectRoot, configPath, localOnly);
-  } else {
-    return loadSingleConfiguration(projectRoot, configPath, localOnly);
-  }
-}
-
 export /**
  * Loads configurations for all .ruler directories in hierarchical mode.
  * Each .ruler directory gets its own independent configuration with separate rules.

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -3,12 +3,12 @@ import { allAgents } from './agents';
 import { McpStrategy } from './types';
 import { logVerbose } from './constants';
 import {
-  loadHierarchicalConfigurations,
   loadSingleConfiguration,
   selectAgentsToRun,
   processHierarchicalConfigurations,
   processSingleConfiguration,
   updateGitignore,
+  loadNestedConfigurations,
 } from './core/apply-engine';
 import { type LoadedConfig } from './core/ConfigLoader';
 
@@ -51,7 +51,7 @@ export async function applyAllAgentConfigs(
   let loadedConfig: LoadedConfig;
 
   if (nested) {
-    const hierarchicalConfigs = await loadHierarchicalConfigurations(
+    const hierarchicalConfigs = await loadNestedConfigurations(
       projectRoot,
       configPath,
       localOnly,

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -35,7 +35,7 @@ export async function applyAllAgentConfigs(
   verbose = false,
   dryRun = false,
   localOnly = false,
-  hierarchical = false,
+  nested = false,
 ): Promise<void> {
   // Load configuration and rules
   logVerbose(
@@ -50,7 +50,7 @@ export async function applyAllAgentConfigs(
   let generatedPaths: string[];
   let loadedConfig: LoadedConfig;
 
-  if (hierarchical) {
+  if (nested) {
     const hierarchicalConfigs = await loadHierarchicalConfigurations(
       projectRoot,
       configPath,

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -3,11 +3,14 @@ import { allAgents } from './agents';
 import { McpStrategy } from './types';
 import { logVerbose } from './constants';
 import {
-  loadRulerConfiguration,
+  loadHierarchicalConfigurations,
+  loadSingleConfiguration,
   selectAgentsToRun,
-  applyConfigurationsToAgents,
+  processHierarchicalConfigurations,
+  processSingleConfiguration,
   updateGitignore,
 } from './core/apply-engine';
+import { type LoadedConfig } from './core/ConfigLoader';
 
 const agents: IAgent[] = allAgents;
 
@@ -32,6 +35,7 @@ export async function applyAllAgentConfigs(
   verbose = false,
   dryRun = false,
   localOnly = false,
+  hierarchical = false,
 ): Promise<void> {
   // Load configuration and rules
   logVerbose(
@@ -42,27 +46,111 @@ export async function applyAllAgentConfigs(
     logVerbose(`Using custom config path: ${configPath}`, verbose);
   }
 
-  const rulerConfiguration = await loadRulerConfiguration(
+  let selectedAgents: IAgent[];
+  let generatedPaths: string[];
+  let loadedConfig: LoadedConfig;
+
+  if (hierarchical) {
+    const hierarchicalConfigs = await loadHierarchicalConfigurations(
+      projectRoot,
+      configPath,
+      localOnly,
+    );
+
+    if (hierarchicalConfigs.length === 0) {
+      throw new Error('No .ruler directories found');
+    }
+
+    // Use the root config for agent selection (all levels share the same agent settings)
+    const rootConfig = hierarchicalConfigs[0].config;
+    loadedConfig = rootConfig;
+    rootConfig.cliAgents = includedAgents;
+
+    logVerbose(
+      `Loaded ${hierarchicalConfigs.length} .ruler directory configurations`,
+      verbose,
+    );
+    logVerbose(
+      `Root configuration has ${Object.keys(rootConfig.agentConfigs).length} agent configs`,
+      verbose,
+    );
+
+    normalizeAgentConfigs(rootConfig, agents);
+
+    selectedAgents = selectAgentsToRun(agents, rootConfig);
+    logVerbose(
+      `Selected ${selectedAgents.length} agents: ${selectedAgents.map((a) => a.getName()).join(', ')}`,
+      verbose,
+    );
+
+    generatedPaths = await processHierarchicalConfigurations(
+      selectedAgents,
+      hierarchicalConfigs,
+      verbose,
+      dryRun,
+      cliMcpEnabled,
+      cliMcpStrategy,
+    );
+  } else {
+    const singleConfig = await loadSingleConfiguration(
+      projectRoot,
+      configPath,
+      localOnly,
+    );
+
+    loadedConfig = singleConfig.config;
+    singleConfig.config.cliAgents = includedAgents;
+
+    logVerbose(
+      `Loaded configuration with ${Object.keys(singleConfig.config.agentConfigs).length} agent configs`,
+      verbose,
+    );
+    logVerbose(
+      `Found .ruler directory with ${singleConfig.concatenatedRules.length} characters of rules`,
+      verbose,
+    );
+
+    normalizeAgentConfigs(singleConfig.config, agents);
+
+    selectedAgents = selectAgentsToRun(agents, singleConfig.config);
+    logVerbose(
+      `Selected ${selectedAgents.length} agents: ${selectedAgents.map((a) => a.getName()).join(', ')}`,
+      verbose,
+    );
+
+    generatedPaths = await processSingleConfiguration(
+      selectedAgents,
+      singleConfig,
+      projectRoot,
+      verbose,
+      dryRun,
+      cliMcpEnabled,
+      cliMcpStrategy,
+    );
+  }
+
+  await updateGitignore(
     projectRoot,
-    configPath,
-    localOnly,
+    generatedPaths,
+    loadedConfig,
+    cliGitignoreEnabled,
+    dryRun,
   );
+}
 
-  // Add CLI agents to the configuration
-  rulerConfiguration.config.cliAgents = includedAgents;
-
-  logVerbose(
-    `Loaded configuration with ${Object.keys(rulerConfiguration.config.agentConfigs).length} agent configs`,
-    verbose,
-  );
-  logVerbose(
-    `Found .ruler directory with ${rulerConfiguration.concatenatedRules.length} characters of rules`,
-    verbose,
-  );
-
-  // Normalize per-agent config keys to agent identifiers (exact match or substring match)
-  const rawConfigs = rulerConfiguration.config.agentConfigs;
+/**
+ * Normalizes per-agent config keys to agent identifiers for consistent lookup.
+ * Maps both exact identifier matches and substring matches with agent names.
+ * @param config The configuration object to normalize
+ * @param agents Array of available agents
+ */
+function normalizeAgentConfigs(
+  config: { agentConfigs: Record<string, any> },
+  agents: IAgent[],
+): void {
+  const rawConfigs = config.agentConfigs;
   const mappedConfigs: Record<string, (typeof rawConfigs)[string]> = {};
+
   for (const [key, cfg] of Object.entries(rawConfigs)) {
     const lowerKey = key.toLowerCase();
     for (const agent of agents) {
@@ -76,34 +164,6 @@ export async function applyAllAgentConfigs(
       }
     }
   }
-  rulerConfiguration.config.agentConfigs = mappedConfigs;
 
-  // Select agents to run
-  const selectedAgents = selectAgentsToRun(agents, rulerConfiguration.config);
-  logVerbose(
-    `Selected ${selectedAgents.length} agents: ${selectedAgents.map((a) => a.getName()).join(', ')}`,
-    verbose,
-  );
-
-  // Apply configurations to agents
-  const generatedPaths = await applyConfigurationsToAgents(
-    selectedAgents,
-    rulerConfiguration.concatenatedRules,
-    rulerConfiguration.rulerMcpJson,
-    rulerConfiguration.config,
-    projectRoot,
-    verbose,
-    dryRun,
-    cliMcpEnabled,
-    cliMcpStrategy,
-  );
-
-  // Update .gitignore
-  await updateGitignore(
-    projectRoot,
-    generatedPaths,
-    rulerConfiguration.config,
-    cliGitignoreEnabled,
-    dryRun,
-  );
+  config.agentConfigs = mappedConfigs;
 }

--- a/tests/integration/hierarchical-rules.test.ts
+++ b/tests/integration/hierarchical-rules.test.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import { applyAllAgentConfigs } from '../../src/lib';
 import { setupTestProject } from '../harness';
 
-describe('Hierarchical Rules Integration', () => {
+describe('Nested Rules Integration', () => {
   let testProject: { projectRoot: string };
 
   beforeAll(async () => {
@@ -15,7 +15,7 @@ describe('Hierarchical Rules Integration', () => {
     await fs.rm(testProject.projectRoot, { recursive: true, force: true });
   });
 
-  it('processes each .ruler directory independently in hierarchical mode', async () => {
+  it('processes each .ruler directory independently in nested mode', async () => {
     // Create nested directory structure
     const moduleDir = path.join(testProject.projectRoot, 'module');
     const submoduleDir = path.join(moduleDir, 'submodule');
@@ -42,7 +42,7 @@ describe('Hierarchical Rules Integration', () => {
       '# Submodule Rules\n\nThese are submodule-level rules that should only appear in submodule-level files.',
     );
 
-    // Apply with hierarchical flag from project root
+    // Apply with nested flag from project root
     await applyAllAgentConfigs(
       testProject.projectRoot, // Start from project root
       ['claude'], // Only test with one agent for simplicity
@@ -53,7 +53,7 @@ describe('Hierarchical Rules Integration', () => {
       false, // verbose
       false, // dryRun
       false, // localOnly
-      true, // hierarchical
+      true, // nested
     );
 
     // Check that each level has its own CLAUDE.md file
@@ -105,7 +105,7 @@ describe('Hierarchical Rules Integration', () => {
     expect(submoduleContent).not.toContain('Module Rules');
   });
 
-  it('falls back to single-directory behavior when hierarchical=false', async () => {
+  it('falls back to single-directory behavior when nested=false', async () => {
     // Create nested structure but only put rules in the root
     const moduleDir = path.join(testProject.projectRoot, 'module2');
     await fs.mkdir(path.join(moduleDir, '.ruler'), { recursive: true });
@@ -115,7 +115,7 @@ describe('Hierarchical Rules Integration', () => {
       '# Only Global Rules\n\nGlobal rules only.',
     );
 
-    // Apply without hierarchical flag (should use single-directory logic)
+    // Apply without nested flag (should use single-directory logic)
     await applyAllAgentConfigs(
       moduleDir,
       ['claude'],
@@ -126,7 +126,7 @@ describe('Hierarchical Rules Integration', () => {
       false,
       false,
       false,
-      false, // hierarchical = false
+      false, // nested = false
     );
 
     // Should work without errors (testing that single-directory logic still works)

--- a/tests/integration/hierarchical-rules.test.ts
+++ b/tests/integration/hierarchical-rules.test.ts
@@ -1,0 +1,135 @@
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { applyAllAgentConfigs } from '../../src/lib';
+import { setupTestProject } from '../harness';
+
+describe('Hierarchical Rules Integration', () => {
+  let testProject: { projectRoot: string };
+
+  beforeAll(async () => {
+    testProject = await setupTestProject();
+  });
+
+  afterAll(async () => {
+    // Cleanup the test project
+    await fs.rm(testProject.projectRoot, { recursive: true, force: true });
+  });
+
+  it('processes each .ruler directory independently in hierarchical mode', async () => {
+    // Create nested directory structure
+    const moduleDir = path.join(testProject.projectRoot, 'module');
+    const submoduleDir = path.join(moduleDir, 'submodule');
+
+    await fs.mkdir(path.join(testProject.projectRoot, '.ruler'), {
+      recursive: true,
+    });
+    await fs.mkdir(path.join(moduleDir, '.ruler'), { recursive: true });
+    await fs.mkdir(path.join(submoduleDir, '.ruler'), { recursive: true });
+
+    // Create different rules in each level
+    await fs.writeFile(
+      path.join(testProject.projectRoot, '.ruler', 'AGENTS.md'),
+      '# Root Rules\n\nThese are root-level rules that should only appear in root-level files.',
+    );
+
+    await fs.writeFile(
+      path.join(moduleDir, '.ruler', 'AGENTS.md'),
+      '# Module Rules\n\nThese are module-level rules that should only appear in module-level files.',
+    );
+
+    await fs.writeFile(
+      path.join(submoduleDir, '.ruler', 'AGENTS.md'),
+      '# Submodule Rules\n\nThese are submodule-level rules that should only appear in submodule-level files.',
+    );
+
+    // Apply with hierarchical flag from project root
+    await applyAllAgentConfigs(
+      testProject.projectRoot, // Start from project root
+      ['claude'], // Only test with one agent for simplicity
+      undefined, // configPath
+      true, // cliMcpEnabled
+      undefined, // cliMcpStrategy
+      undefined, // cliGitignoreEnabled
+      false, // verbose
+      false, // dryRun
+      false, // localOnly
+      true, // hierarchical
+    );
+
+    // Check that each level has its own CLAUDE.md file
+    const rootClaudeFile = path.join(testProject.projectRoot, 'CLAUDE.md');
+    const moduleClaudeFile = path.join(moduleDir, 'CLAUDE.md');
+    const submoduleClaudeFile = path.join(submoduleDir, 'CLAUDE.md');
+
+    // Verify files exist
+    expect(
+      await fs
+        .access(rootClaudeFile)
+        .then(() => true)
+        .catch(() => false),
+    ).toBe(true);
+    expect(
+      await fs
+        .access(moduleClaudeFile)
+        .then(() => true)
+        .catch(() => false),
+    ).toBe(true);
+    expect(
+      await fs
+        .access(submoduleClaudeFile)
+        .then(() => true)
+        .catch(() => false),
+    ).toBe(true);
+
+    // Read file contents
+    const rootContent = await fs.readFile(rootClaudeFile, 'utf8');
+    const moduleContent = await fs.readFile(moduleClaudeFile, 'utf8');
+    const submoduleContent = await fs.readFile(submoduleClaudeFile, 'utf8');
+
+    // Verify each file contains only its level's rules
+    expect(rootContent).toContain('Root Rules');
+    expect(rootContent).toContain('should only appear in root-level files');
+    expect(rootContent).not.toContain('Module Rules');
+    expect(rootContent).not.toContain('Submodule Rules');
+
+    expect(moduleContent).toContain('Module Rules');
+    expect(moduleContent).toContain('should only appear in module-level files');
+    expect(moduleContent).not.toContain('Root Rules');
+    expect(moduleContent).not.toContain('Submodule Rules');
+
+    expect(submoduleContent).toContain('Submodule Rules');
+    expect(submoduleContent).toContain(
+      'should only appear in submodule-level files',
+    );
+    expect(submoduleContent).not.toContain('Root Rules');
+    expect(submoduleContent).not.toContain('Module Rules');
+  });
+
+  it('falls back to single-directory behavior when hierarchical=false', async () => {
+    // Create nested structure but only put rules in the root
+    const moduleDir = path.join(testProject.projectRoot, 'module2');
+    await fs.mkdir(path.join(moduleDir, '.ruler'), { recursive: true });
+
+    await fs.writeFile(
+      path.join(testProject.projectRoot, '.ruler', 'AGENTS.md'),
+      '# Only Global Rules\n\nGlobal rules only.',
+    );
+
+    // Apply without hierarchical flag (should use single-directory logic)
+    await applyAllAgentConfigs(
+      moduleDir,
+      ['claude'],
+      undefined,
+      true,
+      undefined,
+      undefined,
+      false,
+      false,
+      false,
+      false, // hierarchical = false
+    );
+
+    // Should work without errors (testing that single-directory logic still works)
+    expect(true).toBe(true); // If we get here, the test passed
+  });
+});

--- a/tests/integration/unified-config-loader.test.ts
+++ b/tests/integration/unified-config-loader.test.ts
@@ -20,7 +20,30 @@ describe('UnifiedConfigLoader integration', () => {
       'extra.md',
     ]);
   });
+
+  test('loads nested configuration option', async () => {
+    const unified = await loadUnifiedConfig({ projectRoot });
+    expect(unified.toml.nested).toBeUndefined(); // Default should be undefined
+
+    // Test with nested = true in TOML
+    const tomlPath = path.join(projectRoot, '.ruler', 'ruler.toml');
+    const originalToml = await fs.readFile(tomlPath, 'utf8');
+    const modifiedToml = `default_agents = ["copilot"]
+nested = true
+
+[agents.copilot]
+output_path = ".github/copilot-instructions.md"
+`;
+    await fs.writeFile(tomlPath, modifiedToml, 'utf8');
+
+    try {
+      const unifiedWithNested = await loadUnifiedConfig({ projectRoot });
+      expect(unifiedWithNested.toml.nested).toBe(true);
+    } finally {
+      // Restore original TOML
+      await fs.writeFile(tomlPath, originalToml, 'utf8');
+    }
+  });
 });
 
 // Separate test for MCP once implemented
-

--- a/tests/integration/unified-config-loader.test.ts
+++ b/tests/integration/unified-config-loader.test.ts
@@ -23,7 +23,7 @@ describe('UnifiedConfigLoader integration', () => {
 
   test('loads nested configuration option', async () => {
     const unified = await loadUnifiedConfig({ projectRoot });
-    expect(unified.toml.nested).toBeUndefined(); // Default should be undefined
+    expect(unified.toml.nested).toBe(false); // Default should be false
 
     // Test with nested = true in TOML
     const tomlPath = path.join(projectRoot, '.ruler', 'ruler.toml');

--- a/tests/integration/unified-equivalence.test.ts
+++ b/tests/integration/unified-equivalence.test.ts
@@ -1,17 +1,30 @@
 import * as path from 'path';
 import { loadUnifiedConfig } from '../../src/core/UnifiedConfigLoader';
-import { loadRulerConfiguration } from '../../src/core/apply-engine';
+import {
+  loadRulerConfiguration,
+  RulerConfiguration,
+} from '../../src/core/apply-engine';
 
 describe('Unified config equivalence (subset)', () => {
   const projectRoot = path.join(__dirname, 'fixtures/agents');
   test('matches defaults and concatenated rules', async () => {
-    const legacy = await loadRulerConfiguration(projectRoot, undefined, false);
+    const legacy = await loadRulerConfiguration(
+      projectRoot,
+      undefined,
+      false,
+      false,
+    );
     const unified = await loadUnifiedConfig({ projectRoot });
+    const legacyConfig = legacy as RulerConfiguration;
     // Legacy default agents live under legacy.config.defaultAgents
-    expect(unified.toml.defaultAgents).toEqual(legacy.config.defaultAgents);
+    expect(unified.toml.defaultAgents).toEqual(
+      legacyConfig.config.defaultAgents,
+    );
     // Both bundles should contain some markdown content (alpha.md/beta.md not created yet, so empty OK)
     expect(typeof unified.rules.concatenated).toBe('string');
     // Enabled agents set equals legacy defaults
-    expect(new Set(Object.keys(unified.agents))).toEqual(new Set(legacy.config.defaultAgents || []));
+    expect(new Set(Object.keys(unified.agents))).toEqual(
+      new Set(legacyConfig.config.defaultAgents || []),
+    );
   });
 });

--- a/tests/integration/unified-equivalence.test.ts
+++ b/tests/integration/unified-equivalence.test.ts
@@ -1,19 +1,14 @@
 import * as path from 'path';
 import { loadUnifiedConfig } from '../../src/core/UnifiedConfigLoader';
 import {
-  loadRulerConfiguration,
+  loadSingleConfiguration,
   RulerConfiguration,
 } from '../../src/core/apply-engine';
 
 describe('Unified config equivalence (subset)', () => {
   const projectRoot = path.join(__dirname, 'fixtures/agents');
   test('matches defaults and concatenated rules', async () => {
-    const legacy = await loadRulerConfiguration(
-      projectRoot,
-      undefined,
-      false,
-      false,
-    );
+    const legacy = await loadSingleConfiguration(projectRoot, undefined, false);
     const unified = await loadUnifiedConfig({ projectRoot });
     const legacyConfig = legacy as RulerConfiguration;
     // Legacy default agents live under legacy.config.defaultAgents

--- a/tests/unit/cli/handlers.test.ts
+++ b/tests/unit/cli/handlers.test.ts
@@ -36,6 +36,7 @@ describe('CLI Handlers', () => {
         verbose: true,
         'dry-run': false,
         'local-only': false,
+        hierarchical: false,
       };
 
       await applyHandler(argv);
@@ -50,6 +51,7 @@ describe('CLI Handlers', () => {
         true,
         false,
         false,
+        false,
       );
     });
 
@@ -61,6 +63,7 @@ describe('CLI Handlers', () => {
         verbose: false,
         'dry-run': false,
         'local-only': false,
+        hierarchical: false,
       };
 
       await applyHandler(argv);
@@ -72,6 +75,7 @@ describe('CLI Handlers', () => {
         true,
         'overwrite',
         undefined,
+        false,
         false,
         false,
         false,
@@ -87,6 +91,7 @@ describe('CLI Handlers', () => {
         verbose: false,
         'dry-run': false,
         'local-only': false,
+        hierarchical: false,
       };
 
       await applyHandler(argv);
@@ -97,6 +102,7 @@ describe('CLI Handlers', () => {
         undefined,
         true,
         undefined,
+        false,
         false,
         false,
         false,
@@ -112,6 +118,7 @@ describe('CLI Handlers', () => {
         verbose: false,
         'dry-run': false,
         'local-only': false,
+        hierarchical: false,
       };
 
       await applyHandler(argv);
@@ -123,6 +130,7 @@ describe('CLI Handlers', () => {
         true,
         undefined,
         undefined,
+        false,
         false,
         false,
         false,
@@ -147,6 +155,7 @@ describe('CLI Handlers', () => {
         verbose: false,
         'dry-run': false,
         'local-only': false,
+        hierarchical: false,
       };
 
       await expect(applyHandler(argv)).rejects.toThrow('process.exit: 1');
@@ -161,9 +170,9 @@ describe('CLI Handlers', () => {
 
   describe('initHandler', () => {
     const mockRulerDir = path.join(mockProjectRoot, '.ruler');
-  const mockInstructionsPath = path.join(mockRulerDir, 'AGENTS.md');
+    const mockInstructionsPath = path.join(mockRulerDir, 'AGENTS.md');
     const mockTomlPath = path.join(mockRulerDir, 'ruler.toml');
-  const mockLegacyPath = path.join(mockRulerDir, 'instructions.md');
+    const mockLegacyPath = path.join(mockRulerDir, 'instructions.md');
 
     beforeEach(() => {
       (fs.access as jest.Mock).mockRejectedValue(new Error('File not found'));
@@ -215,12 +224,12 @@ describe('CLI Handlers', () => {
 
       // Find the call that writes to ruler.toml
       const tomlWriteCall = (fs.writeFile as jest.Mock).mock.calls.find(
-        call => call[0] === mockTomlPath
+        (call) => call[0] === mockTomlPath,
       );
-      
+
       expect(tomlWriteCall).toBeDefined();
       const tomlContent = tomlWriteCall[1];
-      
+
       // Verify MCP server sections are present
       expect(tomlContent).toContain('# --- MCP Servers ---');
       expect(tomlContent).toContain('[mcp_servers.example_stdio]');
@@ -279,7 +288,7 @@ describe('CLI Handlers', () => {
       expect(fs.writeFile).not.toHaveBeenCalled();
     });
 
-  it('should create AGENTS.md when legacy instructions.md exists (legacy preserved silently)', async () => {
+    it('should create AGENTS.md when legacy instructions.md exists (legacy preserved silently)', async () => {
       // access sequence: AGENTS.md (fail), legacy instructions.md (exists), ruler.toml (fail)
       (fs.access as jest.Mock)
         .mockRejectedValueOnce(new Error('AGENTS missing'))
@@ -295,8 +304,12 @@ describe('CLI Handlers', () => {
         expect.stringContaining('# AGENTS.md'),
       );
       // Expect a notice about legacy detection once implementation added
-  // No legacy notice expected anymore
-  expect(logSpy.mock.calls.some(c => /legacy instructions\.md detected/i.test(c[0]))).toBe(false);
+      // No legacy notice expected anymore
+      expect(
+        logSpy.mock.calls.some((c) =>
+          /legacy instructions\.md detected/i.test(c[0]),
+        ),
+      ).toBe(false);
       logSpy.mockRestore();
     });
   });
@@ -311,6 +324,7 @@ describe('CLI Handlers', () => {
         verbose: true,
         'dry-run': false,
         'local-only': false,
+        hierarchical: false,
       };
 
       await revertHandler(argv);
@@ -323,6 +337,7 @@ describe('CLI Handlers', () => {
         true,
         false,
         false,
+        false,
       );
     });
 
@@ -333,6 +348,7 @@ describe('CLI Handlers', () => {
         verbose: false,
         'dry-run': false,
         'local-only': false,
+        hierarchical: false,
       };
 
       await revertHandler(argv);
@@ -341,6 +357,7 @@ describe('CLI Handlers', () => {
         mockProjectRoot,
         undefined,
         undefined,
+        false,
         false,
         false,
         false,
@@ -365,6 +382,7 @@ describe('CLI Handlers', () => {
         verbose: false,
         'dry-run': false,
         'local-only': false,
+        hierarchical: false,
       };
 
       await expect(revertHandler(argv)).rejects.toThrow('process.exit: 1');

--- a/tests/unit/cli/handlers.test.ts
+++ b/tests/unit/cli/handlers.test.ts
@@ -36,7 +36,7 @@ describe('CLI Handlers', () => {
         verbose: true,
         'dry-run': false,
         'local-only': false,
-        hierarchical: false,
+        nested: false,
       };
 
       await applyHandler(argv);
@@ -63,7 +63,7 @@ describe('CLI Handlers', () => {
         verbose: false,
         'dry-run': false,
         'local-only': false,
-        hierarchical: false,
+        nested: false,
       };
 
       await applyHandler(argv);
@@ -91,7 +91,7 @@ describe('CLI Handlers', () => {
         verbose: false,
         'dry-run': false,
         'local-only': false,
-        hierarchical: false,
+        nested: false,
       };
 
       await applyHandler(argv);
@@ -118,7 +118,7 @@ describe('CLI Handlers', () => {
         verbose: false,
         'dry-run': false,
         'local-only': false,
-        hierarchical: false,
+        nested: false,
       };
 
       await applyHandler(argv);
@@ -155,7 +155,7 @@ describe('CLI Handlers', () => {
         verbose: false,
         'dry-run': false,
         'local-only': false,
-        hierarchical: false,
+        nested: false,
       };
 
       await expect(applyHandler(argv)).rejects.toThrow('process.exit: 1');
@@ -324,7 +324,6 @@ describe('CLI Handlers', () => {
         verbose: true,
         'dry-run': false,
         'local-only': false,
-        hierarchical: false,
       };
 
       await revertHandler(argv);
@@ -337,7 +336,6 @@ describe('CLI Handlers', () => {
         true,
         false,
         false,
-        false,
       );
     });
 
@@ -348,7 +346,6 @@ describe('CLI Handlers', () => {
         verbose: false,
         'dry-run': false,
         'local-only': false,
-        hierarchical: false,
       };
 
       await revertHandler(argv);
@@ -357,7 +354,6 @@ describe('CLI Handlers', () => {
         mockProjectRoot,
         undefined,
         undefined,
-        false,
         false,
         false,
         false,
@@ -382,7 +378,6 @@ describe('CLI Handlers', () => {
         verbose: false,
         'dry-run': false,
         'local-only': false,
-        hierarchical: false,
       };
 
       await expect(revertHandler(argv)).rejects.toThrow('process.exit: 1');

--- a/tests/unit/core/AgentsMdFallback.test.ts
+++ b/tests/unit/core/AgentsMdFallback.test.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import os from 'os';
 import {
-  loadRulerConfiguration,
+  loadSingleConfiguration,
   RulerConfiguration,
 } from '../../../src/core/apply-engine';
 
@@ -38,12 +38,7 @@ describe('AGENTS.md fallback behavior', () => {
     const legacy = path.join(rulerDir, 'instructions.md');
     await fs.writeFile(legacy, '# Legacy Rules');
 
-    const result = await loadRulerConfiguration(
-      tmpDir,
-      undefined,
-      false,
-      false,
-    );
+    const result = await loadSingleConfiguration(tmpDir, undefined, false);
     expect((result as RulerConfiguration).concatenatedRules).toContain(
       '# Legacy Rules',
     );
@@ -61,12 +56,7 @@ describe('AGENTS.md fallback behavior', () => {
     await fs.writeFile(legacy, '# Legacy Rules');
     await fs.writeFile(agents, '# New Agents Rules');
 
-    const result = await loadRulerConfiguration(
-      tmpDir,
-      undefined,
-      false,
-      false,
-    );
+    const result = await loadSingleConfiguration(tmpDir, undefined, false);
     const configResult = result as RulerConfiguration;
     expect(configResult.concatenatedRules).toContain('# New Agents Rules');
     // Legacy content may still be concatenated, but AGENTS.md section should appear before legacy section.
@@ -86,12 +76,7 @@ describe('AGENTS.md fallback behavior', () => {
     const agents = path.join(rulerDir, 'AGENTS.md');
     await fs.writeFile(agents, '# New Agents Rules');
 
-    const result = await loadRulerConfiguration(
-      tmpDir,
-      undefined,
-      false,
-      false,
-    );
+    const result = await loadSingleConfiguration(tmpDir, undefined, false);
     expect((result as RulerConfiguration).concatenatedRules).toContain(
       '# New Agents Rules',
     );

--- a/tests/unit/core/AgentsMdFallback.test.ts
+++ b/tests/unit/core/AgentsMdFallback.test.ts
@@ -1,7 +1,10 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import os from 'os';
-import { loadRulerConfiguration } from '../../../src/core/apply-engine';
+import {
+  loadRulerConfiguration,
+  RulerConfiguration,
+} from '../../../src/core/apply-engine';
 
 // We'll capture console warnings to assert legacy warning emitted only once.
 describe('AGENTS.md fallback behavior', () => {
@@ -35,11 +38,20 @@ describe('AGENTS.md fallback behavior', () => {
     const legacy = path.join(rulerDir, 'instructions.md');
     await fs.writeFile(legacy, '# Legacy Rules');
 
-    const result = await loadRulerConfiguration(tmpDir, undefined, false);
-    expect(result.concatenatedRules).toContain('# Legacy Rules');
-  // Expect no legacy warning now that warning has been removed
-  const legacyWarnings = warnMessages.filter(m => m.includes('instructions.md'));
-  expect(legacyWarnings.length).toBe(0);
+    const result = await loadRulerConfiguration(
+      tmpDir,
+      undefined,
+      false,
+      false,
+    );
+    expect((result as RulerConfiguration).concatenatedRules).toContain(
+      '# Legacy Rules',
+    );
+    // Expect no legacy warning now that warning has been removed
+    const legacyWarnings = warnMessages.filter((m) =>
+      m.includes('instructions.md'),
+    );
+    expect(legacyWarnings.length).toBe(0);
   });
 
   it('prefers AGENTS.md ordering over legacy when both exist (no warning)', async () => {
@@ -49,16 +61,24 @@ describe('AGENTS.md fallback behavior', () => {
     await fs.writeFile(legacy, '# Legacy Rules');
     await fs.writeFile(agents, '# New Agents Rules');
 
-    const result = await loadRulerConfiguration(tmpDir, undefined, false);
-  expect(result.concatenatedRules).toContain('# New Agents Rules');
-  // Legacy content may still be concatenated, but AGENTS.md section should appear before legacy section.
-  const idxNew = result.concatenatedRules.indexOf('# New Agents Rules');
-  const idxLegacy = result.concatenatedRules.indexOf('# Legacy Rules');
-  expect(idxNew).toBeGreaterThanOrEqual(0);
-  expect(idxLegacy).toBeGreaterThan(idxNew);
-  // No legacy warning expected
-  const legacyWarnings = warnMessages.filter(m => m.includes('instructions.md'));
-  expect(legacyWarnings.length).toBe(0);
+    const result = await loadRulerConfiguration(
+      tmpDir,
+      undefined,
+      false,
+      false,
+    );
+    const configResult = result as RulerConfiguration;
+    expect(configResult.concatenatedRules).toContain('# New Agents Rules');
+    // Legacy content may still be concatenated, but AGENTS.md section should appear before legacy section.
+    const idxNew = configResult.concatenatedRules.indexOf('# New Agents Rules');
+    const idxLegacy = configResult.concatenatedRules.indexOf('# Legacy Rules');
+    expect(idxNew).toBeGreaterThanOrEqual(0);
+    expect(idxLegacy).toBeGreaterThan(idxNew);
+    // No legacy warning expected
+    const legacyWarnings = warnMessages.filter((m) =>
+      m.includes('instructions.md'),
+    );
+    expect(legacyWarnings.length).toBe(0);
   });
 
   it('uses AGENTS.md without warning when only AGENTS.md present', async () => {
@@ -66,9 +86,18 @@ describe('AGENTS.md fallback behavior', () => {
     const agents = path.join(rulerDir, 'AGENTS.md');
     await fs.writeFile(agents, '# New Agents Rules');
 
-    const result = await loadRulerConfiguration(tmpDir, undefined, false);
-    expect(result.concatenatedRules).toContain('# New Agents Rules');
-    const legacyWarnings = warnMessages.filter(m => m.includes('instructions.md'));
+    const result = await loadRulerConfiguration(
+      tmpDir,
+      undefined,
+      false,
+      false,
+    );
+    expect((result as RulerConfiguration).concatenatedRules).toContain(
+      '# New Agents Rules',
+    );
+    const legacyWarnings = warnMessages.filter((m) =>
+      m.includes('instructions.md'),
+    );
     expect(legacyWarnings.length).toBe(0);
   });
   // Removed test verifying single warning emission; warning no longer produced.

--- a/tests/unit/core/ConfigLoader.test.ts
+++ b/tests/unit/core/ConfigLoader.test.ts
@@ -50,7 +50,7 @@ describe('ConfigLoader', () => {
     const content = `default_agents = ["A"]`;
     await fs.writeFile(path.join(rulerDir, 'ruler.toml'), content);
     const config = await loadConfig({ projectRoot: tmpDir });
-    expect(config.nested).toBeUndefined();
+    expect(config.nested).toBe(false);
   });
 
   it('parses agent enabled overrides', async () => {
@@ -76,44 +76,50 @@ describe('ConfigLoader', () => {
     expect(config.agentConfigs.A.outputPath).toBe(
       path.resolve(tmpDir, 'foo/bar.md'),
     );
-});
+  });
 
-it('parses agent output_path_instructions and resolves to projectRoot', async () => {
-  const content = `
+  it('parses agent output_path_instructions and resolves to projectRoot', async () => {
+    const content = `
     [agents.A]
     output_path_instructions = "foo/instructions.md"
   `;
-  await fs.writeFile(path.join(rulerDir, 'ruler.toml'), content);
-  const config = await loadConfig({ projectRoot: tmpDir });
-  expect(config.agentConfigs.A.outputPathInstructions).toBe(
-    path.resolve(tmpDir, 'foo/instructions.md'),
-  );
-});
+    await fs.writeFile(path.join(rulerDir, 'ruler.toml'), content);
+    const config = await loadConfig({ projectRoot: tmpDir });
+    expect(config.agentConfigs.A.outputPathInstructions).toBe(
+      path.resolve(tmpDir, 'foo/instructions.md'),
+    );
+  });
 
-it('parses agent output_path_config and resolves to projectRoot', async () => {
-  const content = `
+  it('parses agent output_path_config and resolves to projectRoot', async () => {
+    const content = `
     [agents.A]
     output_path_config = "foo/config.toml"
   `;
-  await fs.writeFile(path.join(rulerDir, 'ruler.toml'), content);
-  const config = await loadConfig({ projectRoot: tmpDir });
-  expect(config.agentConfigs.A.outputPathConfig).toBe(
-    path.resolve(tmpDir, 'foo/config.toml'),
-  );
-});
+    await fs.writeFile(path.join(rulerDir, 'ruler.toml'), content);
+    const config = await loadConfig({ projectRoot: tmpDir });
+    expect(config.agentConfigs.A.outputPathConfig).toBe(
+      path.resolve(tmpDir, 'foo/config.toml'),
+    );
+  });
 
-it('loads config from custom path via configPath option', async () => {
+  it('loads config from custom path via configPath option', async () => {
     const altDir = path.join(tmpDir, 'alt');
     await fs.mkdir(altDir, { recursive: true });
     const altPath = path.join(altDir, 'myconfig.toml');
     await fs.writeFile(altPath, `default_agents = ["X"]`);
-    const config = await loadConfig({ projectRoot: tmpDir, configPath: altPath });
+    const config = await loadConfig({
+      projectRoot: tmpDir,
+      configPath: altPath,
+    });
     expect(config.defaultAgents).toEqual(['X']);
   });
 
   it('captures CLI agents override', async () => {
     const overrides = ['C', 'D'];
-    const config = await loadConfig({ projectRoot: tmpDir, cliAgents: overrides });
+    const config = await loadConfig({
+      projectRoot: tmpDir,
+      cliAgents: overrides,
+    });
     expect(config.cliAgents).toEqual(overrides);
   });
 

--- a/tests/unit/core/ConfigLoader.test.ts
+++ b/tests/unit/core/ConfigLoader.test.ts
@@ -39,6 +39,20 @@ describe('ConfigLoader', () => {
     expect(config.defaultAgents).toEqual(['A', 'B']);
   });
 
+  it('parses nested configuration option', async () => {
+    const content = `nested = true`;
+    await fs.writeFile(path.join(rulerDir, 'ruler.toml'), content);
+    const config = await loadConfig({ projectRoot: tmpDir });
+    expect(config.nested).toBe(true);
+  });
+
+  it('defaults nested to undefined when not specified', async () => {
+    const content = `default_agents = ["A"]`;
+    await fs.writeFile(path.join(rulerDir, 'ruler.toml'), content);
+    const config = await loadConfig({ projectRoot: tmpDir });
+    expect(config.nested).toBeUndefined();
+  });
+
   it('parses agent enabled overrides', async () => {
     const content = `
       [agents.A]

--- a/tests/unit/core/FileSystemUtils.hierarchical.test.ts
+++ b/tests/unit/core/FileSystemUtils.hierarchical.test.ts
@@ -1,0 +1,47 @@
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import os from 'os';
+import { findAllRulerDirs } from '../../../src/core/FileSystemUtils';
+
+describe('FileSystemUtils - Hierarchical', () => {
+  let tmpDir: string;
+
+  beforeAll(async () => {
+    tmpDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'ruler-hierarchical-test-'),
+    );
+  });
+
+  afterAll(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('findAllRulerDirs', () => {
+    it('finds all .ruler directories in hierarchy', async () => {
+      // Create nested directory structure
+      const projectDir = path.join(tmpDir, 'project');
+      const moduleDir = path.join(projectDir, 'module');
+      const submoduleDir = path.join(moduleDir, 'submodule');
+
+      await fs.mkdir(path.join(projectDir, '.ruler'), { recursive: true });
+      await fs.mkdir(path.join(moduleDir, '.ruler'), { recursive: true });
+      await fs.mkdir(path.join(submoduleDir, '.ruler'), { recursive: true });
+
+      const rulerDirs = await findAllRulerDirs(projectDir);
+
+      // Should find all three .ruler directories, most specific first
+      expect(rulerDirs).toHaveLength(3);
+      expect(rulerDirs[0]).toBe(path.join(submoduleDir, '.ruler'));
+      expect(rulerDirs[1]).toBe(path.join(moduleDir, '.ruler'));
+      expect(rulerDirs[2]).toBe(path.join(projectDir, '.ruler'));
+    });
+
+    it('returns empty array when no .ruler directories found', async () => {
+      const someDir = path.join(tmpDir, 'empty');
+      await fs.mkdir(someDir, { recursive: true });
+
+      const rulerDirs = await findAllRulerDirs(someDir);
+      expect(rulerDirs).toHaveLength(0);
+    });
+  });
+});

--- a/tests/unit/core/FileSystemUtils.nested.test.ts
+++ b/tests/unit/core/FileSystemUtils.nested.test.ts
@@ -3,13 +3,11 @@ import * as path from 'path';
 import os from 'os';
 import { findAllRulerDirs } from '../../../src/core/FileSystemUtils';
 
-describe('FileSystemUtils - Hierarchical', () => {
+describe('FileSystemUtils - Nested', () => {
   let tmpDir: string;
 
   beforeAll(async () => {
-    tmpDir = await fs.mkdtemp(
-      path.join(os.tmpdir(), 'ruler-hierarchical-test-'),
-    );
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ruler-nested-test-'));
   });
 
   afterAll(async () => {

--- a/tests/unit/core/apply-engine.test.ts
+++ b/tests/unit/core/apply-engine.test.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import os from 'os';
 
 import {
-  loadRulerConfiguration,
+  loadSingleConfiguration,
   selectAgentsToRun,
   applyConfigurationsToAgents,
   updateGitignore,
@@ -81,12 +81,7 @@ describe('apply-engine', () => {
       });
       await fs.writeFile(path.join(rulerDir, 'mcp.json'), mcpContent);
 
-      const result = await loadRulerConfiguration(
-        tmpDir,
-        undefined,
-        false,
-        false,
-      );
+      const result = await loadSingleConfiguration(tmpDir, undefined, false);
 
       // Since hierarchical=false, result should be RulerConfiguration
       expect(result).toHaveProperty('config');
@@ -116,12 +111,7 @@ describe('apply-engine', () => {
       const rulesContent = '# Test rules';
       await fs.writeFile(path.join(rulerDir, 'instructions.md'), rulesContent);
 
-      const result = await loadRulerConfiguration(
-        tmpDir,
-        undefined,
-        false,
-        false,
-      );
+      const result = await loadSingleConfiguration(tmpDir, undefined, false);
 
       // Since hierarchical=false, result should be RulerConfiguration
       expect(result).toHaveProperty('config');
@@ -137,16 +127,13 @@ describe('apply-engine', () => {
     it('should throw error when .ruler directory not found', async () => {
       const nonExistentDir = path.join(tmpDir, 'nonexistent');
 
-      // Mock the findRulerDir to return null to simulate directory not found
-      const originalFindRulerDir = FileSystemUtils.findRulerDir;
       jest.spyOn(FileSystemUtils, 'findRulerDir').mockResolvedValue(null);
 
       try {
         await expect(
-          loadRulerConfiguration(nonExistentDir, undefined, true),
+          loadSingleConfiguration(nonExistentDir, undefined, true),
         ).rejects.toThrow('.ruler directory not found');
       } finally {
-        // Restore the original function
         (FileSystemUtils.findRulerDir as jest.Mock).mockRestore();
       }
     });


### PR DESCRIPTION
## 🚀 **Nested Rule Loading: Context-Specific AI Instructions**

### **✨ Overview**

This PR introduces **nested rule loading** - a highly requested feature that enables context-specific AI coding instructions for complex project structures. With the new `--nested` flag, Ruler can now discover and process multiple `.ruler/` directories throughout your project hierarchy, allowing different components, services, or directories to have their own specialised AI guidelines.

### **🎯 Problem Solved**

Previously, Ruler could only manage a single `.ruler/` directory per project, making it challenging for:

- **Monorepos** with multiple services requiring different coding standards
- **Complex applications** with distinct frontend/backend requirements
- **Large teams** needing component-specific or directory-specific instructions

### **🔧 How It Works**

#### **Directory Structure Support**

```
project/
├── .ruler/           # Global project rules
│   ├── AGENTS.md
│   └── coding_style.md
├── src/
│   └── .ruler/       # Component-specific rules
│       └── api_guidelines.md
├── tests/
│   └── .ruler/       # Test-specific rules
│       └── testing_conventions.md
└── docs/
    └── .ruler/       # Documentation rules
        └── writing_style.md
```

#### **Rule Processing**

- **Discovery**: Automatically finds all `.ruler/` directories in the project hierarchy
- **Concatenation**: Loads and concatenates rules from each directory in order
- **Precedence**: Maintains the existing precedence order (root AGENTS.md → .ruler/AGENTS.md → other .md files)

### **📋 Usage Examples**

#### **Basic Usage**

```bash
# Enable nested rule loading
ruler apply --nested
```

```toml
# Enable from the root toml
nested = true
```

### **🛠️ Technical Implementation**

#### **Core Changes**

- **Enhanced `loadRulerConfiguration()`**: Added `hierarchical` parameter to support both single and nested modes
- **New `findAllRulerDirs()`**: Discovers all `.ruler/` directories in the project hierarchy
- **Hierarchical Processing**: Independent processing of each `.ruler/` directory with separate rule concatenation
- **Backward Compatibility**: Existing single-directory behavior preserved when `--nested` is not used

#### **CLI Integration**

- Added `--nested` flag to the `apply` command

### **🚫 Limitations**

- The nested is currently not supported for the `revert` command.