### PR TITLE
feat(kiro): add MCP support for Kiro agent

### DIFF
--- a/src/agents/KiroAgent.ts
+++ b/src/agents/KiroAgent.ts
@@ -18,4 +18,12 @@ export class KiroAgent extends AbstractAgent {
       'ruler_kiro_instructions.md',
     );
   }
+
+  supportsMcpStdio(): boolean {
+    return true;
+  }
+
+  supportsMcpRemote(): boolean {
+    return true;
+  }
 }

--- a/src/paths/mcp.ts
+++ b/src/paths/mcp.ts
@@ -43,6 +43,9 @@ export async function getNativeMcpPath(
     case 'Kilo Code':
       candidates.push(path.join(projectRoot, '.kilocode', 'mcp.json'));
       break;
+    case 'Kiro':
+      candidates.push(path.join(projectRoot, '.kiro', 'settings', 'mcp.json'));
+      break;
     case 'OpenCode':
       candidates.push(path.join(projectRoot, 'opencode.json'));
       break;

--- a/tests/unit/agents/KiroAgent.test.ts
+++ b/tests/unit/agents/KiroAgent.test.ts
@@ -1,37 +1,68 @@
+import { promises as fs } from 'fs';
+import * as path from 'path';
 import { KiroAgent } from '../../../src/agents/KiroAgent';
-import * as FileSystemUtils from '../../../src/core/FileSystemUtils';
-
-jest.mock('../../../src/core/FileSystemUtils');
+import { AbstractAgent } from '../../../src/agents/AbstractAgent';
+import { setupTestProject, teardownTestProject } from '../../harness';
 
 describe('KiroAgent', () => {
-    let agent: KiroAgent;
+  it('should be defined', () => {
+    expect(new KiroAgent()).toBeDefined();
+  });
 
-    beforeEach(() => {
-        agent = new KiroAgent();
-        jest.clearAllMocks();
-    });
+  it('should extend AbstractAgent', () => {
+    const agent = new KiroAgent();
+    expect(agent instanceof AbstractAgent).toBe(true);
+  });
 
-    it('should return the correct identifier', () => {
-        expect(agent.getIdentifier()).toBe('kiro');
-    });
+  it('should have the correct identifier', () => {
+    const agent = new KiroAgent();
+    expect(agent.getIdentifier()).toBe('kiro');
+  });
 
-    it('should return the correct name', () => {
-        expect(agent.getName()).toBe('Kiro');
-    });
+  it('should have the correct name', () => {
+    const agent = new KiroAgent();
+    expect(agent.getName()).toBe('Kiro');
+  });
 
-    it('should return correct default output path', () => {
-        expect(agent.getDefaultOutputPath('/root')).toBe('/root/.kiro/steering/ruler_kiro_instructions.md');
-    });
+  it('should support MCP stdio', () => {
+    const agent = new KiroAgent();
+    expect(agent.supportsMcpStdio()).toBe(true);
+  });
 
-    it('should apply ruler config to the default output path', async () => {
-        const writeGeneratedFile = jest.spyOn(FileSystemUtils, 'writeGeneratedFile');
-        await agent.applyRulerConfig('rules', '/root', null);
-        expect(writeGeneratedFile).toHaveBeenCalledWith('/root/.kiro/steering/ruler_kiro_instructions.md', 'rules');
-    });
+  it('should support MCP remote', () => {
+    const agent = new KiroAgent();
+    expect(agent.supportsMcpRemote()).toBe(true);
+  });
 
-    it('should apply ruler config to a custom output path', async () => {
-        const writeGeneratedFile = jest.spyOn(FileSystemUtils, 'writeGeneratedFile');
-        await agent.applyRulerConfig('rules', '/root', null, { outputPath: 'CUSTOM.md' });
-        expect(writeGeneratedFile).toHaveBeenCalledWith('/root/CUSTOM.md', 'rules');
+  it('should have the correct default output path', () => {
+    const agent = new KiroAgent();
+    const projectRoot = '/test/project';
+    expect(agent.getDefaultOutputPath(projectRoot)).toBe(
+      path.join(projectRoot, '.kiro', 'steering', 'ruler_kiro_instructions.md'),
+    );
+  });
+
+  it('writes rules to .kiro/steering/ruler_kiro_instructions.md file', async () => {
+    const { projectRoot } = await setupTestProject({
+      '.ruler/AGENTS.md': 'Rule A',
     });
+    try {
+      const agent = new KiroAgent();
+      const rules = 'Combined rules\n- Rule A';
+
+      await agent.applyRulerConfig(rules, projectRoot, null);
+
+      // ruler_kiro_instructions.md should be written at .kiro/steering/
+      const kiroInstructionsPath = path.join(
+        projectRoot,
+        '.kiro',
+        'steering',
+        'ruler_kiro_instructions.md',
+      );
+      const content = await fs.readFile(kiroInstructionsPath, 'utf8');
+      expect(content).toContain('Rule A');
+    } finally {
+      await teardownTestProject(projectRoot);
+    }
+  });
 });

--- a/tests/unit/paths/mcp-paths.test.ts
+++ b/tests/unit/paths/mcp-paths.test.ts
@@ -40,6 +40,7 @@ describe('MCP Path Resolution', () => {
         'Gemini CLI',
         'Qwen Code',
         'Kilo Code',
+        'Kiro',
         'OpenCode',
         'Zed',
         'Firebase Studio'
@@ -97,6 +98,11 @@ describe('MCP Path Resolution', () => {
       it('Firebase Studio should use project-local path', async () => {
         const mcpPath = await getNativeMcpPath('Firebase Studio', projectRoot);
         expect(mcpPath).toBe(path.join(projectRoot, '.idx', 'mcp.json'));
+      });
+
+      it('Kiro should use project-local path', async () => {
+        const mcpPath = await getNativeMcpPath('Kiro', projectRoot);
+        expect(mcpPath).toBe(path.join(projectRoot, '.kiro', 'settings', 'mcp.json'));
       });
     });
   });


### PR DESCRIPTION
Add Model Context Protocol (MCP) support to the Kiro agent adapter, enabling Ruler to manage MCP server configurations for Kiro users.

This implementation allows users to centralize their MCP server definitions in `.ruler/mcp.json` and have Ruler automatically propagate them to Kiro's configuration format at
`.kiro/settings/mcp.json`.

Changes:
- Enable STDIO and remote MCP server support in KiroAgent
- Add Kiro MCP path resolution to `.kiro/settings/mcp.json`
- Add comprehensive unit tests for KiroAgent MCP capabilities
- Update MCP path tests to include Kiro configuration

References:
- Kiro MCP Configuration: https://kiro.dev/docs/mcp/configuration/