### PR TITLE
feat(cursor): add support for rule anatomy fields

### DIFF
--- a/src/agents/CursorAgent.ts
+++ b/src/agents/CursorAgent.ts
@@ -37,9 +37,8 @@ export class CursorAgent extends AbstractAgent {
       agentConfig?.outputPath ?? this.getDefaultOutputPath(projectRoot);
     const absolutePath = path.resolve(projectRoot, output);
 
-    // Extract Cursor-specific config
     const cursorConfig = agentConfig as CursorAgentConfig | undefined;
-    const alwaysApply = cursorConfig?.alwaysApply ?? true; // Default to true
+    const alwaysApply = cursorConfig?.alwaysApply ?? true;
     const description = cursorConfig?.description ?? '';
     const globs = cursorConfig?.globs ?? [];
 
@@ -47,12 +46,10 @@ export class CursorAgent extends AbstractAgent {
     // See: https://docs.cursor.com/context/rules#rule-anatomy
     const frontMatterLines = ['---'];
     
-    // Add description if provided
     if (description) {
       frontMatterLines.push(`description: ${description}`);
     }
     
-    // Add globs if provided
     if (globs.length > 0) {
       frontMatterLines.push('globs:');
     }

--- a/src/agents/CursorAgent.ts
+++ b/src/agents/CursorAgent.ts
@@ -1,6 +1,13 @@
 import * as path from 'path';
 import { AbstractAgent } from './AbstractAgent';
 import { IAgentConfig } from './IAgent';
+
+// Cursor-specific configuration extending the base config
+interface CursorAgentConfig extends IAgentConfig {
+  description?: string;
+  globs?: string[];
+  alwaysApply?: boolean;
+}
 import {
   backupFile,
   writeGeneratedFile,
@@ -30,9 +37,29 @@ export class CursorAgent extends AbstractAgent {
       agentConfig?.outputPath ?? this.getDefaultOutputPath(projectRoot);
     const absolutePath = path.resolve(projectRoot, output);
 
+    // Extract Cursor-specific config
+    const cursorConfig = agentConfig as CursorAgentConfig | undefined;
+    const alwaysApply = cursorConfig?.alwaysApply ?? true; // Default to true
+    const description = cursorConfig?.description ?? '';
+    const globs = cursorConfig?.globs ?? [];
+
     // Cursor expects a YAML front-matter block with an `alwaysApply` flag.
     // See: https://docs.cursor.com/context/rules#rule-anatomy
-    const frontMatter = ['---', 'alwaysApply: true', '---', ''].join('\n');
+    const frontMatterLines = ['---'];
+    
+    // Add description if provided
+    if (description) {
+      frontMatterLines.push(`description: ${description}`);
+    }
+    
+    // Add globs if provided
+    if (globs.length > 0) {
+      frontMatterLines.push('globs:');
+    }
+    
+    frontMatterLines.push(`alwaysApply: ${alwaysApply}`);
+    frontMatterLines.push('---', '');
+    const frontMatter = frontMatterLines.join('\n');
     const content = `${frontMatter}${concatenatedRules.trimStart()}`;
 
     await ensureDirExists(path.dirname(absolutePath));

--- a/src/core/ConfigLoader.ts
+++ b/src/core/ConfigLoader.ts
@@ -180,6 +180,18 @@ export async function loadConfig(
         }
         cfg.mcp = mcpCfg;
       }
+      // Handle Cursor-specific configuration
+      if (name === 'cursor') {
+        if (typeof sectionObj.always_apply === 'boolean') {
+          (cfg as any).alwaysApply = sectionObj.always_apply;
+        }
+        if (typeof sectionObj.description === 'string') {
+          (cfg as any).description = sectionObj.description;
+        }
+        if (Array.isArray(sectionObj.globs)) {
+          (cfg as any).globs = sectionObj.globs.filter(g => typeof g === 'string');
+        }
+      }
       agentConfigs[name] = cfg;
     }
   }


### PR DESCRIPTION
This PR allows you to specify 

```toml
[agents.cursor]
description = "RPC Service boilerplate"
globs = ["*.tsx", "*.rs"]
always_apply = false
```

which translates to 

```yaml
---
description: RPC Service boilerplate
globs: *.tsx, *.rs
alwaysApply: false
---
```

I added this because I usually want the setting of the cursor rule to be intelligent AI search vs "alwaysApply: true"