### PR TITLE
CI: weekly 'This Code Smells' discussion powered by GitHub Models

### DIFF
--- a/.github/workflows/this-code-smells.yml
+++ b/.github/workflows/this-code-smells.yml
@@ -1,0 +1,122 @@
+name: This Code Smells
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    # Hourly on Sundays (UTC); we gate to run only at 16:00 Europe/Zurich
+    - cron: "0 * * * 0"
+
+permissions:
+  contents: read
+  discussions: write
+
+env:
+  CODEX_HOME: ./.github/workflows/this-code-smells
+  TZ: Europe/Zurich
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Time gate (run only at 16:00 Europe/Zurich)
+        id: gate
+        if: ${{ github.event_name == 'schedule' }}
+        run: |
+          hour=$(TZ=Europe/Zurich date +%H)
+          if [ "$hour" = "16" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            echo "It's 16:00 Europe/Zurich; proceeding."
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "Not 16:00 Europe/Zurich; skipping subsequent steps."
+          fi
+
+      - uses: actions/checkout@v4
+        if: ${{ steps.gate.outputs.run != 'false' }}
+
+      - uses: actions/setup-node@v4
+        if: ${{ steps.gate.outputs.run != 'false' }}
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Verify GH_MODELS_TOKEN presence
+        if: ${{ steps.gate.outputs.run != 'false' }}
+        env:
+          GH_MODELS_TOKEN: ${{ secrets.GH_MODELS_TOKEN }}
+        run: |
+          if [ -z "$GH_MODELS_TOKEN" ]; then
+            echo "GH_MODELS_TOKEN is not set. Add a repo secret with scopes: models:read and models:generate."
+            exit 1
+          fi
+
+      - name: Install Codex CLI
+        if: ${{ steps.gate.outputs.run != 'false' }}
+        run: |
+          npm install -g @openai/codex
+          codex --version
+
+      - name: Run Codex analysis
+        if: ${{ steps.gate.outputs.run != 'false' }}
+        env:
+          # Map our secret for the configured provider's env_key
+          GH_MODELS_TOKEN: ${{ secrets.GH_MODELS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p "$RUNNER_TEMP"
+          # Run codex non-interactively with our prompt; quiet mode; read-only sandbox; never ask for approval
+          codex -q exec --sandbox read-only --ask-for-approval never < "$CODEX_HOME/prompt.md" > "$RUNNER_TEMP/report.md"
+          test -s "$RUNNER_TEMP/report.md" || (echo "Report not generated" && exit 1)
+
+      - name: Resolve Discussion category ID
+        if: ${{ steps.gate.outputs.run != 'false' }}
+        id: cat
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          owner="intellectronica"
+          repo="ruler"
+          gh api graphql -f query='
+            query($owner:String!,$repo:String!){
+              repository(owner:$owner,name:$repo){
+                discussionCategories(first:100){
+                  nodes{ id name }
+                }
+              }
+            }' -F owner="$owner" -F repo="$repo" > cat.json
+          cat_id=$(jq -r '.data.repository.discussionCategories.nodes[] | select(.name=="Workflow") | .id' cat.json)
+          if [ -z "$cat_id" ]; then echo "Workflow discussion category not found"; exit 1; fi
+          echo "id=$cat_id" >> "$GITHUB_OUTPUT"
+
+      - name: Create Discussion
+        if: ${{ steps.gate.outputs.run != 'false' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          owner="intellectronica"
+          repo="ruler"
+          repo_id=$(gh api "repos/$owner/$repo" --jq .node_id)
+          if [ -z "$repo_id" ]; then echo "Failed to get repository node_id"; exit 1; fi
+
+          title="This Codebase Smells! [$(TZ=Europe/Zurich date +%F)]"
+
+          # JSON-escape the report body safely
+          body_json=$(jq -Rs . < "$RUNNER_TEMP/report.md")
+
+          # Build GraphQL payload
+          jq -n --arg repoId "$repo_id" \
+                --arg catId "${{ steps.cat.outputs.id }}" \
+                --arg title "$title" \
+                --argjson body "$body_json" \
+                '{
+                   query: "mutation($repoId:ID!,$categoryId:ID!,$title:String!,$body:String!){ createDiscussion(input:{repositoryId:$repoId, categoryId:$categoryId, title:$title, body:$body}){ discussion{ url } } }",
+                   variables: { repoId: $repoId, categoryId: $catId, title: $title, body: $body }
+                 }' > payload.json
+
+          gh api graphql --input payload.json -q '.data.createDiscussion.discussion.url' | tee discussion_url.txt
+
+      - name: Show Discussion URL
+        if: ${{ steps.gate.outputs.run != 'false' }}
+        run: |
+          echo "Discussion created:"
+          cat discussion_url.txt

--- a/.github/workflows/this-code-smells/config.toml
+++ b/.github/workflows/this-code-smells/config.toml
@@ -1,0 +1,54 @@
+# Codex configuration for weekly repo review via GitHub Models
+
+# Select model and provider
+model = "gpt-5"
+model_provider = "github-models"
+
+# Reasoning settings for GPT-5 family (Responses API)
+model_reasoning_effort = "medium"   # minimal | low | medium | high
+model_verbosity = "medium"          # low | medium | high
+
+# Keep the CLI quiet and avoid storing history in CI
+hide_agent_reasoning = true
+
+[history]
+persistence = "none"
+
+# Custom provider for GitHub Models (OpenAI-compatible endpoint)
+[model_providers."github-models"]
+name = "GitHub Models"
+base_url = "https://models.inference.ai.azure.com"
+# Codex will read the token from this environment variable
+env_key = "GH_MODELS_TOKEN"
+# GPT‑5 on GitHub Models uses the Responses API
+wire_api = "responses"
+
+# Optional: network tuning (sane defaults already present in Codex)
+# request_max_retries = 4
+# stream_max_retries = 10
+# stream_idle_timeout_ms = 300000
+
+# File scanning preferences
+[paths]
+root = "."
+include = ["**/*"]
+exclude = [
+  ".git/**",
+  "node_modules/**",
+  "dist/**",
+  "build/**",
+  "coverage/**",
+  "target/**",
+  "vendor/**",
+  ".venv/**",
+  ".env",
+  ".cache/**",
+  "out/**",
+  ".next/**",
+  ".turbo/**",
+  ".yarn/**",
+  "yarn.lock",
+  "package-lock.json",
+  "pnpm-lock.yaml",
+  ".github/workflows/this-code-smells/*.md"
+]

--- a/.github/workflows/this-code-smells/prompt.md
+++ b/.github/workflows/this-code-smells/prompt.md
@@ -1,0 +1,33 @@
+# This Codebase Smells! A Weekly Report
+
+Produce a concise, constructive, and slightly cynical code review of this entire repository. Be witty, but keep it helpful and focused. No emojis.
+
+Goals:
+- Identify independent improvements that will improve quality, robustness, maintainability, performance, security, and developer experience.
+- Keep the writing tight and actionable.
+
+For each improvement, include:
+1. One-sentence summary.
+2. Explanation (1–2 short paragraphs).
+3. List of relevant files (relative paths).
+4. Quotes from relevant files with line ranges (keep each quote short). For each quote, also include the GitHub link as described below.
+5. Concrete suggestions: code-level steps or refactor outline.
+
+Output format:
+- One GitHub-Flavored Markdown document.
+- Start with a clear title and a Table of Contents.
+- Each improvement in its own section with an H2 header.
+- For any file references, include correct GitHub links to the main branch, anchored to the exact line ranges:
+  - https://github.com/intellectronica/ruler/blob/main/PATH/TO/FILE#LSTART-LEND
+- Prefer bullet points over long prose. If a file is generated or vendored, ignore it.
+- If you can't find enough issues, say so explicitly.
+
+Repository context and scope:
+- Assume working directory is the repository root.
+- Scan the entire codebase but ignore these directories/files:
+  - .git, node_modules, dist, build, coverage, target, vendor, .venv, .env, .cache, out, .next, .turbo, .yarn
+  - yarn.lock, package-lock.json, pnpm-lock.yaml
+  - .github/workflows/this-code-smells/*.md (this prompt and related docs)
+
+Tone:
+- Witty, slightly frustrated, but constructive and respectful. Aim for helpful, not snarky.


### PR DESCRIPTION
This adds a weekly workflow that runs a repository-wide code-review via GitHub Models and posts a Discussion.

What it does:
- Runs every Sunday (UTC hourly) but gates execution to exactly 16:00 Europe/Zurich.
- Allows manual runs via workflow_dispatch.
- Uses the Codex CLI (npm) to analyze the repo and generate a markdown report.
- Posts a GitHub Discussion in the "Workflow" category titled "This Codebase Smells! [YYYY-MM-DD]".

Scheduling and time-gating:
- GitHub Actions cron is UTC. We schedule hourly on Sundays ("0 * * * 0") then gate execution by checking local Zurich hour.
- Non-16:00 runs exit early and successfully; no work is performed.

Permissions:
- contents: read
- discussions: write

Secrets:
- GH_MODELS_TOKEN must be set (if GITHUB_TOKEN lacks model scopes). Recommended scopes: models:read, models:generate. The Actions job still uses GITHUB_TOKEN for GitHub Discussions.

Manual runs:
- Use "Run workflow" from the Actions tab. Manual dispatch bypasses the time gate.

Implementation notes:
- CODEX_HOME: .github/workflows/this-code-smells
- Node LTS 20.x for CLI.
- Repo ignores common large/generated directories during analysis.

Follow-ups after merge:
- Verify GH_MODELS_TOKEN secret is present and has the required scopes.
- Verify the "Workflow" discussion category exists (job will fail if missing).
