### PR TITLE
Warn about experimental nested mode

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import { IAgent, IAgentConfig } from './agents/IAgent';
 import { allAgents } from './agents';
 import { McpStrategy } from './types';
-import { logVerbose } from './constants';
+import { logVerbose, logWarn } from './constants';
 import {
   loadSingleConfiguration,
   processHierarchicalConfigurations,
@@ -65,6 +65,11 @@ export async function applyAllAgentConfigs(
     if (hierarchicalConfigs.length === 0) {
       throw new Error('No .ruler directories found');
     }
+
+    logWarn(
+      'Nested mode is experimental and may change in future releases.',
+      dryRun,
+    );
 
     // Use the root config for agent selection (all levels share the same agent settings)
     const rootConfigEntry = selectRootConfiguration(

--- a/tests/integration/hierarchical-rules.test.ts
+++ b/tests/integration/hierarchical-rules.test.ts
@@ -80,6 +80,8 @@ enabled = true
       .spyOn(Constants, 'logWarn')
       .mockImplementation(() => {});
 
+    const experimentalWarningMessage = 'Nested mode is experimental';
+
     try {
       await applyAllAgentConfigs(
         testProject.projectRoot, // Start from project root
@@ -94,6 +96,11 @@ enabled = true
         true, // nested
       );
 
+      const experimentalWarnings = warnSpy.mock.calls.filter((call) =>
+        String(call[0]).includes(experimentalWarningMessage),
+      );
+
+      expect(experimentalWarnings).toHaveLength(1);
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining(
           path.join(submoduleDir, '.ruler', 'ruler.toml'),
@@ -166,18 +173,32 @@ enabled = true
     );
 
     // Apply without nested flag (should use single-directory logic)
-    await applyAllAgentConfigs(
-      moduleDir,
-      ['claude'],
-      undefined,
-      true,
-      undefined,
-      undefined,
-      false,
-      false,
-      false,
-      false, // nested = false
-    );
+    const warnSpy = jest
+      .spyOn(Constants, 'logWarn')
+      .mockImplementation(() => {});
+
+    try {
+      await applyAllAgentConfigs(
+        moduleDir,
+        ['claude'],
+        undefined,
+        true,
+        undefined,
+        undefined,
+        false,
+        false,
+        false,
+        false, // nested = false
+      );
+
+      const experimentalWarnings = warnSpy.mock.calls.filter((call) =>
+        String(call[0]).includes('Nested mode is experimental'),
+      );
+
+      expect(experimentalWarnings).toHaveLength(0);
+    } finally {
+      warnSpy.mockRestore();
+    }
 
     // Should work without errors (testing that single-directory logic still works)
     expect(true).toBe(true); // If we get here, the test passed


### PR DESCRIPTION
## Summary
- emit a warning that nested mode is experimental when hierarchical configs are loaded
- extend hierarchical integration tests to cover the new warning and ensure single-directory runs stay quiet

## Testing
- npm test -- integration/hierarchical-rules.test.ts
- npm test -- unit/core/apply-engine.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68f21552be94832eb6ab9a0a638734ae