### PR TITLE
CI: use latest LTS Node version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,15 +9,12 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [18.x, 20.x]
     steps:
-      - uses: actions/checkout@v3
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - name: Setup Node.js (latest LTS)
+        uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: lts/*
           cache: 'npm'
       - run: npm ci
       - run: npm run lint


### PR DESCRIPTION
Update CI workflow to drop Node version matrix (18.x, 20.x) and rely on actions/setup-node with node-version: lts/* to always test against current active LTS. Also bump actions/checkout/setup-node to v4.