### PR TITLE
Propagate nested configurations to descendants

### DIFF
--- a/src/core/ConfigLoader.ts
+++ b/src/core/ConfigLoader.ts
@@ -72,6 +72,8 @@ export interface LoadedConfig {
   gitignore?: GitignoreConfig;
   /** Whether to enable nested rule loading from nested .ruler directories. */
   nested?: boolean;
+  /** Whether the nested option was explicitly provided in the config. */
+  nestedDefined?: boolean;
 }
 
 /**
@@ -210,7 +212,8 @@ export async function loadConfig(
     gitignoreConfig.enabled = rawGitignoreSection.enabled;
   }
 
-  const nested = typeof raw.nested === 'boolean' ? raw.nested : false;
+  const nestedDefined = typeof raw.nested === 'boolean';
+  const nested = nestedDefined ? (raw.nested as boolean) : false;
 
   return {
     defaultAgents,
@@ -219,5 +222,6 @@ export async function loadConfig(
     mcp: globalMcpConfig,
     gitignore: gitignoreConfig,
     nested,
+    nestedDefined,
   };
 }


### PR DESCRIPTION
## Summary
- ensure nested configuration loading builds isolated configs per .ruler directory and forces nested mode while warning on conflicting local flags
- track whether nested was explicitly defined in the config loader and use the shallowest .ruler directory for agent selection
- extend unit and integration coverage to validate nested propagation, configuration isolation, and warning behavior

## Testing
- `npm test -- --runTestsByPath tests/unit/core/apply-engine.test.ts`
- `npm test -- --runTestsByPath tests/integration/hierarchical-rules.test.ts`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68f20ff5f558832e82c008d9fecb09f9