### PR TITLE
Global hooks config + Pi agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Ruler solves this by providing a **single source of truth** for all your AI agen
 - **Automatic Distribution**: Ruler applies these rules to configuration files of supported AI agents
 - **Targeted Agent Configuration**: Fine-tune which agents are affected and their specific output paths via `ruler.toml`
 - **MCP Server Propagation**: Manage and distribute Model Context Protocol (MCP) server settings
+- **Hooks Propagation**: Manage and distribute hook definitions for agents that support hooks (Claude Code, Gemini CLI, Windsurf)
 - **`.gitignore` Automation**: Keeps generated agent config files out of version control automatically
 - **Simple CLI**: Easy-to-use commands for initialising and applying configurations
 
@@ -58,11 +59,11 @@ Ruler solves this by providing a **single source of truth** for all your AI agen
 | ---------------- | ------------------------------------------------ | ------------------------------------------------ |
 | AGENTS.md        | `AGENTS.md`                                      | (pseudo-agent ensuring root `AGENTS.md` exists)  |
 | GitHub Copilot   | `AGENTS.md`                                      | `.vscode/mcp.json`                               |
-| Claude Code      | `CLAUDE.md`                                      | `.mcp.json`                                      |
+| Claude Code      | `CLAUDE.md`                                      | `.mcp.json`; hooks: `.claude/settings.json`      |
 | OpenAI Codex CLI | `AGENTS.md`                                      | `.codex/config.toml`                             |
 | Jules            | `AGENTS.md`                                      | -                                                |
 | Cursor           | `AGENTS.md`                                      | `.cursor/mcp.json`                               |
-| Windsurf         | `AGENTS.md`                                      | `.windsurf/mcp_config.json`                      |
+| Windsurf         | `AGENTS.md`                                      | `.windsurf/mcp_config.json`; hooks: `.windsurf/hooks.json` |
 | Cline            | `.clinerules`                                    | -                                                |
 | Crush            | `CRUSH.md`                                       | `.crush.json`                                    |
 | Amp              | `AGENTS.md`                                      | -                                                |
@@ -71,7 +72,7 @@ Ruler solves this by providing a **single source of truth** for all your AI agen
 | Aider            | `AGENTS.md`, `.aider.conf.yml`                   | `.mcp.json`                                      |
 | Firebase Studio  | `.idx/airules.md`                                | `.idx/mcp.json`                                  |
 | Open Hands       | `.openhands/microagents/repo.md`                 | `config.toml`                                    |
-| Gemini CLI       | `AGENTS.md`                                      | `.gemini/settings.json`                          |
+| Gemini CLI       | `AGENTS.md`                                      | `.gemini/settings.json` (MCP + hooks)            |
 | Junie            | `.junie/guidelines.md`                           | -                                                |
 | AugmentCode      | `.augment/rules/ruler_augment_instructions.md`   | -                                                |
 | Kilo Code        | `.kilocode/rules/ruler_kilocode_instructions.md` | `.kilocode/mcp.json`                             |
@@ -453,6 +454,43 @@ output_path = ".kilocode/rules/ruler_kilocode_instructions.md"
 [agents.warp]
 enabled = true
 output_path = "WARP.md"
+```
+
+### Hooks Configuration (Agent-Specific)
+
+Hooks are configured per agent using the `[agents.<agent>.hooks]` section.
+Provide a JSON source file containing either a top-level `hooks` object or the hooks object directly.
+
+```toml
+[agents.claude.hooks]
+enabled = true
+merge_strategy = "merge"
+source = ".ruler/hooks/claude.json"
+
+[agents.gemini-cli.hooks]
+enabled = true
+merge_strategy = "merge"
+source = ".ruler/hooks/gemini.json"
+
+[agents.windsurf.hooks]
+enabled = true
+merge_strategy = "overwrite"
+source = ".ruler/hooks/windsurf.json"
+```
+
+Example hook file:
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "bash",
+        "hooks": [{ "type": "command", "command": "echo hook" }]
+      }
+    ]
+  }
+}
 ```
 
 ### Configuration Precedence

--- a/src/agents/IAgent.ts
+++ b/src/agents/IAgent.ts
@@ -1,7 +1,7 @@
 /**
  * Interface defining an AI agent configuration adapter.
  */
-import { McpConfig } from '../types';
+import { HooksConfig, McpConfig } from '../types';
 /**
  * Configuration overrides for a specific agent.
  */
@@ -16,6 +16,8 @@ export interface IAgentConfig {
   outputPathConfig?: string;
   /** MCP propagation config for this agent. */
   mcp?: McpConfig;
+  /** Hooks propagation config for this agent. */
+  hooks?: HooksConfig;
 }
 
 export interface IAgent {

--- a/src/agents/PiAgent.ts
+++ b/src/agents/PiAgent.ts
@@ -1,0 +1,18 @@
+import { AgentsMdAgent } from './AgentsMdAgent';
+
+/**
+ * Pi coding agent adapter.
+ */
+export class PiAgent extends AgentsMdAgent {
+  getIdentifier(): string {
+    return 'pi';
+  }
+
+  getName(): string {
+    return 'Pi Coding Agent';
+  }
+
+  supportsNativeSkills(): boolean {
+    return true;
+  }
+}

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -29,6 +29,7 @@ import { AmazonQCliAgent } from './AmazonQCliAgent';
 import { FirebenderAgent } from './FirebenderAgent';
 import { AntigravityAgent } from './AntigravityAgent';
 import { MistralVibeAgent } from './MistralVibeAgent';
+import { PiAgent } from './PiAgent';
 
 export { AbstractAgent };
 
@@ -62,6 +63,7 @@ export const allAgents: IAgent[] = [
   new FirebenderAgent(),
   new AntigravityAgent(),
   new MistralVibeAgent(),
+  new PiAgent(),
 ];
 
 /**

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -77,6 +77,11 @@ export function run(): void {
             type: 'boolean',
             description:
               'Enable/disable skills support (experimental, default: enabled)',
+          })
+          .option('hooks', {
+            type: 'boolean',
+            description:
+              'Enable/disable hooks support (default: enabled when hooks source exists)',
           });
       },
       applyHandler,

--- a/src/cli/handlers.ts
+++ b/src/cli/handlers.ts
@@ -180,6 +180,13 @@ export async function initHandler(argv: InitArgs): Promise<void> {
 # [agents.gemini-cli]
 # enabled = true
 
+# --- Hooks (Agent-Specific) ---
+# Hooks are configured per agent via [agents.<agent>.hooks]
+# [agents.claude.hooks]
+# enabled = true
+# merge_strategy = "merge"
+# source = ".ruler/hooks/claude.json"
+
 # --- MCP Servers ---
 # Define Model Context Protocol servers here. Two examples:
 # 1. A stdio server (local executable)

--- a/src/cli/handlers.ts
+++ b/src/cli/handlers.ts
@@ -20,6 +20,7 @@ export interface ApplyArgs {
   nested?: boolean;
   backup: boolean;
   skills?: boolean;
+  hooks?: boolean;
 }
 
 export interface InitArgs {
@@ -105,6 +106,14 @@ export async function applyHandler(argv: ApplyArgs): Promise<void> {
     skillsEnabled = undefined; // Let config/default decide
   }
 
+  // Determine hooks preference: CLI > TOML > Default (enabled)
+  let hooksEnabled: boolean | undefined;
+  if (argv.hooks !== undefined) {
+    hooksEnabled = argv.hooks;
+  } else {
+    hooksEnabled = undefined; // Let config/default decide
+  }
+
   try {
     await applyAllAgentConfigs(
       projectRoot,
@@ -119,6 +128,7 @@ export async function applyHandler(argv: ApplyArgs): Promise<void> {
       nested,
       backup,
       skillsEnabled,
+      hooksEnabled,
     );
     console.log('Ruler apply completed successfully.');
   } catch (err: unknown) {
@@ -180,12 +190,14 @@ export async function initHandler(argv: InitArgs): Promise<void> {
 # [agents.gemini-cli]
 # enabled = true
 
-# --- Hooks (Agent-Specific) ---
-# Hooks are configured per agent via [agents.<agent>.hooks]
-# [agents.claude.hooks]
+# --- Hooks (Global + Agent Overrides) ---
+# [hooks]
 # enabled = true
 # merge_strategy = "merge"
-# source = ".ruler/hooks/claude.json"
+# source = ".ruler/hooks.json"
+#
+# [agents.claude.hooks]
+# merge_strategy = "overwrite"
 
 # --- MCP Servers ---
 # Define Model Context Protocol servers here. Two examples:

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -60,6 +60,7 @@ export const CODEX_SKILLS_PATH = '.codex/skills';
 export const OPENCODE_SKILLS_PATH = '.opencode/skill';
 export const GOOSE_SKILLS_PATH = '.agents/skills';
 export const VIBE_SKILLS_PATH = '.vibe/skills';
+export const PI_SKILLS_PATH = '.pi/skills';
 export const SKILLZ_DIR = '.skillz';
 export const SKILL_MD_FILENAME = 'SKILL.md';
 export const SKILLZ_MCP_SERVER_NAME = 'skillz';

--- a/src/core/UnifiedConfigLoader.ts
+++ b/src/core/UnifiedConfigLoader.ts
@@ -14,6 +14,7 @@ import {
   RuleFile,
   McpServerDef,
 } from './UnifiedConfigTypes';
+import { GlobalHooksConfig } from '../types';
 
 export interface UnifiedLoadOptions {
   projectRoot: string;
@@ -94,6 +95,28 @@ export async function loadUnifiedConfig(
     }
   }
 
+  // Parse hooks configuration
+  let hooksConfig: GlobalHooksConfig | undefined;
+  if (tomlRaw && typeof tomlRaw === 'object') {
+    const hooksSection = (tomlRaw as Record<string, unknown>).hooks;
+    if (hooksSection && typeof hooksSection === 'object') {
+      const hooksObj = hooksSection as Record<string, unknown>;
+      hooksConfig = {};
+      if (typeof hooksObj.enabled === 'boolean') {
+        hooksConfig.enabled = hooksObj.enabled;
+      }
+      if (typeof hooksObj.merge_strategy === 'string') {
+        const strat = hooksObj.merge_strategy;
+        if (strat === 'merge' || strat === 'overwrite') {
+          hooksConfig.strategy = strat;
+        }
+      }
+      if (typeof hooksObj.source === 'string') {
+        hooksConfig.source = hooksObj.source;
+      }
+    }
+  }
+
   const toml: TomlConfig = {
     raw: tomlRaw,
     schemaVersion: 1,
@@ -101,6 +124,7 @@ export async function loadUnifiedConfig(
     defaultAgents,
     nested,
     skills: skillsConfig,
+    hooks: hooksConfig,
   };
 
   // Collect rule markdown files

--- a/src/core/UnifiedConfigTypes.ts
+++ b/src/core/UnifiedConfigTypes.ts
@@ -3,6 +3,7 @@ import {
   GitignoreConfig,
   SkillsConfig,
   McpStrategy,
+  GlobalHooksConfig,
 } from '../types';
 
 export interface RulerUnifiedConfig {
@@ -29,6 +30,7 @@ export interface TomlConfig {
   schemaVersion: number;
   defaultAgents?: string[];
   agents: Record<string, AgentTomlConfig>;
+  hooks?: GlobalHooksConfig;
   mcp?: McpToggleConfig;
   mcpServers?: Record<string, McpServerDef>;
   gitignore?: GitignoreConfig;

--- a/src/core/revert-engine.ts
+++ b/src/core/revert-engine.ts
@@ -514,7 +514,9 @@ export async function revertAgentConfiguration(
   }
 
   // Handle hooks files
-  const hooksPath = await getNativeHooksPath(agent.getName(), projectRoot);
+  const hooksPath =
+    agentConfig?.hooks?.outputPath ??
+    (await getNativeHooksPath(agent.getName(), projectRoot));
   if (hooksPath && hooksPath.startsWith(projectRoot)) {
     if (hooksPath === mcpPath) {
       logVerbose(

--- a/src/paths/hooks.ts
+++ b/src/paths/hooks.ts
@@ -1,0 +1,41 @@
+import * as path from 'path';
+import { promises as fs } from 'fs';
+
+/** Determine the native hooks config path for a given agent. */
+export async function getNativeHooksPath(
+  adapterName: string,
+  projectRoot: string,
+): Promise<string | null> {
+  switch (adapterName) {
+    case 'Claude Code':
+      return path.join(projectRoot, '.claude', 'settings.json');
+    case 'Gemini CLI':
+      return path.join(projectRoot, '.gemini', 'settings.json');
+    case 'Windsurf':
+      return path.join(projectRoot, '.windsurf', 'hooks.json');
+    default:
+      return null;
+  }
+}
+
+/** Read native hooks config from disk, or return empty object if missing/invalid. */
+export async function readNativeHooks(
+  filePath: string,
+): Promise<Record<string, unknown>> {
+  try {
+    const text = await fs.readFile(filePath, 'utf8');
+    return JSON.parse(text) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+/** Write native hooks config to disk, creating parent directories as needed. */
+export async function writeNativeHooks(
+  filePath: string,
+  data: unknown,
+): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  const text = JSON.stringify(data, null, 2) + '\n';
+  await fs.writeFile(filePath, text, 'utf8');
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@
  * Types for Model Context Protocol (MCP) server configuration.
  */
 export type McpStrategy = 'merge' | 'overwrite';
+export type HooksStrategy = 'merge' | 'overwrite';
 
 /** MCP configuration for an agent or global. */
 export interface McpConfig {
@@ -9,6 +10,18 @@ export interface McpConfig {
   enabled?: boolean;
   /** Merge strategy: 'merge' to merge servers, 'overwrite' to replace config. */
   strategy?: McpStrategy;
+}
+
+/** Hooks configuration for an agent. */
+export interface HooksConfig {
+  /** Enable or disable hook propagation. */
+  enabled?: boolean;
+  /** Merge strategy: 'merge' to append hooks, 'overwrite' to replace hooks. */
+  strategy?: HooksStrategy;
+  /** Path to the hooks source JSON file. */
+  source?: string;
+  /** Override for the agent hooks output path. */
+  outputPath?: string;
 }
 
 /** Global MCP configuration section (same as agent-specific config). */

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,16 @@ export interface HooksConfig {
   outputPath?: string;
 }
 
+/** Global hooks configuration section. */
+export interface GlobalHooksConfig {
+  /** Enable or disable hook propagation. */
+  enabled?: boolean;
+  /** Merge strategy: 'merge' to append hooks, 'overwrite' to replace hooks. */
+  strategy?: HooksStrategy;
+  /** Path to the hooks source JSON file. */
+  source?: string;
+}
+
 /** Global MCP configuration section (same as agent-specific config). */
 export type GlobalMcpConfig = McpConfig;
 

--- a/tests/claude-hooks.test.ts
+++ b/tests/claude-hooks.test.ts
@@ -1,0 +1,146 @@
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { applyAllAgentConfigs } from '../src/lib';
+import { setupTestProject, teardownTestProject } from './harness';
+
+describe('Claude hooks support', () => {
+  let projectRoot: string | undefined;
+
+  afterEach(async () => {
+    if (projectRoot) {
+      await teardownTestProject(projectRoot);
+    }
+  });
+
+  it('merges hooks into .claude/settings.json', async () => {
+    const { projectRoot: root } = await setupTestProject({
+      '.ruler/AGENTS.md': '# Rules',
+      '.ruler/ruler.toml': `
+[agents.claude.hooks]
+enabled = true
+merge_strategy = "merge"
+source = ".ruler/hooks/claude.json"
+`,
+      '.ruler/hooks/claude.json': JSON.stringify(
+        {
+          hooks: {
+            PostToolUse: [
+              {
+                matcher: 'bash',
+                hooks: [{ type: 'command', command: 'echo new' }],
+              },
+            ],
+            Stop: [{ hooks: [{ type: 'command', command: 'echo stop' }] }],
+          },
+        },
+        null,
+        2,
+      ),
+      '.claude/settings.json': JSON.stringify(
+        {
+          theme: 'dark',
+          hooks: {
+            PostToolUse: [
+              {
+                matcher: 'bash',
+                hooks: [{ type: 'command', command: 'echo existing' }],
+              },
+            ],
+          },
+        },
+        null,
+        2,
+      ),
+    });
+
+    projectRoot = root;
+
+    await applyAllAgentConfigs(
+      projectRoot,
+      ['claude'],
+      undefined,
+      true,
+      undefined,
+      undefined,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+    );
+
+    const settingsPath = path.join(projectRoot, '.claude', 'settings.json');
+    const settings = JSON.parse(await fs.readFile(settingsPath, 'utf8'));
+
+    expect(settings.theme).toBe('dark');
+    expect(settings.hooks.PostToolUse).toHaveLength(2);
+    expect(settings.hooks.Stop).toHaveLength(1);
+  });
+
+  it('overwrites hooks when merge_strategy is overwrite', async () => {
+    const { projectRoot: root } = await setupTestProject({
+      '.ruler/AGENTS.md': '# Rules',
+      '.ruler/ruler.toml': `
+[agents.claude.hooks]
+enabled = true
+merge_strategy = "overwrite"
+source = ".ruler/hooks/claude.json"
+`,
+      '.ruler/hooks/claude.json': JSON.stringify(
+        {
+          hooks: {
+            PostToolUse: [
+              {
+                matcher: 'bash',
+                hooks: [{ type: 'command', command: 'echo new' }],
+              },
+            ],
+          },
+        },
+        null,
+        2,
+      ),
+      '.claude/settings.json': JSON.stringify(
+        {
+          theme: 'light',
+          hooks: {
+            PostToolUse: [
+              {
+                matcher: 'bash',
+                hooks: [{ type: 'command', command: 'echo old' }],
+              },
+            ],
+            Stop: [{ hooks: [{ type: 'command', command: 'echo stop' }] }],
+          },
+        },
+        null,
+        2,
+      ),
+    });
+
+    projectRoot = root;
+
+    await applyAllAgentConfigs(
+      projectRoot,
+      ['claude'],
+      undefined,
+      true,
+      undefined,
+      undefined,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+    );
+
+    const settingsPath = path.join(projectRoot, '.claude', 'settings.json');
+    const settings = JSON.parse(await fs.readFile(settingsPath, 'utf8'));
+
+    expect(settings.theme).toBe('light');
+    expect(settings.hooks.PostToolUse).toHaveLength(1);
+    expect(settings.hooks.Stop).toBeUndefined();
+  });
+});

--- a/tests/integration/skills-mcp-agent-integration.test.ts
+++ b/tests/integration/skills-mcp-agent-integration.test.ts
@@ -127,6 +127,37 @@ describe('Skills MCP Agent Integration', () => {
       expect(skillContent).toBe('# Test Skill');
     });
 
+    it('adds skills to .pi/skills for Pi Coding Agent (native skills)', async () => {
+      await applyAllAgentConfigs(
+        tmpDir,
+        ['pi'],
+        undefined,
+        true,
+        undefined,
+        undefined,
+        false,
+        false,
+        false,
+        false,
+        true,
+        true, // skills enabled
+      );
+
+      // Check that .pi/skills exists and contains the test skill
+      const piSkillsPath = path.join(tmpDir, '.pi', 'skills');
+      const testSkillPath = path.join(piSkillsPath, 'test-skill');
+      const skillMdPath = path.join(testSkillPath, SKILL_MD_FILENAME);
+
+      // Verify the skill directory and file exist
+      await expect(fs.access(piSkillsPath)).resolves.toBeUndefined();
+      await expect(fs.access(testSkillPath)).resolves.toBeUndefined();
+      await expect(fs.access(skillMdPath)).resolves.toBeUndefined();
+
+      // Verify skill content was copied
+      const skillContent = await fs.readFile(skillMdPath, 'utf8');
+      expect(skillContent).toBe('# Test Skill');
+    });
+
     it('does not add Skillz server when skills are disabled', async () => {
       await applyAllAgentConfigs(
         tmpDir,

--- a/tests/unit/agents/DynamicCliHelp.test.ts
+++ b/tests/unit/agents/DynamicCliHelp.test.ts
@@ -43,7 +43,18 @@ describe('Dynamic CLI Help Agent List', () => {
     const result = getAgentIdentifiersForCliHelp();
     
     // These agents were missing from the hardcoded list but should be included
-    const newAgents = ['amazonqcli', 'kiro', 'warp', 'roo', 'augmentcode', 'jules', 'junie', 'goose', 'openhands'];
+    const newAgents = [
+      'amazonqcli',
+      'kiro',
+      'warp',
+      'roo',
+      'augmentcode',
+      'jules',
+      'junie',
+      'goose',
+      'openhands',
+      'pi',
+    ];
     
     for (const agent of newAgents) {
       expect(result).toContain(agent);

--- a/tests/unit/cli/handlers.test.ts
+++ b/tests/unit/cli/handlers.test.ts
@@ -64,7 +64,9 @@ describe('CLI Handlers', () => {
         false,
         false,
         false,
-        true, undefined,
+        true,
+        undefined,
+        undefined,
       );
     });
 
@@ -93,7 +95,9 @@ describe('CLI Handlers', () => {
         false,
         false,
         false,
-        true, undefined,
+        true,
+        undefined,
+        undefined,
       );
     });
 
@@ -123,7 +127,9 @@ describe('CLI Handlers', () => {
         false,
         false,
         false,
-        true, undefined,
+        true,
+        undefined,
+        undefined,
       );
     });
 
@@ -152,7 +158,9 @@ describe('CLI Handlers', () => {
         false,
         false,
         false,
-        true, undefined,
+        true,
+        undefined,
+        undefined,
       );
     });
 
@@ -181,7 +189,9 @@ describe('CLI Handlers', () => {
         false,
         false,
         true, // nested should be true from CLI
-        true, undefined,
+        true,
+        undefined,
+        undefined,
       );
       // loadConfig should not be called when CLI explicitly sets nested
       expect(loadConfig).not.toHaveBeenCalled();
@@ -225,7 +235,9 @@ describe('CLI Handlers', () => {
         false,
         false,
         true, // nested should be true from TOML
-        true, undefined,
+        true,
+        undefined,
+        undefined,
       );
     });
 
@@ -263,7 +275,9 @@ describe('CLI Handlers', () => {
         false,
         false,
         false, // nested should default to false
-        true, undefined,
+        true,
+        undefined,
+        undefined,
       );
     });
 
@@ -303,7 +317,9 @@ describe('CLI Handlers', () => {
         false,
         false,
         true, // nested should be true from CLI, ignoring TOML
-        true, undefined,
+        true,
+        undefined,
+        undefined,
       );
     });
 

--- a/tests/unit/core/ConfigLoader.test.ts
+++ b/tests/unit/core/ConfigLoader.test.ts
@@ -174,4 +174,44 @@ describe('ConfigLoader', () => {
       expect(config.gitignore?.enabled).toBeUndefined();
     });
   });
+
+  describe('hooks configuration', () => {
+    it('parses [hooks] section with enabled and source', async () => {
+      const content = `
+        [hooks]
+        enabled = true
+        merge_strategy = "overwrite"
+        source = ".ruler/hooks.json"
+      `;
+      await fs.writeFile(path.join(rulerDir, 'ruler.toml'), content);
+      const config = await loadConfig({ projectRoot: tmpDir });
+      expect(config.hooks).toBeDefined();
+      expect(config.hooks?.enabled).toBe(true);
+      expect(config.hooks?.strategy).toBe('overwrite');
+      expect(config.hooks?.source).toBe(
+        path.resolve(tmpDir, '.ruler/hooks.json'),
+      );
+    });
+
+    it('parses agent hooks configuration', async () => {
+      const content = `
+        [agents.A.hooks]
+        enabled = true
+        merge_strategy = "merge"
+        source = "hooks/agent.json"
+        output_path = ".claude/settings.json"
+      `;
+      await fs.writeFile(path.join(rulerDir, 'ruler.toml'), content);
+      const config = await loadConfig({ projectRoot: tmpDir });
+      expect(config.agentConfigs.A.hooks).toBeDefined();
+      expect(config.agentConfigs.A.hooks?.enabled).toBe(true);
+      expect(config.agentConfigs.A.hooks?.strategy).toBe('merge');
+      expect(config.agentConfigs.A.hooks?.source).toBe(
+        path.resolve(tmpDir, 'hooks/agent.json'),
+      );
+      expect(config.agentConfigs.A.hooks?.outputPath).toBe(
+        path.resolve(tmpDir, '.claude/settings.json'),
+      );
+    });
+  });
 });

--- a/tests/unit/core/unified-config-hooks.test.ts
+++ b/tests/unit/core/unified-config-hooks.test.ts
@@ -1,0 +1,50 @@
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import { loadUnifiedConfig } from '../../../src/core/UnifiedConfigLoader';
+
+describe('UnifiedConfigLoader (hooks)', () => {
+  const tmpRoot = path.join(
+    __dirname,
+    '..',
+    '..',
+    '..',
+    'tmp-fixtures',
+    'unified-hooks',
+  );
+  const rulerDir = path.join(tmpRoot, '.ruler');
+  const tomlPath = path.join(rulerDir, 'ruler.toml');
+
+  beforeAll(async () => {
+    await fs.mkdir(rulerDir, { recursive: true });
+    await fs.writeFile(path.join(rulerDir, 'AGENTS.md'), '# AGENTS\\nMain');
+  });
+
+  afterAll(async () => {
+    await fs.rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  test('parses hooks config from TOML', async () => {
+    await fs.writeFile(
+      tomlPath,
+      `
+[hooks]
+enabled = true
+merge_strategy = "overwrite"
+source = ".ruler/hooks.json"
+`,
+    );
+
+    const unified = await loadUnifiedConfig({ projectRoot: tmpRoot });
+    expect(unified.toml.hooks).toBeDefined();
+    expect(unified.toml.hooks?.enabled).toBe(true);
+    expect(unified.toml.hooks?.strategy).toBe('overwrite');
+    expect(unified.toml.hooks?.source).toBe('.ruler/hooks.json');
+  });
+
+  test('defaults hooks to undefined when not specified', async () => {
+    await fs.writeFile(tomlPath, '');
+
+    const unified = await loadUnifiedConfig({ projectRoot: tmpRoot });
+    expect(unified.toml.hooks).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- switch hooks to a global .ruler/hooks.json source with optional per-agent overrides (mirrors skills)
- add Pi Coding Agent support (AGENTS.md + native skills directory .pi/skills)
- extend skills propagation + gitignore to include .pi/skills
- update docs and tests for hooks + skills

## Testing
- npm ci
- npm run lint
- npm test
- npm run build