### PR TITLE
Add global skills support from ~/.config/ruler/skills

### DIFF
--- a/src/core/SkillsProcessor.ts
+++ b/src/core/SkillsProcessor.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs/promises';
 import { SkillInfo } from '../types';
 import {
   RULER_SKILLS_PATH,
+  SKILLS_DIR,
   CLAUDE_SKILLS_PATH,
   CODEX_SKILLS_PATH,
   OPENCODE_SKILLS_PATH,
@@ -19,7 +20,8 @@ import {
   logWarn,
   logVerboseInfo,
 } from '../constants';
-import { walkSkillsTree, copySkillsDirectory } from './SkillsUtils';
+import { walkSkillsTree, copySkillsDirectory, mergeSkillsDirectories } from './SkillsUtils';
+import { findGlobalRulerDir } from './FileSystemUtils';
 import type { IAgent } from '../agents/IAgent';
 
 /**
@@ -44,19 +46,59 @@ export async function discoverSkills(
 }
 
 /**
+ * Discovers skills in the global config directory (~/.config/ruler/skills).
+ * Returns discovered skills and any validation warnings.
+ */
+export async function discoverGlobalSkills(): Promise<{ skills: SkillInfo[]; warnings: string[]; globalSkillsDir: string | null }> {
+  const globalDir = await findGlobalRulerDir();
+  if (!globalDir) {
+    return { skills: [], warnings: [], globalSkillsDir: null };
+  }
+
+  const globalSkillsDir = path.join(globalDir, SKILLS_DIR);
+  try {
+    await fs.access(globalSkillsDir);
+  } catch {
+    return { skills: [], warnings: [], globalSkillsDir: null };
+  }
+
+  const result = await walkSkillsTree(globalSkillsDir);
+  return { ...result, globalSkillsDir };
+}
+
+/**
  * Gets the paths that skills will generate, for gitignore purposes.
  * Returns empty array if skills directory doesn't exist.
  */
 export async function getSkillsGitignorePaths(
   projectRoot: string,
   agents: IAgent[],
+  localOnly: boolean = false,
 ): Promise<string[]> {
   const skillsDir = path.join(projectRoot, RULER_SKILLS_PATH);
 
-  // Check if skills directory exists
+  // Check if any skills exist (local or global)
+  let hasLocalSkills = false;
+  let hasGlobalSkills = false;
   try {
     await fs.access(skillsDir);
+    hasLocalSkills = true;
   } catch {
+    // no local skills
+  }
+  if (!localOnly) {
+    const globalDir = await findGlobalRulerDir();
+    if (globalDir) {
+      try {
+        await fs.access(path.join(globalDir, SKILLS_DIR));
+        hasGlobalSkills = true;
+      } catch {
+        // no global skills
+      }
+    }
+  }
+
+  if (!hasLocalSkills && !hasGlobalSkills) {
     return [];
   }
 
@@ -469,6 +511,9 @@ async function cleanupSkillsDirectories(
 
 /**
  * Propagates skills for agents that need them.
+ * Discovers skills from both local (.ruler/skills) and global (~/.config/ruler/skills) directories.
+ * When both local and global skills exist, local skills take precedence (override global by name).
+ * When localOnly is true, global skills are skipped.
  */
 export async function propagateSkills(
   projectRoot: string,
@@ -476,6 +521,7 @@ export async function propagateSkills(
   skillsEnabled: boolean,
   verbose: boolean,
   dryRun: boolean,
+  localOnly: boolean = false,
 ): Promise<void> {
   if (!skillsEnabled) {
     logVerboseInfo(
@@ -488,34 +534,90 @@ export async function propagateSkills(
     return;
   }
 
-  const skillsDir = path.join(projectRoot, RULER_SKILLS_PATH);
+  const localSkillsDir = path.join(projectRoot, RULER_SKILLS_PATH);
+  let hasLocalSkills = false;
+  let hasGlobalSkills = false;
+  let globalSkillsDir: string | null = null;
 
-  // Check if skills directory exists
+  // Check if local skills directory exists
   try {
-    await fs.access(skillsDir);
+    await fs.access(localSkillsDir);
+    hasLocalSkills = true;
   } catch {
-    // No skills directory - this is fine
+    // No local skills directory
+  }
+
+  // Check if global skills directory exists (unless --local-only)
+  if (!localOnly) {
+    const globalResult = await discoverGlobalSkills();
+    if (globalResult.globalSkillsDir) {
+      hasGlobalSkills = true;
+      globalSkillsDir = globalResult.globalSkillsDir;
+    }
+  }
+
+  if (!hasLocalSkills && !hasGlobalSkills) {
     logVerboseInfo(
-      'No .ruler/skills directory found, skipping skills propagation',
+      'No skills directory found (checked local .ruler/skills' + (localOnly ? '' : ' and global config') + '), skipping skills propagation',
       verbose,
       dryRun,
     );
     return;
   }
 
-  // Discover skills
-  const { skills, warnings } = await discoverSkills(projectRoot);
+  // Discover and merge skills from both sources
+  let allSkills: SkillInfo[] = [];
+  let allWarnings: string[] = [];
 
-  if (warnings.length > 0) {
-    warnings.forEach((warning) => logWarn(warning, dryRun));
+  if (hasGlobalSkills && globalSkillsDir) {
+    const globalResult = await walkSkillsTree(globalSkillsDir);
+    allSkills = [...globalResult.skills];
+    allWarnings = [...globalResult.warnings];
+    if (globalResult.skills.length > 0) {
+      logVerboseInfo(
+        `Discovered ${globalResult.skills.length} global skill(s) from ${globalSkillsDir}`,
+        verbose,
+        dryRun,
+      );
+    }
   }
 
-  if (skills.length === 0) {
-    logVerboseInfo('No valid skills found in .ruler/skills', verbose, dryRun);
+  if (hasLocalSkills) {
+    const localResult = await discoverSkills(projectRoot);
+    allWarnings = [...allWarnings, ...localResult.warnings];
+
+    if (localResult.skills.length > 0) {
+      logVerboseInfo(
+        `Discovered ${localResult.skills.length} local skill(s) from ${RULER_SKILLS_PATH}`,
+        verbose,
+        dryRun,
+      );
+
+      // Local skills override global skills with the same name
+      const localNames = new Set(localResult.skills.map((s) => s.name));
+      const overridden = allSkills.filter((s) => localNames.has(s.name));
+      if (overridden.length > 0) {
+        logVerboseInfo(
+          `Local skills override ${overridden.length} global skill(s): ${overridden.map((s) => s.name).join(', ')}`,
+          verbose,
+          dryRun,
+        );
+      }
+      allSkills = allSkills.filter((s) => !localNames.has(s.name));
+      allSkills = [...allSkills, ...localResult.skills];
+    }
+  }
+
+  if (allWarnings.length > 0) {
+    allWarnings.forEach((warning) => logWarn(warning, dryRun));
+  }
+
+  if (allSkills.length === 0) {
+    logVerboseInfo('No valid skills found', verbose, dryRun);
     return;
   }
 
-  logVerboseInfo(`Discovered ${skills.length} skill(s)`, verbose, dryRun);
+  logVerboseInfo(`Total: ${allSkills.length} skill(s) to propagate`, verbose, dryRun);
 
   const hasNativeSkillsAgent = agents.some((a) => a.supportsNativeSkills?.());
   const nonNativeAgents = agents.filter(
@@ -554,6 +656,29 @@ export async function propagateSkills(
     return;
   }
 
+  // Build a merged skills source directory if we have both local and global skills.
+  // Global skills are copied first, then local skills overwrite (local takes precedence).
+  let mergedSkillsDir: string | null = null;
+  let effectiveSkillsDir: string;
+
+  if (hasLocalSkills && hasGlobalSkills && globalSkillsDir) {
+    // Need to merge: create a temp dir with global first, then local on top
+    mergedSkillsDir = path.join(projectRoot, '.ruler', `.skills-merged-${Date.now()}`);
+    try {
+      await mergeSkillsDirectories(globalSkillsDir, localSkillsDir, mergedSkillsDir);
+      effectiveSkillsDir = mergedSkillsDir;
+    } catch (error) {
+      // Clean up on error
+      try { await fs.rm(mergedSkillsDir, { recursive: true, force: true }); } catch { /* ignore */ }
+      throw error;
+    }
+  } else if (hasLocalSkills) {
+    effectiveSkillsDir = localSkillsDir;
+  } else {
+    effectiveSkillsDir = globalSkillsDir!;
+  }
+
+  try {
   // Copy to Claude skills directory if needed
   if (selectedTargets.has('claude')) {
     logVerboseInfo(
@@ -561,7 +686,7 @@ export async function propagateSkills(
       verbose,
       dryRun,
     );
-    await propagateSkillsForClaude(projectRoot, { dryRun });
+    await propagateSkillsForClaude(projectRoot, { dryRun, skillsSourceDir: effectiveSkillsDir });
   }
 
   if (selectedTargets.has('codex')) {
@@ -570,7 +695,7 @@ export async function propagateSkills(
       verbose,
       dryRun,
     );
-    await propagateSkillsForCodex(projectRoot, { dryRun });
+    await propagateSkillsForCodex(projectRoot, { dryRun, skillsSourceDir: effectiveSkillsDir });
   }
 
   if (selectedTargets.has('opencode')) {
@@ -579,7 +704,7 @@ export async function propagateSkills(
       verbose,
       dryRun,
     );
-    await propagateSkillsForOpenCode(projectRoot, { dryRun });
+    await propagateSkillsForOpenCode(projectRoot, { dryRun, skillsSourceDir: effectiveSkillsDir });
   }
 
   if (selectedTargets.has('pi')) {
@@ -588,7 +713,7 @@ export async function propagateSkills(
       verbose,
       dryRun,
     );
-    await propagateSkillsForPi(projectRoot, { dryRun });
+    await propagateSkillsForPi(projectRoot, { dryRun, skillsSourceDir: effectiveSkillsDir });
   }
 
   if (selectedTargets.has('goose')) {
@@ -597,7 +722,7 @@ export async function propagateSkills(
       verbose,
       dryRun,
     );
-    await propagateSkillsForGoose(projectRoot, { dryRun });
+    await propagateSkillsForGoose(projectRoot, { dryRun, skillsSourceDir: effectiveSkillsDir });
   }
 
   if (selectedTargets.has('vibe')) {
@@ -606,7 +731,7 @@ export async function propagateSkills(
       verbose,
       dryRun,
     );
-    await propagateSkillsForVibe(projectRoot, { dryRun });
+    await propagateSkillsForVibe(projectRoot, { dryRun, skillsSourceDir: effectiveSkillsDir });
   }
 
   if (selectedTargets.has('roo')) {
@@ -615,7 +740,7 @@ export async function propagateSkills(
       verbose,
       dryRun,
     );
-    await propagateSkillsForRoo(projectRoot, { dryRun });
+    await propagateSkillsForRoo(projectRoot, { dryRun, skillsSourceDir: effectiveSkillsDir });
   }
 
   if (selectedTargets.has('gemini')) {
@@ -624,7 +749,7 @@ export async function propagateSkills(
       verbose,
       dryRun,
     );
-    await propagateSkillsForGemini(projectRoot, { dryRun });
+    await propagateSkillsForGemini(projectRoot, { dryRun, skillsSourceDir: effectiveSkillsDir });
   }
 
   if (selectedTargets.has('junie')) {
@@ -633,7 +758,7 @@ export async function propagateSkills(
       verbose,
       dryRun,
     );
-    await propagateSkillsForJunie(projectRoot, { dryRun });
+    await propagateSkillsForJunie(projectRoot, { dryRun, skillsSourceDir: effectiveSkillsDir });
   }
 
   if (selectedTargets.has('cursor')) {
@@ -642,7 +767,7 @@ export async function propagateSkills(
       verbose,
       dryRun,
     );
-    await propagateSkillsForCursor(projectRoot, { dryRun });
+    await propagateSkillsForCursor(projectRoot, { dryRun, skillsSourceDir: effectiveSkillsDir });
   }
 
   if (selectedTargets.has('windsurf')) {
@@ -651,7 +776,7 @@ export async function propagateSkills(
       verbose,
       dryRun,
     );
-    await propagateSkillsForWindsurf(projectRoot, { dryRun });
+    await propagateSkillsForWindsurf(projectRoot, { dryRun, skillsSourceDir: effectiveSkillsDir });
   }
 
   if (selectedTargets.has('factory')) {
@@ -660,7 +785,7 @@ export async function propagateSkills(
       verbose,
       dryRun,
     );
-    await propagateSkillsForFactory(projectRoot, { dryRun });
+    await propagateSkillsForFactory(projectRoot, { dryRun, skillsSourceDir: effectiveSkillsDir });
   }
 
   if (selectedTargets.has('antigravity')) {
@@ -669,10 +794,16 @@ export async function propagateSkills(
       verbose,
       dryRun,
     );
-    await propagateSkillsForAntigravity(projectRoot, { dryRun });
+    await propagateSkillsForAntigravity(projectRoot, { dryRun, skillsSourceDir: effectiveSkillsDir });
   }
 
   // No MCP-based propagation; only native skills are supported.
+  } finally {
+    // Clean up merged temp directory if we created one
+    if (mergedSkillsDir) {
+      try { await fs.rm(mergedSkillsDir, { recursive: true, force: true }); } catch { /* ignore */ }
+    }
+  }
 }
 
 /**
@@ -682,9 +813,9 @@ export async function propagateSkills(
  */
 export async function propagateSkillsForClaude(
   projectRoot: string,
-  options: { dryRun: boolean },
+  options: { dryRun: boolean; skillsSourceDir?: string },
 ): Promise<string[]> {
-  const skillsDir = path.join(projectRoot, RULER_SKILLS_PATH);
+  const skillsDir = options.skillsSourceDir || path.join(projectRoot, RULER_SKILLS_PATH);
   const claudeSkillsPath = path.join(projectRoot, CLAUDE_SKILLS_PATH);
   const claudeDir = path.dirname(claudeSkillsPath);
 
@@ -740,9 +871,9 @@ export async function propagateSkillsForClaude(
  */
 export async function propagateSkillsForCodex(
   projectRoot: string,
-  options: { dryRun: boolean },
+  options: { dryRun: boolean; skillsSourceDir?: string },
 ): Promise<string[]> {
-  const skillsDir = path.join(projectRoot, RULER_SKILLS_PATH);
+  const skillsDir = options.skillsSourceDir || path.join(projectRoot, RULER_SKILLS_PATH);
   const codexSkillsPath = path.join(projectRoot, CODEX_SKILLS_PATH);
   const codexDir = path.dirname(codexSkillsPath);
 
@@ -798,9 +929,9 @@ export async function propagateSkillsForCodex(
  */
 export async function propagateSkillsForOpenCode(
   projectRoot: string,
-  options: { dryRun: boolean },
+  options: { dryRun: boolean; skillsSourceDir?: string },
 ): Promise<string[]> {
-  const skillsDir = path.join(projectRoot, RULER_SKILLS_PATH);
+  const skillsDir = options.skillsSourceDir || path.join(projectRoot, RULER_SKILLS_PATH);
   const opencodeSkillsPath = path.join(projectRoot, OPENCODE_SKILLS_PATH);
   const opencodeDir = path.dirname(opencodeSkillsPath);
 
@@ -856,9 +987,9 @@ export async function propagateSkillsForOpenCode(
  */
 export async function propagateSkillsForPi(
   projectRoot: string,
-  options: { dryRun: boolean },
+  options: { dryRun: boolean; skillsSourceDir?: string },
 ): Promise<string[]> {
-  const skillsDir = path.join(projectRoot, RULER_SKILLS_PATH);
+  const skillsDir = options.skillsSourceDir || path.join(projectRoot, RULER_SKILLS_PATH);
   const piSkillsPath = path.join(projectRoot, PI_SKILLS_PATH);
   const piDir = path.dirname(piSkillsPath);
 
@@ -914,9 +1045,9 @@ export async function propagateSkillsForPi(
  */
 export async function propagateSkillsForGoose(
   projectRoot: string,
-  options: { dryRun: boolean },
+  options: { dryRun: boolean; skillsSourceDir?: string },
 ): Promise<string[]> {
-  const skillsDir = path.join(projectRoot, RULER_SKILLS_PATH);
+  const skillsDir = options.skillsSourceDir || path.join(projectRoot, RULER_SKILLS_PATH);
   const gooseSkillsPath = path.join(projectRoot, GOOSE_SKILLS_PATH);
   const gooseDir = path.dirname(gooseSkillsPath);
 
@@ -972,9 +1103,9 @@ export async function propagateSkillsForGoose(
  */
 export async function propagateSkillsForVibe(
   projectRoot: string,
-  options: { dryRun: boolean },
+  options: { dryRun: boolean; skillsSourceDir?: string },
 ): Promise<string[]> {
-  const skillsDir = path.join(projectRoot, RULER_SKILLS_PATH);
+  const skillsDir = options.skillsSourceDir || path.join(projectRoot, RULER_SKILLS_PATH);
   const vibeSkillsPath = path.join(projectRoot, VIBE_SKILLS_PATH);
   const vibeDir = path.dirname(vibeSkillsPath);
 
@@ -1030,9 +1161,9 @@ export async function propagateSkillsForVibe(
  */
 export async function propagateSkillsForRoo(
   projectRoot: string,
-  options: { dryRun: boolean },
+  options: { dryRun: boolean; skillsSourceDir?: string },
 ): Promise<string[]> {
-  const skillsDir = path.join(projectRoot, RULER_SKILLS_PATH);
+  const skillsDir = options.skillsSourceDir || path.join(projectRoot, RULER_SKILLS_PATH);
   const rooSkillsPath = path.join(projectRoot, ROO_SKILLS_PATH);
   const rooDir = path.dirname(rooSkillsPath);
 
@@ -1088,9 +1219,9 @@ export async function propagateSkillsForRoo(
  */
 export async function propagateSkillsForGemini(
   projectRoot: string,
-  options: { dryRun: boolean },
+  options: { dryRun: boolean; skillsSourceDir?: string },
 ): Promise<string[]> {
-  const skillsDir = path.join(projectRoot, RULER_SKILLS_PATH);
+  const skillsDir = options.skillsSourceDir || path.join(projectRoot, RULER_SKILLS_PATH);
   const geminiSkillsPath = path.join(projectRoot, GEMINI_SKILLS_PATH);
   const geminiDir = path.dirname(geminiSkillsPath);
 
@@ -1146,9 +1277,9 @@ export async function propagateSkillsForGemini(
  */
 export async function propagateSkillsForJunie(
   projectRoot: string,
-  options: { dryRun: boolean },
+  options: { dryRun: boolean; skillsSourceDir?: string },
 ): Promise<string[]> {
-  const skillsDir = path.join(projectRoot, RULER_SKILLS_PATH);
+  const skillsDir = options.skillsSourceDir || path.join(projectRoot, RULER_SKILLS_PATH);
   const junieSkillsPath = path.join(projectRoot, JUNIE_SKILLS_PATH);
   const junieDir = path.dirname(junieSkillsPath);
 
@@ -1195,9 +1326,9 @@ export async function propagateSkillsForJunie(
  */
 export async function propagateSkillsForCursor(
   projectRoot: string,
-  options: { dryRun: boolean },
+  options: { dryRun: boolean; skillsSourceDir?: string },
 ): Promise<string[]> {
-  const skillsDir = path.join(projectRoot, RULER_SKILLS_PATH);
+  const skillsDir = options.skillsSourceDir || path.join(projectRoot, RULER_SKILLS_PATH);
   const cursorSkillsPath = path.join(projectRoot, CURSOR_SKILLS_PATH);
   const cursorDir = path.dirname(cursorSkillsPath);
 
@@ -1253,9 +1384,9 @@ export async function propagateSkillsForCursor(
  */
 export async function propagateSkillsForWindsurf(
   projectRoot: string,
-  options: { dryRun: boolean },
+  options: { dryRun: boolean; skillsSourceDir?: string },
 ): Promise<string[]> {
-  const skillsDir = path.join(projectRoot, RULER_SKILLS_PATH);
+  const skillsDir = options.skillsSourceDir || path.join(projectRoot, RULER_SKILLS_PATH);
   const windsurfSkillsPath = path.join(projectRoot, WINDSURF_SKILLS_PATH);
   const windsurfDir = path.dirname(windsurfSkillsPath);
 
@@ -1311,9 +1442,9 @@ export async function propagateSkillsForWindsurf(
  */
 export async function propagateSkillsForFactory(
   projectRoot: string,
-  options: { dryRun: boolean },
+  options: { dryRun: boolean; skillsSourceDir?: string },
 ): Promise<string[]> {
-  const skillsDir = path.join(projectRoot, RULER_SKILLS_PATH);
+  const skillsDir = options.skillsSourceDir || path.join(projectRoot, RULER_SKILLS_PATH);
   const factorySkillsPath = path.join(projectRoot, FACTORY_SKILLS_PATH);
   const factoryDir = path.dirname(factorySkillsPath);
 
@@ -1369,9 +1500,9 @@ export async function propagateSkillsForFactory(
  */
 export async function propagateSkillsForAntigravity(
   projectRoot: string,
-  options: { dryRun: boolean },
+  options: { dryRun: boolean; skillsSourceDir?: string },
 ): Promise<string[]> {
-  const skillsDir = path.join(projectRoot, RULER_SKILLS_PATH);
+  const skillsDir = options.skillsSourceDir || path.join(projectRoot, RULER_SKILLS_PATH);
   const antigravitySkillsPath = path.join(projectRoot, ANTIGRAVITY_SKILLS_PATH);
   const antigravityDir = path.dirname(antigravitySkillsPath);
 

--- a/src/core/SkillsUtils.ts
+++ b/src/core/SkillsUtils.ts
@@ -138,3 +138,22 @@ export async function copySkillsDirectory(
   await fs.mkdir(destDir, { recursive: true });
   await copyRecursive(srcDir, destDir);
 }
+
+/**
+ * Merges two skills directories into a destination directory.
+ * Files from the override directory take precedence over files from the base directory.
+ * This is used to merge global skills (base) with local skills (override).
+ */
+export async function mergeSkillsDirectories(
+  baseDir: string,
+  overrideDir: string,
+  destDir: string,
+): Promise<void> {
+  await fs.mkdir(destDir, { recursive: true });
+
+  // Copy base (global) skills first
+  await copyRecursive(baseDir, destDir);
+
+  // Copy override (local) skills on top — overwrites any same-named skills
+  await copyRecursive(overrideDir, destDir);
+}

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -135,6 +135,7 @@ export async function applyAllAgentConfigs(
           skillsEnabledResolved,
           verbose,
           dryRun,
+          localOnly,
         );
       }
     }
@@ -188,6 +189,7 @@ export async function applyAllAgentConfigs(
         skillsEnabledResolved,
         verbose,
         dryRun,
+        localOnly,
       );
     }
 
@@ -215,6 +217,7 @@ export async function applyAllAgentConfigs(
     const skillsPaths = await getSkillsGitignorePaths(
       projectRoot,
       selectedAgents,
+      localOnly,
     );
     allGeneratedPaths = [...generatedPaths, ...skillsPaths];
   }

--- a/tests/global-skills.test.ts
+++ b/tests/global-skills.test.ts
@@ -1,0 +1,221 @@
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import {
+  discoverGlobalSkills,
+  propagateSkills,
+} from '../src/core/SkillsProcessor';
+import { mergeSkillsDirectories } from '../src/core/SkillsUtils';
+import {
+  CLAUDE_SKILLS_PATH,
+  CURSOR_SKILLS_PATH,
+  CODEX_SKILLS_PATH,
+  SKILL_MD_FILENAME,
+} from '../src/constants';
+
+// Mock findGlobalRulerDir to point to our test directory
+let mockGlobalDir: string | null = null;
+jest.mock('../src/core/FileSystemUtils', () => {
+  const actual = jest.requireActual('../src/core/FileSystemUtils');
+  return {
+    ...actual,
+    findGlobalRulerDir: jest.fn(async () => mockGlobalDir),
+  };
+});
+
+// Create a mock agent that supports native skills
+function createMockAgent(identifier: string, name: string, supportsSkills: boolean) {
+  return {
+    getIdentifier: () => identifier,
+    getName: () => name,
+    supportsNativeSkills: () => supportsSkills,
+    getOutputPaths: () => [],
+    apply: jest.fn(),
+    revert: jest.fn(),
+    getMcpConfigPath: () => null,
+    getMcpStrategy: () => 'merge' as const,
+    getMcpServerKey: () => 'mcpServers',
+    applyRulerConfig: jest.fn(),
+    getDefaultOutputPath: () => '',
+  };
+}
+
+describe('Global Skills Support', () => {
+  let tmpDir: string;
+  let globalDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ruler-global-skills-'));
+    globalDir = path.join(tmpDir, 'global-config', 'ruler');
+    await fs.mkdir(globalDir, { recursive: true });
+    mockGlobalDir = globalDir;
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+    mockGlobalDir = null;
+  });
+
+  describe('discoverGlobalSkills', () => {
+    it('discovers skills from the global config directory', async () => {
+      const globalSkillsDir = path.join(globalDir, 'skills');
+      const skill1 = path.join(globalSkillsDir, 'global-skill');
+      await fs.mkdir(skill1, { recursive: true });
+      await fs.writeFile(path.join(skill1, SKILL_MD_FILENAME), '# Global Skill');
+
+      const result = await discoverGlobalSkills();
+
+      expect(result.skills).toHaveLength(1);
+      expect(result.skills[0].name).toBe('global-skill');
+      expect(result.globalSkillsDir).toBe(globalSkillsDir);
+    });
+
+    it('returns empty when no global skills directory exists', async () => {
+      // globalDir exists but has no 'skills' subdirectory
+      const result = await discoverGlobalSkills();
+
+      expect(result.skills).toHaveLength(0);
+      expect(result.globalSkillsDir).toBeNull();
+    });
+
+    it('returns empty when no global ruler dir exists', async () => {
+      mockGlobalDir = null;
+
+      const result = await discoverGlobalSkills();
+
+      expect(result.skills).toHaveLength(0);
+      expect(result.globalSkillsDir).toBeNull();
+    });
+  });
+
+  describe('mergeSkillsDirectories', () => {
+    it('merges global and local skills with local taking precedence', async () => {
+      const globalSkills = path.join(tmpDir, 'global-skills');
+      const localSkills = path.join(tmpDir, 'local-skills');
+      const merged = path.join(tmpDir, 'merged');
+
+      // Global skill
+      const globalSkill = path.join(globalSkills, 'shared-skill');
+      await fs.mkdir(globalSkill, { recursive: true });
+      await fs.writeFile(path.join(globalSkill, SKILL_MD_FILENAME), '# Global Version');
+
+      // Global-only skill
+      const globalOnly = path.join(globalSkills, 'global-only');
+      await fs.mkdir(globalOnly, { recursive: true });
+      await fs.writeFile(path.join(globalOnly, SKILL_MD_FILENAME), '# Global Only');
+
+      // Local skill with same name (should override)
+      const localSkill = path.join(localSkills, 'shared-skill');
+      await fs.mkdir(localSkill, { recursive: true });
+      await fs.writeFile(path.join(localSkill, SKILL_MD_FILENAME), '# Local Version');
+
+      // Local-only skill
+      const localOnly = path.join(localSkills, 'local-only');
+      await fs.mkdir(localOnly, { recursive: true });
+      await fs.writeFile(path.join(localOnly, SKILL_MD_FILENAME), '# Local Only');
+
+      await mergeSkillsDirectories(globalSkills, localSkills, merged);
+
+      // Check merged result
+      const sharedContent = await fs.readFile(
+        path.join(merged, 'shared-skill', SKILL_MD_FILENAME),
+        'utf8',
+      );
+      expect(sharedContent).toBe('# Local Version'); // Local takes precedence
+
+      const globalOnlyContent = await fs.readFile(
+        path.join(merged, 'global-only', SKILL_MD_FILENAME),
+        'utf8',
+      );
+      expect(globalOnlyContent).toBe('# Global Only');
+
+      const localOnlyContent = await fs.readFile(
+        path.join(merged, 'local-only', SKILL_MD_FILENAME),
+        'utf8',
+      );
+      expect(localOnlyContent).toBe('# Local Only');
+    });
+  });
+
+  describe('propagateSkills with global skills', () => {
+    it('propagates global skills when no local skills exist', async () => {
+      const projectRoot = path.join(tmpDir, 'project');
+      await fs.mkdir(projectRoot, { recursive: true });
+
+      // Set up global skill
+      const globalSkillsDir = path.join(globalDir, 'skills', 'axe');
+      await fs.mkdir(globalSkillsDir, { recursive: true });
+      await fs.writeFile(
+        path.join(globalSkillsDir, SKILL_MD_FILENAME),
+        '# AXe Skill',
+      );
+
+      const agents = [createMockAgent('claude', 'Claude Code', true)];
+
+      await propagateSkills(projectRoot, agents, true, false, false, false);
+
+      // Check that the skill was propagated to .claude/skills
+      const claudeSkillContent = await fs.readFile(
+        path.join(projectRoot, CLAUDE_SKILLS_PATH, 'axe', SKILL_MD_FILENAME),
+        'utf8',
+      );
+      expect(claudeSkillContent).toBe('# AXe Skill');
+    });
+
+    it('merges local and global skills with local taking precedence', async () => {
+      const projectRoot = path.join(tmpDir, 'project');
+      const localSkillsDir = path.join(projectRoot, '.ruler', 'skills');
+
+      // Set up global skill
+      const globalSkill = path.join(globalDir, 'skills', 'shared');
+      await fs.mkdir(globalSkill, { recursive: true });
+      await fs.writeFile(path.join(globalSkill, SKILL_MD_FILENAME), '# Global');
+
+      const globalOnly = path.join(globalDir, 'skills', 'global-only');
+      await fs.mkdir(globalOnly, { recursive: true });
+      await fs.writeFile(path.join(globalOnly, SKILL_MD_FILENAME), '# Global Only');
+
+      // Set up local skill that overrides global
+      const localSkill = path.join(localSkillsDir, 'shared');
+      await fs.mkdir(localSkill, { recursive: true });
+      await fs.writeFile(path.join(localSkill, SKILL_MD_FILENAME), '# Local');
+
+      const agents = [createMockAgent('claude', 'Claude Code', true)];
+
+      await propagateSkills(projectRoot, agents, true, false, false, false);
+
+      // Local overrides global
+      const sharedContent = await fs.readFile(
+        path.join(projectRoot, CLAUDE_SKILLS_PATH, 'shared', SKILL_MD_FILENAME),
+        'utf8',
+      );
+      expect(sharedContent).toBe('# Local');
+
+      // Global-only skill is also propagated
+      const globalOnlyContent = await fs.readFile(
+        path.join(projectRoot, CLAUDE_SKILLS_PATH, 'global-only', SKILL_MD_FILENAME),
+        'utf8',
+      );
+      expect(globalOnlyContent).toBe('# Global Only');
+    });
+
+    it('skips global skills when localOnly is true', async () => {
+      const projectRoot = path.join(tmpDir, 'project');
+      await fs.mkdir(projectRoot, { recursive: true });
+
+      // Set up global skill only (no local skills)
+      const globalSkill = path.join(globalDir, 'skills', 'global-skill');
+      await fs.mkdir(globalSkill, { recursive: true });
+      await fs.writeFile(path.join(globalSkill, SKILL_MD_FILENAME), '# Global');
+
+      const agents = [createMockAgent('claude', 'Claude Code', true)];
+
+      await propagateSkills(projectRoot, agents, true, false, false, true);
+
+      // .claude/skills should NOT exist since localOnly=true and there are no local skills
+      await expect(
+        fs.access(path.join(projectRoot, CLAUDE_SKILLS_PATH)),
+      ).rejects.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Skills defined in the global config directory (`~/.config/ruler/skills` or `$XDG_CONFIG_HOME/ruler/skills`) are now discovered and propagated to agent-specific skill directories
- When both local (`.ruler/skills`) and global skills exist, **local skills take precedence** over global skills with the same name
- The `--local-only` flag skips global skills discovery, consistent with existing behavior for rules and config
- Added `discoverGlobalSkills()` and `mergeSkillsDirectories()` utilities

## Motivation

`ruler init --global` creates a global config at `~/.config/ruler/` that correctly handles rules (markdown) and MCP servers. However, skills placed in `~/.config/ruler/skills/` were silently ignored because `SkillsProcessor` only checked `.ruler/skills` relative to the project root.

This made it impossible to define skills once globally and have them propagated to all agents — a natural use case for tools that should be available in every project.

Closes #410

## Test plan

- [x] Added 7 new tests in `tests/global-skills.test.ts` covering:
  - Global skills discovery
  - Merging global + local skills with local precedence
  - `--local-only` flag skipping global skills
- [x] All 93 existing skills tests continue to pass
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)