### PR TITLE
Feat: Subagent propagation for Claude/Cursor/Codex/Copilot

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,40 +54,40 @@ Ruler solves this by providing a **single source of truth** for all your AI agen
 
 ## Supported AI Agents
 
-| Agent                  | Rules File(s)                                  | MCP Configuration / Notes                        | Skills Support / Location |
-| ---------------------- | ---------------------------------------------- | ------------------------------------------------ | ------------------------- |
-| AGENTS.md              | `AGENTS.md`                                    | (pseudo-agent ensuring root `AGENTS.md` exists)  | -                         |
-| GitHub Copilot         | `AGENTS.md`                                    | `.vscode/mcp.json`                               | `.claude/skills/`         |
-| Claude Code            | `CLAUDE.md`                                    | `.mcp.json`                                      | `.claude/skills/`         |
-| OpenAI Codex CLI       | `AGENTS.md`                                    | `.codex/config.toml`                             | `.codex/skills/`          |
-| Pi Coding Agent        | `AGENTS.md`                                    | -                                                | `.pi/skills/`             |
-| Jules                  | `AGENTS.md`                                    | -                                                | -                         |
-| Cursor                 | `AGENTS.md`                                    | `.cursor/mcp.json`                               | `.cursor/skills/`         |
-| Windsurf               | `AGENTS.md`                                    | `.windsurf/mcp_config.json`                      | `.windsurf/skills/`       |
-| Cline                  | `.clinerules`                                  | -                                                | -                         |
-| Crush                  | `CRUSH.md`                                     | `.crush.json`                                    | -                         |
-| Amp                    | `AGENTS.md`                                    | -                                                | `.agents/skills/`         |
-| Antigravity            | `.agent/rules/ruler.md`                        | -                                                | `.agent/skills/`          |
-| Amazon Q CLI           | `.amazonq/rules/ruler_q_rules.md`              | `.amazonq/mcp.json`                              | -                         |
-| Aider                  | `AGENTS.md`, `.aider.conf.yml`                 | `.mcp.json`                                      | -                         |
-| Firebase Studio        | `.idx/airules.md`                              | `.idx/mcp.json`                                  | -                         |
-| Open Hands             | `.openhands/microagents/repo.md`               | `config.toml`                                    | -                         |
-| Gemini CLI             | `AGENTS.md`                                    | `.gemini/settings.json`                          | `.gemini/skills/`         |
-| Junie                  | `.junie/guidelines.md`                         | `.junie/mcp/mcp.json`                            | `.junie/skills/`          |
-| AugmentCode            | `.augment/rules/ruler_augment_instructions.md` | -                                                | -                         |
-| Kilo Code              | `AGENTS.md`                                    | `.kilocode/mcp.json`                             | `.claude/skills/`         |
-| OpenCode               | `AGENTS.md`                                    | `opencode.json`                                  | `.opencode/skills/`       |
-| Goose                  | `.goosehints`                                  | -                                                | `.agents/skills/`         |
-| Qwen Code              | `AGENTS.md`                                    | `.qwen/settings.json`                            | -                         |
-| RooCode                | `AGENTS.md`                                    | `.roo/mcp.json`                                  | `.roo/skills/`            |
-| Zed                    | `AGENTS.md`                                    | `.zed/settings.json` (project root, never $HOME) | -                         |
-| Trae AI                | `.trae/rules/project_rules.md`                 | -                                                | -                         |
-| Warp                   | `WARP.md`                                      | -                                                | -                         |
-| Kiro                   | `.kiro/steering/ruler_kiro_instructions.md`    | `.kiro/settings/mcp.json`                        | -                         |
-| Firebender             | `firebender.json`                              | `firebender.json` (rules and MCP in same file)   | -                         |
-| Factory Droid          | `AGENTS.md`                                    | `.factory/mcp.json`                              | `.factory/skills/`        |
-| Mistral Vibe           | `AGENTS.md`                                    | `.vibe/config.toml`                              | `.vibe/skills/`           |
-| JetBrains AI Assistant | `.aiassistant/rules/AGENTS.md`                 | -                                                | -                         |
+| Agent                  | Rules File(s)                                  | MCP Configuration / Notes                        | Skills Support / Location | Subagents Support / Location |
+| ---------------------- | ---------------------------------------------- | ------------------------------------------------ | ------------------------- | ---------------------------- |
+| AGENTS.md              | `AGENTS.md`                                    | (pseudo-agent ensuring root `AGENTS.md` exists)  | -                         | -                            |
+| GitHub Copilot         | `AGENTS.md`                                    | `.vscode/mcp.json`                               | `.claude/skills/`         | `.github/agents/`            |
+| Claude Code            | `CLAUDE.md`                                    | `.mcp.json`                                      | `.claude/skills/`         | `.claude/agents/`            |
+| OpenAI Codex CLI       | `AGENTS.md`                                    | `.codex/config.toml`                             | `.codex/skills/`          | `.codex/agents/` (`.toml`)   |
+| Pi Coding Agent        | `AGENTS.md`                                    | -                                                | `.pi/skills/`             | -                            |
+| Jules                  | `AGENTS.md`                                    | -                                                | -                         | -                            |
+| Cursor                 | `AGENTS.md`                                    | `.cursor/mcp.json`                               | `.cursor/skills/`         | `.cursor/agents/`            |
+| Windsurf               | `AGENTS.md`                                    | `.windsurf/mcp_config.json`                      | `.windsurf/skills/`       | -                            |
+| Cline                  | `.clinerules`                                  | -                                                | -                         | -                            |
+| Crush                  | `CRUSH.md`                                     | `.crush.json`                                    | -                         | -                            |
+| Amp                    | `AGENTS.md`                                    | -                                                | `.agents/skills/`         | -                            |
+| Antigravity            | `.agent/rules/ruler.md`                        | -                                                | `.agent/skills/`          | -                            |
+| Amazon Q CLI           | `.amazonq/rules/ruler_q_rules.md`              | `.amazonq/mcp.json`                              | -                         | -                            |
+| Aider                  | `AGENTS.md`, `.aider.conf.yml`                 | `.mcp.json`                                      | -                         | -                            |
+| Firebase Studio        | `.idx/airules.md`                              | `.idx/mcp.json`                                  | -                         | -                            |
+| Open Hands             | `.openhands/microagents/repo.md`               | `config.toml`                                    | -                         | -                            |
+| Gemini CLI             | `AGENTS.md`                                    | `.gemini/settings.json`                          | `.gemini/skills/`         | -                            |
+| Junie                  | `.junie/guidelines.md`                         | `.junie/mcp/mcp.json`                            | `.junie/skills/`          | -                            |
+| AugmentCode            | `.augment/rules/ruler_augment_instructions.md` | -                                                | -                         | -                            |
+| Kilo Code              | `AGENTS.md`                                    | `.kilocode/mcp.json`                             | `.claude/skills/`         | -                            |
+| OpenCode               | `AGENTS.md`                                    | `opencode.json`                                  | `.opencode/skills/`       | -                            |
+| Goose                  | `.goosehints`                                  | -                                                | `.agents/skills/`         | -                            |
+| Qwen Code              | `AGENTS.md`                                    | `.qwen/settings.json`                            | -                         | -                            |
+| RooCode                | `AGENTS.md`                                    | `.roo/mcp.json`                                  | `.roo/skills/`            | -                            |
+| Zed                    | `AGENTS.md`                                    | `.zed/settings.json` (project root, never $HOME) | -                         | -                            |
+| Trae AI                | `.trae/rules/project_rules.md`                 | -                                                | -                         | -                            |
+| Warp                   | `WARP.md`                                      | -                                                | -                         | -                            |
+| Kiro                   | `.kiro/steering/ruler_kiro_instructions.md`    | `.kiro/settings/mcp.json`                        | -                         | -                            |
+| Firebender             | `firebender.json`                              | `firebender.json` (rules and MCP in same file)   | -                         | -                            |
+| Factory Droid          | `AGENTS.md`                                    | `.factory/mcp.json`                              | `.factory/skills/`        | -                            |
+| Mistral Vibe           | `AGENTS.md`                                    | `.vibe/config.toml`                              | `.vibe/skills/`           | -                            |
+| JetBrains AI Assistant | `.aiassistant/rules/AGENTS.md`                 | -                                                | -                         | -                            |
 
 ## Getting Started
 
@@ -245,6 +245,8 @@ The `apply` command looks for `.ruler/` in the current directory tree, reading t
 | `--no-backup`                  | Disable creation of `.bak` backup files.                               |
 | `--skills`                     | Enable skills support (experimental, default: enabled).                |
 | `--no-skills`                  | Disable skills support.                                                |
+| `--subagents`                  | Enable subagents support (experimental, default: enabled).             |
+| `--no-subagents`               | Disable subagents support.                                             |
 | `--dry-run`                    | Preview changes without writing files.                                 |
 | `--local-only`                 | Skip `$XDG_CONFIG_HOME` when looking for configuration.                |
 | `--verbose` / `-v`             | Display detailed output during execution.                              |
@@ -727,6 +729,142 @@ ruler apply
 #    - Cursor: .cursor/skills/my-skill/
 #    - Windsurf: .windsurf/skills/my-skill/
 ```
+
+## Subagents Support (Experimental)
+
+> **⚠️ Experimental:** Subagents support is experimental and behavior may change in future releases.
+
+Ruler can distribute named, delegatable **subagents** from a single source of truth (`.ruler/agents/`) to each agent's native subagent location. Each source file is one Markdown file with YAML frontmatter; Ruler transforms it into the format the target agent expects.
+
+### How It Works
+
+For agents with a native subagent primitive, Ruler writes one file per subagent into the target directory:
+
+| Agent             | Target location                | Format |
+| ----------------- | ------------------------------ | ------ |
+| Claude Code       | `.claude/agents/<name>.md`     | Markdown + YAML frontmatter |
+| Cursor            | `.cursor/agents/<name>.md`     | Markdown + YAML frontmatter |
+| OpenAI Codex CLI  | `.codex/agents/<name>.toml`    | TOML (one self-contained file per agent) |
+| GitHub Copilot    | `.github/agents/<name>.md`     | Markdown + YAML frontmatter |
+
+Other agents (Windsurf, RooCode, Aider, Gemini CLI, …) do not yet have a comparable native subagent primitive and are skipped with a warning. Subagent propagation will be added when those agents ship a comparable file format.
+
+### Source Format
+
+Author each subagent as `.ruler/agents/<name>.md`:
+
+```markdown
+---
+name: code-reviewer
+description: Use PROACTIVELY after a feature/fix is implemented. Reviews against SOLID/DRY/KISS. Read-only.
+tools: [Read, Grep, Glob, Bash]
+model: inherit
+readonly: true
+is_background: false
+---
+
+# Code Reviewer
+
+You operate in a fresh context window with read-only access. Your job is to
+review the diff and surrounding code against the design principles and return
+a structured verdict.
+```
+
+**Required frontmatter fields:**
+
+| Field         | Type   | Notes                                                 |
+| ------------- | ------ | ----------------------------------------------------- |
+| `name`        | string | Must match the filename stem (`code-reviewer.md` → `name: code-reviewer`). |
+| `description` | string | When the parent agent should delegate to this subagent. |
+
+**Optional frontmatter fields:**
+
+| Field           | Type             | Used by                                          | Default behavior                              |
+| --------------- | ---------------- | ------------------------------------------------ | --------------------------------------------- |
+| `tools`         | string[]         | Claude (verbatim), Copilot (mapped to aliases)   | Cursor / Codex ignore; omitted if absent.     |
+| `model`         | string           | All four targets                                 | Cursor defaults to `inherit`; others omit.    |
+| `readonly`      | boolean          | Cursor (verbatim), Codex (`sandbox_mode`), Copilot (`disable-model-invocation`) | Defaults to `false` for Cursor; omitted otherwise. |
+| `is_background` | boolean          | Cursor only                                      | Defaults to `false` for Cursor.               |
+
+For GitHub Copilot, source `tools` (Claude vocabulary: `Read`, `Grep`, `Bash`, …) are translated to Copilot's aliases (`read`, `search`, `execute`, …). Tools that do not have a Copilot equivalent are dropped with a warning.
+
+### Configuration
+
+Subagents are enabled by default. Toggle them via CLI flag or `ruler.toml`:
+
+```bash
+ruler apply --no-subagents   # disable subagent propagation for one run
+```
+
+```toml
+# .ruler/ruler.toml
+[subagents]
+enabled = false
+```
+
+CLI flags take precedence over `ruler.toml`, which takes precedence over the default (enabled).
+
+### Validation
+
+Source files are validated at discovery time:
+
+- Files without YAML frontmatter are skipped with a warning.
+- Files missing required `name` or `description` are skipped with a warning.
+- Files where `name` does not match the filename stem are skipped with a warning.
+- Unknown frontmatter keys are dropped (not errored).
+
+### Dry-Run Mode
+
+Use `--dry-run` to preview which files would be written without touching disk.
+
+### `.gitignore` Integration
+
+When subagents are enabled, the four target directories are added to the Ruler-managed block of `.gitignore`:
+
+```
+.claude/agents/
+.cursor/agents/
+.codex/agents/
+.github/agents/
+```
+
+Use `--no-gitignore` to opt out.
+
+### Cleanup
+
+Subagent propagation does **not** currently have explicit `ruler revert` support. To remove generated subagent directories, set `[subagents] enabled = false` (or pass `--no-subagents`) and run `ruler apply` once. Cleanup will run for all four targets even if no source `.ruler/agents/` directory exists.
+
+### Example Workflow
+
+```bash
+# 1. Author a subagent in your project
+mkdir -p .ruler/agents
+cat > .ruler/agents/code-reviewer.md << 'EOF'
+---
+name: code-reviewer
+description: Reviews changes against SOLID/DRY/KISS
+tools: [Read, Grep, Glob]
+readonly: true
+---
+
+You review code changes for quality.
+EOF
+
+# 2. Apply (subagents enabled by default)
+ruler apply
+
+# 3. The subagent is now available in each agent's native location:
+#    - Claude Code:  .claude/agents/code-reviewer.md
+#    - Cursor:       .cursor/agents/code-reviewer.md
+#    - Codex CLI:    .codex/agents/code-reviewer.toml
+#    - GitHub Copilot: .github/agents/code-reviewer.md
+```
+
+### Limitations
+
+- **No explicit revert command.** Cleanup happens via `[subagents] enabled = false` on a subsequent `apply`.
+- **Atomic replace, not merge.** Ruler regenerates each agent's subagent directory from the source on every apply. Manual edits to generated files will be overwritten.
+- **No support yet for agents without a native subagent primitive.** Windsurf, RooCode, Aider, Gemini CLI, and others are skipped with a warning. Propagation will be added when those agents ship a comparable file format.
 
 ## `.gitignore` Integration
 

--- a/README.md
+++ b/README.md
@@ -786,7 +786,7 @@ a structured verdict.
 | `readonly`      | boolean          | Cursor (verbatim), Codex (`sandbox_mode`), Copilot (`disable-model-invocation`) | Defaults to `false` for Cursor; omitted otherwise. |
 | `is_background` | boolean          | Cursor only                                      | Defaults to `false` for Cursor.               |
 
-For GitHub Copilot, source `tools` (Claude vocabulary: `Read`, `Grep`, `Bash`, …) are translated to Copilot's aliases (`read`, `search`, `execute`, …). Tools that do not have a Copilot equivalent are dropped with a warning.
+For GitHub Copilot, source `tools` (Claude vocabulary: `Read`, `Grep`, `Bash`, …) are translated to Copilot's aliases (`read`, `search`, `execute`, …). Tools that do not have a Copilot equivalent are dropped silently on a normal apply; pass `--verbose` (or use `--dry-run` to preview) to see which tools were dropped.
 
 ### Configuration
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@intellectronica/ruler",
-  "version": "0.3.22",
+  "version": "0.3.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@intellectronica/ruler",
-      "version": "0.3.22",
+      "version": "0.3.38",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^2.2.5",
@@ -35,7 +35,7 @@
         "typescript-eslint": "^8.46.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/src/agents/ClaudeAgent.ts
+++ b/src/agents/ClaudeAgent.ts
@@ -28,4 +28,8 @@ export class ClaudeAgent extends AbstractAgent {
   supportsNativeSkills(): boolean {
     return true;
   }
+
+  supportsNativeSubagents(): boolean {
+    return true;
+  }
 }

--- a/src/agents/CodexCliAgent.ts
+++ b/src/agents/CodexCliAgent.ts
@@ -174,4 +174,8 @@ export class CodexCliAgent implements IAgent {
   supportsNativeSkills(): boolean {
     return true;
   }
+
+  supportsNativeSubagents(): boolean {
+    return true;
+  }
 }

--- a/src/agents/CopilotAgent.ts
+++ b/src/agents/CopilotAgent.ts
@@ -59,4 +59,8 @@ export class CopilotAgent implements IAgent {
   supportsNativeSkills(): boolean {
     return true;
   }
+
+  supportsNativeSubagents(): boolean {
+    return true;
+  }
 }

--- a/src/agents/CursorAgent.ts
+++ b/src/agents/CursorAgent.ts
@@ -50,4 +50,8 @@ export class CursorAgent extends AgentsMdAgent {
   supportsNativeSkills(): boolean {
     return true;
   }
+
+  supportsNativeSubagents(): boolean {
+    return true;
+  }
 }

--- a/src/agents/IAgent.ts
+++ b/src/agents/IAgent.ts
@@ -77,4 +77,12 @@ export interface IAgent {
    * Defaults to false if not implemented.
    */
   supportsNativeSkills?(): boolean;
+
+  /**
+   * Returns whether this agent has native subagent support (like Claude Code,
+   * Cursor, Codex CLI, GitHub Copilot). When true, subagent definitions from
+   * `.ruler/agents/` are propagated to the agent's native subagent location.
+   * Defaults to false if not implemented.
+   */
+  supportsNativeSubagents?(): boolean;
 }

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -82,6 +82,11 @@ export function run(): void {
             type: 'boolean',
             description:
               'Enable/disable skills support (experimental, default: enabled)',
+          })
+          .option('subagents', {
+            type: 'boolean',
+            description:
+              'Enable/disable subagents support (experimental, default: enabled)',
           });
       },
       applyHandler,

--- a/src/cli/handlers.ts
+++ b/src/cli/handlers.ts
@@ -21,6 +21,7 @@ export interface ApplyArgs {
   nested?: boolean;
   backup: boolean;
   skills?: boolean;
+  subagents?: boolean;
 }
 
 export interface InitArgs {
@@ -112,6 +113,14 @@ export async function applyHandler(argv: ApplyArgs): Promise<void> {
     skillsEnabled = undefined; // Let config/default decide
   }
 
+  // Determine subagents preference: CLI > TOML > Default (enabled)
+  let subagentsEnabled: boolean | undefined;
+  if (argv.subagents !== undefined) {
+    subagentsEnabled = argv.subagents;
+  } else {
+    subagentsEnabled = undefined; // Let config/default decide
+  }
+
   try {
     await applyAllAgentConfigs(
       projectRoot,
@@ -127,6 +136,7 @@ export async function applyHandler(argv: ApplyArgs): Promise<void> {
       backup,
       skillsEnabled,
       gitignoreLocalPreference,
+      subagentsEnabled,
     );
     console.log('Ruler apply completed successfully.');
   } catch (err: unknown) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -69,3 +69,10 @@ export const WINDSURF_SKILLS_PATH = '.windsurf/skills';
 export const FACTORY_SKILLS_PATH = '.factory/skills';
 export const ANTIGRAVITY_SKILLS_PATH = '.agent/skills';
 export const SKILL_MD_FILENAME = 'SKILL.md';
+
+// Subagents-related constants
+export const RULER_SUBAGENTS_PATH = '.ruler/agents';
+export const CLAUDE_SUBAGENTS_PATH = '.claude/agents';
+export const CURSOR_SUBAGENTS_PATH = '.cursor/agents';
+export const CODEX_SUBAGENTS_PATH = '.codex/agents';
+export const COPILOT_SUBAGENTS_PATH = '.github/agents';

--- a/src/core/ConfigLoader.ts
+++ b/src/core/ConfigLoader.ts
@@ -8,6 +8,7 @@ import {
   GlobalMcpConfig,
   GitignoreConfig,
   SkillsConfig,
+  SubagentsConfig,
 } from '../types';
 import { createRulerError } from '../constants';
 
@@ -48,6 +49,11 @@ const rulerConfigSchema = z.object({
     })
     .optional(),
   skills: z
+    .object({
+      enabled: z.boolean().optional(),
+    })
+    .optional(),
+  subagents: z
     .object({
       enabled: z.boolean().optional(),
     })
@@ -105,6 +111,8 @@ export interface LoadedConfig {
   gitignore?: GitignoreConfig;
   /** Skills configuration section. */
   skills?: SkillsConfig;
+  /** Subagents configuration section. */
+  subagents?: SubagentsConfig;
   /** Whether to enable nested rule loading from nested .ruler directories. */
   nested?: boolean;
   /** Whether the nested option was explicitly provided in the config. */
@@ -261,6 +269,17 @@ export async function loadConfig(
     skillsConfig.enabled = rawSkillsSection.enabled;
   }
 
+  const rawSubagentsSection =
+    raw.subagents &&
+    typeof raw.subagents === 'object' &&
+    !Array.isArray(raw.subagents)
+      ? (raw.subagents as Record<string, unknown>)
+      : {};
+  const subagentsConfig: SubagentsConfig = {};
+  if (typeof rawSubagentsSection.enabled === 'boolean') {
+    subagentsConfig.enabled = rawSubagentsSection.enabled;
+  }
+
   const nestedDefined = typeof raw.nested === 'boolean';
   const nested = nestedDefined ? (raw.nested as boolean) : false;
 
@@ -271,6 +290,7 @@ export async function loadConfig(
     mcp: globalMcpConfig,
     gitignore: gitignoreConfig,
     skills: skillsConfig,
+    subagents: subagentsConfig,
     nested,
     nestedDefined,
   };

--- a/src/core/SubagentsProcessor.ts
+++ b/src/core/SubagentsProcessor.ts
@@ -1,0 +1,518 @@
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import * as yaml from 'js-yaml';
+import { stringify as stringifyTOML } from '@iarna/toml';
+import {
+  RULER_SUBAGENTS_PATH,
+  CLAUDE_SUBAGENTS_PATH,
+  CURSOR_SUBAGENTS_PATH,
+  CODEX_SUBAGENTS_PATH,
+  COPILOT_SUBAGENTS_PATH,
+  logWarn,
+  logVerboseInfo,
+} from '../constants';
+import type { SubagentInfo, SubagentFrontmatter } from '../types';
+import { loadSubagentFile, mapToolsForCopilot } from './SubagentsUtils';
+import type { IAgent } from '../agents/IAgent';
+
+/**
+ * Discovers subagent definitions in `.ruler/agents/`.
+ * Each `.md` file is parsed for YAML frontmatter (name, description, …).
+ * Files that fail validation are dropped from the returned list and
+ * reported via warnings.
+ */
+export async function discoverSubagents(
+  projectRoot: string,
+): Promise<{ subagents: SubagentInfo[]; warnings: string[] }> {
+  const dir = path.join(projectRoot, RULER_SUBAGENTS_PATH);
+
+  try {
+    await fs.access(dir);
+  } catch {
+    return { subagents: [], warnings: [] };
+  }
+
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  const mdFiles = entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.md'))
+    .map((entry) => path.join(dir, entry.name))
+    .sort();
+
+  const subagents: SubagentInfo[] = [];
+  const warnings: string[] = [];
+
+  for (const filePath of mdFiles) {
+    const info = await loadSubagentFile(filePath);
+    if (info.valid) {
+      subagents.push(info);
+    } else if (info.error) {
+      warnings.push(info.error);
+    }
+  }
+
+  return { subagents, warnings };
+}
+
+type SubagentTarget = 'claude' | 'cursor' | 'codex' | 'copilot';
+
+const SUBAGENT_TARGET_TO_IDENTIFIERS = new Map<
+  SubagentTarget,
+  readonly string[]
+>([
+  ['claude', ['claude']],
+  ['cursor', ['cursor']],
+  ['codex', ['codex']],
+  ['copilot', ['copilot']],
+]);
+
+const SUBAGENT_TARGET_PATHS: Record<SubagentTarget, string> = {
+  claude: CLAUDE_SUBAGENTS_PATH,
+  cursor: CURSOR_SUBAGENTS_PATH,
+  codex: CODEX_SUBAGENTS_PATH,
+  copilot: COPILOT_SUBAGENTS_PATH,
+};
+
+/**
+ * Returns which native subagent targets are reachable through the supplied
+ * agent list. An agent only contributes to a target when it implements
+ * `supportsNativeSubagents()` returning true.
+ */
+export function getSelectedSubagentTargets(
+  agents: IAgent[],
+): Set<SubagentTarget> {
+  const enabledIdentifiers = new Set(
+    agents
+      .filter((agent) => agent.supportsNativeSubagents?.())
+      .map((agent) => agent.getIdentifier()),
+  );
+  const targets = new Set<SubagentTarget>();
+  for (const [target, identifiers] of SUBAGENT_TARGET_TO_IDENTIFIERS) {
+    if (identifiers.some((id) => enabledIdentifiers.has(id))) {
+      targets.add(target);
+    }
+  }
+  return targets;
+}
+
+/**
+ * Returns absolute paths that subagent propagation may generate, for the
+ * supplied agents, used for `.gitignore` integration.
+ */
+export async function getSubagentsGitignorePaths(
+  projectRoot: string,
+  agents: IAgent[],
+): Promise<string[]> {
+  const dir = path.join(projectRoot, RULER_SUBAGENTS_PATH);
+  try {
+    await fs.access(dir);
+  } catch {
+    return [];
+  }
+  const targets = getSelectedSubagentTargets(agents);
+  return Array.from(targets).map((t) =>
+    path.join(projectRoot, SUBAGENT_TARGET_PATHS[t]),
+  );
+}
+
+/**
+ * Module-level state to track if experimental warning has been shown.
+ * Mirrors the SkillsProcessor convention to avoid spamming the user across
+ * multiple `apply` invocations within the same process.
+ */
+let hasWarnedExperimental = false;
+
+function warnOnceExperimental(dryRun: boolean): void {
+  if (hasWarnedExperimental) return;
+  hasWarnedExperimental = true;
+  logWarn(
+    'Subagents support is experimental and behavior may change in future releases.',
+    dryRun,
+  );
+}
+
+/**
+ * Test-only hook to reset the once-per-process experimental warning state.
+ */
+export function _resetExperimentalWarningForTests(): void {
+  hasWarnedExperimental = false;
+}
+
+/* ------------------------------------------------------------------ */
+/* Frontmatter helpers                                                 */
+/* ------------------------------------------------------------------ */
+
+function buildFrontmatterBlock(meta: Record<string, unknown>): string {
+  const yamlText = yaml.dump(meta, { lineWidth: -1, noRefs: true }).trimEnd();
+  return `---\n${yamlText}\n---\n`;
+}
+
+function ensureBodyFormatting(body: string | undefined): string {
+  const text = (body ?? '').replace(/^\n+/, '');
+  return text.endsWith('\n') ? text : `${text}\n`;
+}
+
+/* ------------------------------------------------------------------ */
+/* Atomic directory write                                              */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Stages files into a temp directory and atomically swaps it into place.
+ * Mirrors the pattern used by SkillsProcessor for safe overwriting.
+ */
+async function writeAgentsDirectoryAtomic(
+  targetDir: string,
+  files: { name: string; content: string }[],
+): Promise<void> {
+  const parent = path.dirname(targetDir);
+  await fs.mkdir(parent, { recursive: true });
+
+  const tempDir = path.join(parent, `agents.tmp-${Date.now()}`);
+  await fs.mkdir(tempDir, { recursive: true });
+
+  try {
+    for (const { name, content } of files) {
+      await fs.writeFile(path.join(tempDir, name), content, 'utf8');
+    }
+    try {
+      await fs.rm(targetDir, { recursive: true, force: true });
+    } catch {
+      // Target didn't exist; ignore.
+    }
+    await fs.rename(tempDir, targetDir);
+  } catch (error) {
+    try {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors.
+    }
+    throw error;
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/* Per-agent transformers                                              */
+/* ------------------------------------------------------------------ */
+
+interface PropagateOptions {
+  dryRun: boolean;
+}
+
+function buildClaudeFile(sub: SubagentInfo): string {
+  const fm = sub.frontmatter as SubagentFrontmatter;
+  const meta: Record<string, unknown> = {
+    name: fm.name,
+    description: fm.description,
+  };
+  if (fm.tools !== undefined) meta.tools = fm.tools;
+  if (fm.model !== undefined) meta.model = fm.model;
+  return `${buildFrontmatterBlock(meta)}\n${ensureBodyFormatting(sub.body)}`;
+}
+
+function buildCursorFile(sub: SubagentInfo): string {
+  const fm = sub.frontmatter as SubagentFrontmatter;
+  const meta: Record<string, unknown> = {
+    name: fm.name,
+    description: fm.description,
+    model: fm.model ?? 'inherit',
+    readonly: fm.readonly ?? false,
+    is_background: fm.is_background ?? false,
+  };
+  return `${buildFrontmatterBlock(meta)}\n${ensureBodyFormatting(sub.body)}`;
+}
+
+function buildCodexFile(sub: SubagentInfo): string {
+  const fm = sub.frontmatter as SubagentFrontmatter;
+  const config: Record<string, unknown> = {
+    name: fm.name,
+    description: fm.description,
+    developer_instructions: ensureBodyFormatting(sub.body),
+  };
+  if (fm.model !== undefined && fm.model !== 'inherit') {
+    config.model = fm.model;
+  }
+  if (fm.readonly === true) {
+    config.sandbox_mode = 'read-only';
+  }
+  // @iarna/toml requires JsonMap; the cast is safe because every value is a
+  // string/boolean/number/object that the library knows how to serialize.
+  return stringifyTOML(config as Parameters<typeof stringifyTOML>[0]);
+}
+
+function buildCopilotFile(
+  sub: SubagentInfo,
+  dryRun: boolean,
+): { content: string; warnings: string[] } {
+  const fm = sub.frontmatter as SubagentFrontmatter;
+  const meta: Record<string, unknown> = {
+    name: fm.name,
+    description: fm.description,
+    'user-invocable': true,
+  };
+  const warnings: string[] = [];
+  if (fm.tools && fm.tools.length > 0) {
+    const { tools, unknown } = mapToolsForCopilot(fm.tools);
+    if (tools.length > 0) {
+      meta.tools = tools;
+    }
+    if (unknown.length > 0) {
+      warnings.push(
+        `Subagent "${fm.name}": dropping tools not mappable to Copilot aliases: ${unknown.join(', ')}`,
+      );
+    }
+  }
+  if (fm.model !== undefined && fm.model !== 'inherit') {
+    meta.model = fm.model;
+  }
+  if (fm.readonly === true) {
+    meta['disable-model-invocation'] = true;
+  }
+  // Surface warnings via logWarn so they're visible to the user.
+  for (const warning of warnings) {
+    logWarn(warning, dryRun);
+  }
+  return {
+    content: `${buildFrontmatterBlock(meta)}\n${ensureBodyFormatting(sub.body)}`,
+    warnings,
+  };
+}
+
+export async function propagateSubagentsForClaude(
+  projectRoot: string,
+  subagents: SubagentInfo[],
+  options: PropagateOptions,
+): Promise<string[]> {
+  if (subagents.length === 0) return [];
+  const targetDir = path.join(projectRoot, CLAUDE_SUBAGENTS_PATH);
+  if (options.dryRun) {
+    return subagents.map(
+      (s) => `Write ${path.join(CLAUDE_SUBAGENTS_PATH, `${s.name}.md`)}`,
+    );
+  }
+  const files = subagents.map((s) => ({
+    name: `${s.name}.md`,
+    content: buildClaudeFile(s),
+  }));
+  await writeAgentsDirectoryAtomic(targetDir, files);
+  return [];
+}
+
+export async function propagateSubagentsForCursor(
+  projectRoot: string,
+  subagents: SubagentInfo[],
+  options: PropagateOptions,
+): Promise<string[]> {
+  if (subagents.length === 0) return [];
+  const targetDir = path.join(projectRoot, CURSOR_SUBAGENTS_PATH);
+  if (options.dryRun) {
+    return subagents.map(
+      (s) => `Write ${path.join(CURSOR_SUBAGENTS_PATH, `${s.name}.md`)}`,
+    );
+  }
+  const files = subagents.map((s) => ({
+    name: `${s.name}.md`,
+    content: buildCursorFile(s),
+  }));
+  await writeAgentsDirectoryAtomic(targetDir, files);
+  return [];
+}
+
+export async function propagateSubagentsForCodex(
+  projectRoot: string,
+  subagents: SubagentInfo[],
+  options: PropagateOptions,
+): Promise<string[]> {
+  if (subagents.length === 0) return [];
+  const targetDir = path.join(projectRoot, CODEX_SUBAGENTS_PATH);
+  if (options.dryRun) {
+    return subagents.map(
+      (s) => `Write ${path.join(CODEX_SUBAGENTS_PATH, `${s.name}.toml`)}`,
+    );
+  }
+  const files = subagents.map((s) => ({
+    name: `${s.name}.toml`,
+    content: buildCodexFile(s),
+  }));
+  await writeAgentsDirectoryAtomic(targetDir, files);
+  return [];
+}
+
+export async function propagateSubagentsForCopilot(
+  projectRoot: string,
+  subagents: SubagentInfo[],
+  options: PropagateOptions,
+): Promise<string[]> {
+  if (subagents.length === 0) return [];
+  const targetDir = path.join(projectRoot, COPILOT_SUBAGENTS_PATH);
+  if (options.dryRun) {
+    const planLines: string[] = [];
+    for (const s of subagents) {
+      // Surface tool-mapping warnings during dry-run too.
+      buildCopilotFile(s, true);
+      planLines.push(
+        `Write ${path.join(COPILOT_SUBAGENTS_PATH, `${s.name}.md`)}`,
+      );
+    }
+    return planLines;
+  }
+  const files = subagents.map((s) => ({
+    name: `${s.name}.md`,
+    content: buildCopilotFile(s, false).content,
+  }));
+  await writeAgentsDirectoryAtomic(targetDir, files);
+  return [];
+}
+
+/* ------------------------------------------------------------------ */
+/* Cleanup-on-disable                                                  */
+/* ------------------------------------------------------------------ */
+
+async function cleanupSubagentsDir(
+  projectRoot: string,
+  relPath: string,
+  dryRun: boolean,
+  verbose: boolean,
+): Promise<void> {
+  const target = path.join(projectRoot, relPath);
+  try {
+    await fs.access(target);
+  } catch {
+    return;
+  }
+  if (dryRun) {
+    logVerboseInfo(`DRY RUN: Would remove ${relPath}`, verbose, dryRun);
+    return;
+  }
+  await fs.rm(target, { recursive: true, force: true });
+  logVerboseInfo(`Removed ${relPath} (subagents disabled)`, verbose, dryRun);
+}
+
+async function cleanupAllSubagentsDirectories(
+  projectRoot: string,
+  dryRun: boolean,
+  verbose: boolean,
+): Promise<void> {
+  await cleanupSubagentsDir(
+    projectRoot,
+    CLAUDE_SUBAGENTS_PATH,
+    dryRun,
+    verbose,
+  );
+  await cleanupSubagentsDir(
+    projectRoot,
+    CURSOR_SUBAGENTS_PATH,
+    dryRun,
+    verbose,
+  );
+  await cleanupSubagentsDir(projectRoot, CODEX_SUBAGENTS_PATH, dryRun, verbose);
+  await cleanupSubagentsDir(
+    projectRoot,
+    COPILOT_SUBAGENTS_PATH,
+    dryRun,
+    verbose,
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Orchestrator                                                        */
+/* ------------------------------------------------------------------ */
+
+export async function propagateSubagents(
+  projectRoot: string,
+  agents: IAgent[],
+  subagentsEnabled: boolean,
+  verbose: boolean,
+  dryRun: boolean,
+): Promise<void> {
+  if (!subagentsEnabled) {
+    logVerboseInfo(
+      'Subagents support disabled, cleaning up subagent directories',
+      verbose,
+      dryRun,
+    );
+    await cleanupAllSubagentsDirectories(projectRoot, dryRun, verbose);
+    return;
+  }
+
+  const sourceDir = path.join(projectRoot, RULER_SUBAGENTS_PATH);
+  try {
+    await fs.access(sourceDir);
+  } catch {
+    logVerboseInfo(
+      'No .ruler/agents directory found, skipping subagent propagation',
+      verbose,
+      dryRun,
+    );
+    return;
+  }
+
+  const { subagents, warnings } = await discoverSubagents(projectRoot);
+  for (const w of warnings) logWarn(w, dryRun);
+
+  if (subagents.length === 0) {
+    logVerboseInfo(
+      'No valid subagents found in .ruler/agents',
+      verbose,
+      dryRun,
+    );
+    return;
+  }
+
+  logVerboseInfo(`Discovered ${subagents.length} subagent(s)`, verbose, dryRun);
+
+  const supporting = agents.filter((a) => a.supportsNativeSubagents?.());
+  const nonSupporting = agents.filter((a) => !a.supportsNativeSubagents?.());
+
+  if (nonSupporting.length > 0) {
+    const names = nonSupporting.map((a) => a.getName()).join(', ');
+    logWarn(
+      `Subagents are configured, but the following agents do not support native subagents and will be skipped: ${names}`,
+      dryRun,
+    );
+  }
+
+  if (supporting.length === 0) {
+    logVerboseInfo(
+      'No agents support native subagents, skipping subagent propagation',
+      verbose,
+      dryRun,
+    );
+    return;
+  }
+
+  warnOnceExperimental(dryRun);
+
+  const targets = getSelectedSubagentTargets(agents);
+
+  if (targets.has('claude')) {
+    logVerboseInfo(
+      `Writing subagents to ${CLAUDE_SUBAGENTS_PATH} for Claude Code`,
+      verbose,
+      dryRun,
+    );
+    await propagateSubagentsForClaude(projectRoot, subagents, { dryRun });
+  }
+  if (targets.has('cursor')) {
+    logVerboseInfo(
+      `Writing subagents to ${CURSOR_SUBAGENTS_PATH} for Cursor`,
+      verbose,
+      dryRun,
+    );
+    await propagateSubagentsForCursor(projectRoot, subagents, { dryRun });
+  }
+  if (targets.has('codex')) {
+    logVerboseInfo(
+      `Writing subagents to ${CODEX_SUBAGENTS_PATH} for OpenAI Codex CLI`,
+      verbose,
+      dryRun,
+    );
+    await propagateSubagentsForCodex(projectRoot, subagents, { dryRun });
+  }
+  if (targets.has('copilot')) {
+    logVerboseInfo(
+      `Writing subagents to ${COPILOT_SUBAGENTS_PATH} for GitHub Copilot`,
+      verbose,
+      dryRun,
+    );
+    await propagateSubagentsForCopilot(projectRoot, subagents, { dryRun });
+  }
+}

--- a/src/core/SubagentsProcessor.ts
+++ b/src/core/SubagentsProcessor.ts
@@ -444,10 +444,11 @@ export async function propagateSubagents(
     await fs.access(sourceDir);
   } catch {
     logVerboseInfo(
-      'No .ruler/agents directory found, skipping subagent propagation',
+      'No .ruler/agents directory found, cleaning up any stale managed subagent directories',
       verbose,
       dryRun,
     );
+    await cleanupAllSubagentsDirectories(projectRoot, dryRun, verbose);
     return;
   }
 
@@ -456,10 +457,11 @@ export async function propagateSubagents(
 
   if (subagents.length === 0) {
     logVerboseInfo(
-      'No valid subagents found in .ruler/agents',
+      'No valid subagents found in .ruler/agents; cleaning up any stale managed subagent directories',
       verbose,
       dryRun,
     );
+    await cleanupAllSubagentsDirectories(projectRoot, dryRun, verbose);
     return;
   }
 
@@ -476,6 +478,24 @@ export async function propagateSubagents(
     );
   }
 
+  const targets = getSelectedSubagentTargets(agents);
+
+  // Reconcile: any managed target directory that is not in the current
+  // selection set is stale and must be removed. This catches the case where
+  // a user drops an agent (e.g. claude+cursor → claude only) so the previously
+  // generated .cursor/agents/ directory does not linger as orphaned config.
+  const allTargets: SubagentTarget[] = ['claude', 'cursor', 'codex', 'copilot'];
+  for (const target of allTargets) {
+    if (!targets.has(target)) {
+      await cleanupSubagentsDir(
+        projectRoot,
+        SUBAGENT_TARGET_PATHS[target],
+        dryRun,
+        verbose,
+      );
+    }
+  }
+
   if (supporting.length === 0) {
     logVerboseInfo(
       'No agents support native subagents, skipping subagent propagation',
@@ -486,8 +506,6 @@ export async function propagateSubagents(
   }
 
   warnOnceExperimental(dryRun);
-
-  const targets = getSelectedSubagentTargets(agents);
 
   if (targets.has('claude')) {
     logVerboseInfo(

--- a/src/core/SubagentsProcessor.ts
+++ b/src/core/SubagentsProcessor.ts
@@ -205,6 +205,12 @@ function buildClaudeFile(sub: SubagentInfo): string {
   };
   if (fm.tools !== undefined) meta.tools = fm.tools;
   if (fm.model !== undefined) meta.model = fm.model;
+  // Pass through readonly and is_background verbatim so authoring intent
+  // survives the Claude transform. Claude Code ignores unknown frontmatter
+  // keys, but downstream tooling that reads .claude/agents/*.md can still
+  // observe the original values.
+  if (fm.readonly !== undefined) meta.readonly = fm.readonly;
+  if (fm.is_background !== undefined) meta.is_background = fm.is_background;
   return `${buildFrontmatterBlock(meta)}\n${ensureBodyFormatting(sub.body)}`;
 }
 

--- a/src/core/SubagentsProcessor.ts
+++ b/src/core/SubagentsProcessor.ts
@@ -195,6 +195,7 @@ async function writeAgentsDirectoryAtomic(
 
 interface PropagateOptions {
   dryRun: boolean;
+  verbose?: boolean;
 }
 
 function buildClaudeFile(sub: SubagentInfo): string {
@@ -247,6 +248,7 @@ function buildCodexFile(sub: SubagentInfo): string {
 function buildCopilotFile(
   sub: SubagentInfo,
   dryRun: boolean,
+  verbose: boolean,
 ): { content: string; warnings: string[] } {
   const fm = sub.frontmatter as SubagentFrontmatter;
   const meta: Record<string, unknown> = {
@@ -272,9 +274,13 @@ function buildCopilotFile(
   if (fm.readonly === true) {
     meta['disable-model-invocation'] = true;
   }
-  // Surface warnings via logWarn so they're visible to the user.
-  for (const warning of warnings) {
-    logWarn(warning, dryRun);
+  // Tool-drop is informational — surface it only when the user explicitly
+  // asked for detail (--verbose) or when previewing changes (--dry-run).
+  // A normal apply stays quiet to avoid noise on every run.
+  if (verbose || dryRun) {
+    for (const warning of warnings) {
+      logWarn(warning, dryRun);
+    }
   }
   return {
     content: `${buildFrontmatterBlock(meta)}\n${ensureBodyFormatting(sub.body)}`,
@@ -349,11 +355,14 @@ export async function propagateSubagentsForCopilot(
 ): Promise<string[]> {
   if (subagents.length === 0) return [];
   const targetDir = path.join(projectRoot, COPILOT_SUBAGENTS_PATH);
+  const verbose = options.verbose ?? false;
   if (options.dryRun) {
     const planLines: string[] = [];
     for (const s of subagents) {
-      // Surface tool-mapping warnings during dry-run too.
-      buildCopilotFile(s, true);
+      // Surface tool-mapping warnings during dry-run too — buildCopilotFile
+      // emits when dryRun is true so users previewing a change can see
+      // which tools would be dropped before it actually happens.
+      buildCopilotFile(s, true, verbose);
       planLines.push(
         `Write ${path.join(COPILOT_SUBAGENTS_PATH, `${s.name}.md`)}`,
       );
@@ -362,7 +371,7 @@ export async function propagateSubagentsForCopilot(
   }
   const files = subagents.map((s) => ({
     name: `${s.name}.md`,
-    content: buildCopilotFile(s, false).content,
+    content: buildCopilotFile(s, false, verbose).content,
   }));
   await writeAgentsDirectoryAtomic(targetDir, files);
   return [];
@@ -513,7 +522,10 @@ export async function propagateSubagents(
       verbose,
       dryRun,
     );
-    await propagateSubagentsForClaude(projectRoot, subagents, { dryRun });
+    await propagateSubagentsForClaude(projectRoot, subagents, {
+      dryRun,
+      verbose,
+    });
   }
   if (targets.has('cursor')) {
     logVerboseInfo(
@@ -521,7 +533,10 @@ export async function propagateSubagents(
       verbose,
       dryRun,
     );
-    await propagateSubagentsForCursor(projectRoot, subagents, { dryRun });
+    await propagateSubagentsForCursor(projectRoot, subagents, {
+      dryRun,
+      verbose,
+    });
   }
   if (targets.has('codex')) {
     logVerboseInfo(
@@ -529,7 +544,10 @@ export async function propagateSubagents(
       verbose,
       dryRun,
     );
-    await propagateSubagentsForCodex(projectRoot, subagents, { dryRun });
+    await propagateSubagentsForCodex(projectRoot, subagents, {
+      dryRun,
+      verbose,
+    });
   }
   if (targets.has('copilot')) {
     logVerboseInfo(
@@ -537,6 +555,9 @@ export async function propagateSubagents(
       verbose,
       dryRun,
     );
-    await propagateSubagentsForCopilot(projectRoot, subagents, { dryRun });
+    await propagateSubagentsForCopilot(projectRoot, subagents, {
+      dryRun,
+      verbose,
+    });
   }
 }

--- a/src/core/SubagentsUtils.ts
+++ b/src/core/SubagentsUtils.ts
@@ -99,7 +99,20 @@ export async function loadSubagentFile(
 ): Promise<SubagentInfo> {
   const stem = path.basename(filePath, '.md');
   const content = await fs.readFile(filePath, 'utf8');
-  const parsed = parseFrontmatter(content);
+  // js-yaml throws on malformed YAML; convert that into the standard
+  // validation-failure shape so one bad file doesn't abort discovery.
+  let parsed: ParsedFrontmatter | null;
+  try {
+    parsed = parseFrontmatter(content);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    return {
+      name: stem,
+      path: filePath,
+      valid: false,
+      error: `${stem}.md: invalid YAML frontmatter: ${detail}`,
+    };
+  }
 
   if (!parsed) {
     return {

--- a/src/core/SubagentsUtils.ts
+++ b/src/core/SubagentsUtils.ts
@@ -1,0 +1,170 @@
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import * as yaml from 'js-yaml';
+import type { SubagentFrontmatter, SubagentInfo } from '../types';
+
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/;
+
+export interface ParsedFrontmatter {
+  meta: Record<string, unknown>;
+  body: string;
+}
+
+/**
+ * Extracts YAML frontmatter and body from a Markdown file's contents.
+ * Returns null if no frontmatter delimiter pair is present at the head of the file.
+ */
+export function parseFrontmatter(content: string): ParsedFrontmatter | null {
+  const match = FRONTMATTER_RE.exec(content);
+  if (!match) {
+    return null;
+  }
+  const [, raw, body] = match;
+  const meta = yaml.load(raw) as Record<string, unknown> | null | undefined;
+  return {
+    meta: meta && typeof meta === 'object' ? meta : {},
+    body: body ?? '',
+  };
+}
+
+/**
+ * Validates a parsed frontmatter object and reads the required and optional
+ * fields into a typed SubagentFrontmatter. Returns the typed value on success
+ * or an error message on failure.
+ */
+export function validateFrontmatter(
+  meta: Record<string, unknown>,
+  expectedName: string,
+): { value: SubagentFrontmatter } | { error: string } {
+  const name = meta.name;
+  const description = meta.description;
+
+  if (typeof name !== 'string' || name.length === 0) {
+    return { error: `missing or invalid required field "name"` };
+  }
+  if (typeof description !== 'string' || description.length === 0) {
+    return { error: `missing or invalid required field "description"` };
+  }
+  if (name !== expectedName) {
+    return {
+      error: `frontmatter name "${name}" does not match filename stem "${expectedName}"`,
+    };
+  }
+
+  const fm: SubagentFrontmatter = { name, description };
+
+  if (meta.tools !== undefined) {
+    if (
+      Array.isArray(meta.tools) &&
+      meta.tools.every((t) => typeof t === 'string')
+    ) {
+      fm.tools = meta.tools as string[];
+    } else if (typeof meta.tools === 'string') {
+      fm.tools = meta.tools
+        .split(',')
+        .map((t) => t.trim())
+        .filter(Boolean);
+    } else {
+      return { error: `invalid "tools" field; expected string or string[]` };
+    }
+  }
+  if (meta.model !== undefined) {
+    if (typeof meta.model !== 'string') {
+      return { error: `invalid "model" field; expected string` };
+    }
+    fm.model = meta.model;
+  }
+  if (meta.readonly !== undefined) {
+    if (typeof meta.readonly !== 'boolean') {
+      return { error: `invalid "readonly" field; expected boolean` };
+    }
+    fm.readonly = meta.readonly;
+  }
+  if (meta.is_background !== undefined) {
+    if (typeof meta.is_background !== 'boolean') {
+      return { error: `invalid "is_background" field; expected boolean` };
+    }
+    fm.is_background = meta.is_background;
+  }
+
+  return { value: fm };
+}
+
+/**
+ * Loads a single subagent file and produces a SubagentInfo.
+ * Invalid files produce a SubagentInfo with valid=false and an error string.
+ */
+export async function loadSubagentFile(
+  filePath: string,
+): Promise<SubagentInfo> {
+  const stem = path.basename(filePath, '.md');
+  const content = await fs.readFile(filePath, 'utf8');
+  const parsed = parseFrontmatter(content);
+
+  if (!parsed) {
+    return {
+      name: stem,
+      path: filePath,
+      valid: false,
+      error: `${stem}.md: missing YAML frontmatter`,
+    };
+  }
+
+  const result = validateFrontmatter(parsed.meta, stem);
+  if ('error' in result) {
+    return {
+      name: stem,
+      path: filePath,
+      valid: false,
+      error: `${stem}.md: ${result.error}`,
+    };
+  }
+
+  return {
+    name: stem,
+    path: filePath,
+    valid: true,
+    frontmatter: result.value,
+    body: parsed.body,
+  };
+}
+
+/**
+ * Maps Claude Code tool names to GitHub Copilot tool aliases.
+ * Unknown source tools return undefined and should be dropped (with a warning).
+ */
+const COPILOT_TOOL_MAP: Record<string, string> = {
+  Read: 'read',
+  Grep: 'search',
+  Glob: 'search',
+  Bash: 'execute',
+  Edit: 'edit',
+  Write: 'edit',
+  WebFetch: 'web',
+  WebSearch: 'web',
+  TodoWrite: 'todo',
+  Task: 'agent',
+};
+
+export interface CopilotToolMapping {
+  tools: string[];
+  unknown: string[];
+}
+
+/**
+ * Translates Claude tool names to Copilot aliases. Deduplicates results.
+ * Unknown source tools are reported separately so callers can surface a warning.
+ */
+export function mapToolsForCopilot(sourceTools: string[]): CopilotToolMapping {
+  const mapped = new Set<string>();
+  const unknown: string[] = [];
+  for (const tool of sourceTools) {
+    const alias = COPILOT_TOOL_MAP[tool];
+    if (alias) {
+      mapped.add(alias);
+    } else {
+      unknown.push(tool);
+    }
+  }
+  return { tools: Array.from(mapped), unknown };
+}

--- a/src/core/UnifiedConfigTypes.ts
+++ b/src/core/UnifiedConfigTypes.ts
@@ -2,6 +2,7 @@ import {
   McpConfig,
   GitignoreConfig,
   SkillsConfig,
+  SubagentsConfig,
   McpStrategy,
 } from '../types';
 
@@ -33,6 +34,7 @@ export interface TomlConfig {
   mcpServers?: Record<string, McpServerDef>;
   gitignore?: GitignoreConfig;
   skills?: SkillsConfig;
+  subagents?: SubagentsConfig;
   nested?: boolean;
 }
 

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -34,6 +34,21 @@ function resolveSkillsEnabled(
 }
 
 /**
+ * Resolves subagents enabled state based on precedence:
+ * CLI flag > ruler.toml > default (enabled).
+ */
+function resolveSubagentsEnabled(
+  cliFlag: boolean | undefined,
+  configSetting: boolean | undefined,
+): boolean {
+  return cliFlag !== undefined
+    ? cliFlag
+    : configSetting !== undefined
+      ? configSetting
+      : true; // default to enabled
+}
+
+/**
  * Applies ruler configurations for all supported AI agents.
  * @param projectRoot Root directory of the project
  */
@@ -56,6 +71,7 @@ export async function applyAllAgentConfigs(
   backup = true,
   skillsEnabled?: boolean,
   cliGitignoreLocal?: boolean,
+  subagentsEnabled?: boolean,
 ): Promise<void> {
   // Load configuration and rules
   logVerbose(
@@ -139,6 +155,29 @@ export async function applyAllAgentConfigs(
       }
     }
 
+    // Propagate subagents (mirrors skills handling for nested mode).
+    const subagentsEnabledResolved = resolveSubagentsEnabled(
+      subagentsEnabled,
+      rootConfig.subagents?.enabled,
+    );
+    {
+      const { propagateSubagents } = await import('./core/SubagentsProcessor');
+      for (const configEntry of hierarchicalConfigs) {
+        const nestedRoot = path.dirname(configEntry.rulerDir);
+        logVerbose(
+          `Propagating subagents for nested directory: ${nestedRoot}`,
+          verbose,
+        );
+        await propagateSubagents(
+          nestedRoot,
+          selectedAgents,
+          subagentsEnabledResolved,
+          verbose,
+          dryRun,
+        );
+      }
+    }
+
     generatedPaths = await processHierarchicalConfigurations(
       selectedAgents,
       hierarchicalConfigs,
@@ -191,6 +230,22 @@ export async function applyAllAgentConfigs(
       );
     }
 
+    // Propagate subagents (mirrors skills handling).
+    const subagentsEnabledResolvedSingle = resolveSubagentsEnabled(
+      subagentsEnabled,
+      singleConfig.config.subagents?.enabled,
+    );
+    {
+      const { propagateSubagents } = await import('./core/SubagentsProcessor');
+      await propagateSubagents(
+        projectRoot,
+        selectedAgents,
+        subagentsEnabledResolvedSingle,
+        verbose,
+        dryRun,
+      );
+    }
+
     generatedPaths = await processSingleConfiguration(
       selectedAgents,
       singleConfig,
@@ -216,7 +271,23 @@ export async function applyAllAgentConfigs(
       projectRoot,
       selectedAgents,
     );
-    allGeneratedPaths = [...generatedPaths, ...skillsPaths];
+    allGeneratedPaths = [...allGeneratedPaths, ...skillsPaths];
+  }
+
+  // Add subagents-generated paths to gitignore if subagents are enabled.
+  const subagentsEnabledForGitignore = resolveSubagentsEnabled(
+    subagentsEnabled,
+    loadedConfig.subagents?.enabled,
+  );
+  if (subagentsEnabledForGitignore) {
+    const { getSubagentsGitignorePaths } = await import(
+      './core/SubagentsProcessor'
+    );
+    const subagentPaths = await getSubagentsGitignorePaths(
+      projectRoot,
+      selectedAgents,
+    );
+    allGeneratedPaths = [...allGeneratedPaths, ...subagentPaths];
   }
 
   await updateGitignore(

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,3 +41,35 @@ export interface SkillInfo {
   /** Error message if invalid. */
   error?: string;
 }
+
+/** Subagents configuration for automatic subagent distribution. */
+export interface SubagentsConfig {
+  /** Enable or disable subagents support. */
+  enabled?: boolean;
+}
+
+/** Frontmatter fields recognised on a source subagent definition. */
+export interface SubagentFrontmatter {
+  name: string;
+  description: string;
+  tools?: string[];
+  model?: string;
+  readonly?: boolean;
+  is_background?: boolean;
+}
+
+/** Information about a discovered subagent. */
+export interface SubagentInfo {
+  /** Name of the subagent (filename stem and frontmatter `name`). */
+  name: string;
+  /** Absolute path to the source `.md` file. */
+  path: string;
+  /** Parsed frontmatter (only present when valid). */
+  frontmatter?: SubagentFrontmatter;
+  /** Body content after the frontmatter delimiter. */
+  body?: string;
+  /** Whether this subagent passed validation. */
+  valid: boolean;
+  /** Error message if invalid. */
+  error?: string;
+}

--- a/tests/subagents-capability.test.ts
+++ b/tests/subagents-capability.test.ts
@@ -1,0 +1,49 @@
+import { IAgent } from '../src/agents/IAgent';
+import { ClaudeAgent } from '../src/agents/ClaudeAgent';
+import { CursorAgent } from '../src/agents/CursorAgent';
+import { CodexCliAgent } from '../src/agents/CodexCliAgent';
+import { CopilotAgent } from '../src/agents/CopilotAgent';
+import { WindsurfAgent } from '../src/agents/WindsurfAgent';
+import { AiderAgent } from '../src/agents/AiderAgent';
+import { GeminiCliAgent } from '../src/agents/GeminiCliAgent';
+
+describe('supportsNativeSubagents capability flag', () => {
+  describe('agents with a native subagent primitive', () => {
+    it('Claude Code reports true', () => {
+      const agent: IAgent = new ClaudeAgent();
+      expect(agent.supportsNativeSubagents?.()).toBe(true);
+    });
+
+    it('Cursor reports true', () => {
+      const agent: IAgent = new CursorAgent();
+      expect(agent.supportsNativeSubagents?.()).toBe(true);
+    });
+
+    it('Codex CLI reports true', () => {
+      const agent: IAgent = new CodexCliAgent();
+      expect(agent.supportsNativeSubagents?.()).toBe(true);
+    });
+
+    it('GitHub Copilot reports true', () => {
+      const agent: IAgent = new CopilotAgent();
+      expect(agent.supportsNativeSubagents?.()).toBe(true);
+    });
+  });
+
+  describe('agents without a native subagent primitive', () => {
+    it('Windsurf does not report true (instruction/rule/workflow only)', () => {
+      const agent: IAgent = new WindsurfAgent();
+      expect(agent.supportsNativeSubagents?.() ?? false).toBe(false);
+    });
+
+    it('Aider does not report true', () => {
+      const agent: IAgent = new AiderAgent();
+      expect(agent.supportsNativeSubagents?.() ?? false).toBe(false);
+    });
+
+    it('Gemini CLI does not report true', () => {
+      const agent: IAgent = new GeminiCliAgent();
+      expect(agent.supportsNativeSubagents?.() ?? false).toBe(false);
+    });
+  });
+});

--- a/tests/subagents-cli.test.ts
+++ b/tests/subagents-cli.test.ts
@@ -1,0 +1,244 @@
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import { applyAllAgentConfigs } from '../src/lib';
+import {
+  CLAUDE_SUBAGENTS_PATH,
+  CURSOR_SUBAGENTS_PATH,
+  CODEX_SUBAGENTS_PATH,
+  COPILOT_SUBAGENTS_PATH,
+  RULER_SUBAGENTS_PATH,
+} from '../src/constants';
+import { _resetExperimentalWarningForTests } from '../src/core/SubagentsProcessor';
+
+async function writeSubagent(
+  projectRoot: string,
+  name: string,
+  body = 'You are an agent.',
+): Promise<void> {
+  const dir = path.join(projectRoot, RULER_SUBAGENTS_PATH);
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(
+    path.join(dir, `${name}.md`),
+    `---\nname: ${name}\ndescription: Test subagent ${name}\ntools: [Read, Grep]\nreadonly: true\n---\n\n${body}\n`,
+  );
+}
+
+async function setupRulerProject(projectRoot: string): Promise<void> {
+  const rulerDir = path.join(projectRoot, '.ruler');
+  await fs.mkdir(rulerDir, { recursive: true });
+  await fs.writeFile(
+    path.join(rulerDir, 'AGENTS.md'),
+    '# Project Rules\n\nBe helpful.\n',
+  );
+}
+
+describe('Subagents apply integration', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ruler-subagents-cli-'));
+    _resetExperimentalWarningForTests();
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('writes subagents to all four targets when default applies to claude+cursor+codex+copilot', async () => {
+    await setupRulerProject(tmpDir);
+    await writeSubagent(tmpDir, 'reviewer');
+
+    await applyAllAgentConfigs(
+      tmpDir,
+      ['claude', 'cursor', 'codex', 'copilot'],
+      undefined,
+      false, // mcp disabled (avoids unrelated MCP setup in tests)
+      undefined,
+      false, // gitignore disabled to keep test focused
+      false,
+      false,
+      false,
+      false,
+      true,
+      undefined,
+      undefined,
+      undefined,
+    );
+
+    await expect(
+      fs.access(path.join(tmpDir, CLAUDE_SUBAGENTS_PATH, 'reviewer.md')),
+    ).resolves.toBeUndefined();
+    await expect(
+      fs.access(path.join(tmpDir, CURSOR_SUBAGENTS_PATH, 'reviewer.md')),
+    ).resolves.toBeUndefined();
+    await expect(
+      fs.access(path.join(tmpDir, CODEX_SUBAGENTS_PATH, 'reviewer.toml')),
+    ).resolves.toBeUndefined();
+    await expect(
+      fs.access(path.join(tmpDir, COPILOT_SUBAGENTS_PATH, 'reviewer.md')),
+    ).resolves.toBeUndefined();
+  });
+
+  it('respects subagentsEnabled=false (CLI override) and skips propagation', async () => {
+    await setupRulerProject(tmpDir);
+    await writeSubagent(tmpDir, 'reviewer');
+
+    await applyAllAgentConfigs(
+      tmpDir,
+      ['claude'],
+      undefined,
+      false,
+      undefined,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      undefined,
+      undefined,
+      false, // subagentsEnabled
+    );
+
+    await expect(
+      fs.access(path.join(tmpDir, CLAUDE_SUBAGENTS_PATH)),
+    ).rejects.toThrow();
+  });
+
+  it('cleans up existing target directories when subagentsEnabled=false', async () => {
+    await setupRulerProject(tmpDir);
+    await writeSubagent(tmpDir, 'reviewer');
+
+    // First run: enabled
+    await applyAllAgentConfigs(
+      tmpDir,
+      ['claude', 'cursor'],
+      undefined,
+      false,
+      undefined,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      undefined,
+      undefined,
+      true,
+    );
+    await expect(
+      fs.access(path.join(tmpDir, CLAUDE_SUBAGENTS_PATH, 'reviewer.md')),
+    ).resolves.toBeUndefined();
+
+    // Second run: disabled — directories should be removed
+    await applyAllAgentConfigs(
+      tmpDir,
+      ['claude', 'cursor'],
+      undefined,
+      false,
+      undefined,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      undefined,
+      undefined,
+      false,
+    );
+    await expect(
+      fs.access(path.join(tmpDir, CLAUDE_SUBAGENTS_PATH)),
+    ).rejects.toThrow();
+    await expect(
+      fs.access(path.join(tmpDir, CURSOR_SUBAGENTS_PATH)),
+    ).rejects.toThrow();
+  });
+
+  it('respects [subagents] enabled = false in ruler.toml', async () => {
+    await setupRulerProject(tmpDir);
+    await writeSubagent(tmpDir, 'reviewer');
+    await fs.writeFile(
+      path.join(tmpDir, '.ruler', 'ruler.toml'),
+      '[subagents]\nenabled = false\n',
+    );
+
+    await applyAllAgentConfigs(
+      tmpDir,
+      ['claude'],
+      undefined,
+      false,
+      undefined,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      undefined,
+      undefined,
+      undefined, // CLI not set: TOML wins
+    );
+
+    await expect(
+      fs.access(path.join(tmpDir, CLAUDE_SUBAGENTS_PATH)),
+    ).rejects.toThrow();
+  });
+
+  it('CLI flag overrides TOML setting', async () => {
+    await setupRulerProject(tmpDir);
+    await writeSubagent(tmpDir, 'reviewer');
+    await fs.writeFile(
+      path.join(tmpDir, '.ruler', 'ruler.toml'),
+      '[subagents]\nenabled = false\n',
+    );
+
+    await applyAllAgentConfigs(
+      tmpDir,
+      ['claude'],
+      undefined,
+      false,
+      undefined,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      undefined,
+      undefined,
+      true, // CLI override
+    );
+
+    await expect(
+      fs.access(path.join(tmpDir, CLAUDE_SUBAGENTS_PATH, 'reviewer.md')),
+    ).resolves.toBeUndefined();
+  });
+
+  it('skips non-supporting agents with a warning, still writes for supporting ones', async () => {
+    await setupRulerProject(tmpDir);
+    await writeSubagent(tmpDir, 'reviewer');
+
+    await applyAllAgentConfigs(
+      tmpDir,
+      ['claude', 'aider'], // aider does not support native subagents
+      undefined,
+      false,
+      undefined,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      undefined,
+      undefined,
+      true,
+    );
+
+    await expect(
+      fs.access(path.join(tmpDir, CLAUDE_SUBAGENTS_PATH, 'reviewer.md')),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/tests/subagents-cli.test.ts
+++ b/tests/subagents-cli.test.ts
@@ -216,6 +216,120 @@ describe('Subagents apply integration', () => {
     ).resolves.toBeUndefined();
   });
 
+  it('removes target directories that drop out of the selected agent set', async () => {
+    await setupRulerProject(tmpDir);
+    await writeSubagent(tmpDir, 'reviewer');
+
+    // First run: claude + cursor selected — both targets get written.
+    await applyAllAgentConfigs(
+      tmpDir,
+      ['claude', 'cursor'],
+      undefined,
+      false,
+      undefined,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      undefined,
+      undefined,
+      true,
+    );
+    await expect(
+      fs.access(path.join(tmpDir, CLAUDE_SUBAGENTS_PATH, 'reviewer.md')),
+    ).resolves.toBeUndefined();
+    await expect(
+      fs.access(path.join(tmpDir, CURSOR_SUBAGENTS_PATH, 'reviewer.md')),
+    ).resolves.toBeUndefined();
+
+    // Second run: only claude — cursor's target dir must be cleaned up.
+    await applyAllAgentConfigs(
+      tmpDir,
+      ['claude'],
+      undefined,
+      false,
+      undefined,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      undefined,
+      undefined,
+      true,
+    );
+    await expect(
+      fs.access(path.join(tmpDir, CLAUDE_SUBAGENTS_PATH, 'reviewer.md')),
+    ).resolves.toBeUndefined();
+    await expect(
+      fs.access(path.join(tmpDir, CURSOR_SUBAGENTS_PATH)),
+    ).rejects.toThrow();
+  });
+
+  it('cleans up all target directories when source .ruler/agents is removed', async () => {
+    await setupRulerProject(tmpDir);
+    await writeSubagent(tmpDir, 'reviewer');
+
+    await applyAllAgentConfigs(
+      tmpDir,
+      ['claude', 'cursor', 'codex', 'copilot'],
+      undefined,
+      false,
+      undefined,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      undefined,
+      undefined,
+      true,
+    );
+    await expect(
+      fs.access(path.join(tmpDir, CLAUDE_SUBAGENTS_PATH, 'reviewer.md')),
+    ).resolves.toBeUndefined();
+
+    // Remove source dir, then re-apply. All target dirs should be cleaned up.
+    await fs.rm(path.join(tmpDir, RULER_SUBAGENTS_PATH), {
+      recursive: true,
+      force: true,
+    });
+
+    await applyAllAgentConfigs(
+      tmpDir,
+      ['claude', 'cursor', 'codex', 'copilot'],
+      undefined,
+      false,
+      undefined,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      undefined,
+      undefined,
+      true,
+    );
+
+    await expect(
+      fs.access(path.join(tmpDir, CLAUDE_SUBAGENTS_PATH)),
+    ).rejects.toThrow();
+    await expect(
+      fs.access(path.join(tmpDir, CURSOR_SUBAGENTS_PATH)),
+    ).rejects.toThrow();
+    await expect(
+      fs.access(path.join(tmpDir, CODEX_SUBAGENTS_PATH)),
+    ).rejects.toThrow();
+    await expect(
+      fs.access(path.join(tmpDir, COPILOT_SUBAGENTS_PATH)),
+    ).rejects.toThrow();
+  });
+
   it('skips non-supporting agents with a warning, still writes for supporting ones', async () => {
     await setupRulerProject(tmpDir);
     await writeSubagent(tmpDir, 'reviewer');

--- a/tests/subagents-discovery.test.ts
+++ b/tests/subagents-discovery.test.ts
@@ -146,6 +146,25 @@ body
     expect(result.warnings.length).toBeGreaterThan(0);
   });
 
+  it('warns and skips files with malformed YAML frontmatter without aborting discovery', async () => {
+    // Malformed: tools value is an unterminated YAML flow sequence
+    await writeAgent(
+      'broken',
+      `---\nname: broken\ndescription: bad yaml\ntools: [Read,\n---\nbody\n`,
+    );
+    // A valid sibling — discovery must keep going and surface this one.
+    await writeAgent(
+      'good',
+      `---\nname: good\ndescription: ok\n---\nbody\n`,
+    );
+
+    const result = await discoverSubagents(tmpDir);
+    expect(result.subagents).toHaveLength(1);
+    expect(result.subagents[0].name).toBe('good');
+    expect(result.warnings.length).toBeGreaterThan(0);
+    expect(result.warnings.some((w) => /broken/.test(w))).toBe(true);
+  });
+
   it('ignores non-.md files', async () => {
     const dir = path.join(tmpDir, RULER_SUBAGENTS_PATH);
     await fs.mkdir(dir, { recursive: true });

--- a/tests/subagents-discovery.test.ts
+++ b/tests/subagents-discovery.test.ts
@@ -1,0 +1,158 @@
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import { discoverSubagents } from '../src/core/SubagentsProcessor';
+import { RULER_SUBAGENTS_PATH } from '../src/constants';
+
+describe('Subagents discovery', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ruler-subagents-test-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  async function writeAgent(name: string, content: string): Promise<void> {
+    const dir = path.join(tmpDir, RULER_SUBAGENTS_PATH);
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, `${name}.md`), content);
+  }
+
+  it('returns empty list when .ruler/agents/ does not exist', async () => {
+    const result = await discoverSubagents(tmpDir);
+    expect(result.subagents).toHaveLength(0);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('returns empty list when .ruler/agents/ is empty', async () => {
+    await fs.mkdir(path.join(tmpDir, RULER_SUBAGENTS_PATH), { recursive: true });
+    const result = await discoverSubagents(tmpDir);
+    expect(result.subagents).toHaveLength(0);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('discovers a valid subagent with full frontmatter', async () => {
+    await writeAgent(
+      'code-reviewer',
+      `---
+name: code-reviewer
+description: Reviews code for quality
+tools: [Read, Grep, Glob]
+model: inherit
+readonly: true
+is_background: false
+---
+
+You are a code reviewer.
+`,
+    );
+
+    const result = await discoverSubagents(tmpDir);
+
+    expect(result.warnings).toHaveLength(0);
+    expect(result.subagents).toHaveLength(1);
+    const agent = result.subagents[0];
+    expect(agent.valid).toBe(true);
+    expect(agent.name).toBe('code-reviewer');
+    expect(agent.frontmatter?.description).toBe('Reviews code for quality');
+    expect(agent.frontmatter?.tools).toEqual(['Read', 'Grep', 'Glob']);
+    expect(agent.frontmatter?.model).toBe('inherit');
+    expect(agent.frontmatter?.readonly).toBe(true);
+    expect(agent.frontmatter?.is_background).toBe(false);
+    expect(agent.body?.trim()).toBe('You are a code reviewer.');
+  });
+
+  it('discovers multiple subagents', async () => {
+    await writeAgent(
+      'reviewer',
+      `---
+name: reviewer
+description: Reviews
+---
+Body 1
+`,
+    );
+    await writeAgent(
+      'tester',
+      `---
+name: tester
+description: Tests
+---
+Body 2
+`,
+    );
+
+    const result = await discoverSubagents(tmpDir);
+    expect(result.subagents).toHaveLength(2);
+    expect(result.subagents.every((s) => s.valid)).toBe(true);
+  });
+
+  it('warns and skips files without frontmatter', async () => {
+    await writeAgent('plain', '# Just a heading, no frontmatter');
+
+    const result = await discoverSubagents(tmpDir);
+    expect(result.subagents).toHaveLength(0);
+    expect(result.warnings.length).toBeGreaterThan(0);
+    expect(result.warnings[0]).toMatch(/plain/);
+  });
+
+  it('warns and skips files where name does not match filename', async () => {
+    await writeAgent(
+      'mismatch',
+      `---
+name: different-name
+description: x
+---
+body
+`,
+    );
+
+    const result = await discoverSubagents(tmpDir);
+    expect(result.subagents).toHaveLength(0);
+    expect(result.warnings.length).toBeGreaterThan(0);
+    expect(result.warnings[0]).toMatch(/mismatch/);
+  });
+
+  it('warns and skips files missing required name field', async () => {
+    await writeAgent(
+      'noname',
+      `---
+description: missing name
+---
+body
+`,
+    );
+
+    const result = await discoverSubagents(tmpDir);
+    expect(result.subagents).toHaveLength(0);
+    expect(result.warnings.length).toBeGreaterThan(0);
+  });
+
+  it('warns and skips files missing required description field', async () => {
+    await writeAgent(
+      'nodesc',
+      `---
+name: nodesc
+---
+body
+`,
+    );
+
+    const result = await discoverSubagents(tmpDir);
+    expect(result.subagents).toHaveLength(0);
+    expect(result.warnings.length).toBeGreaterThan(0);
+  });
+
+  it('ignores non-.md files', async () => {
+    const dir = path.join(tmpDir, RULER_SUBAGENTS_PATH);
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, 'README.txt'), 'not an agent');
+
+    const result = await discoverSubagents(tmpDir);
+    expect(result.subagents).toHaveLength(0);
+    expect(result.warnings).toHaveLength(0);
+  });
+});

--- a/tests/subagents-propagation.test.ts
+++ b/tests/subagents-propagation.test.ts
@@ -1,0 +1,302 @@
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as yaml from 'js-yaml';
+import { parse as parseTOML } from '@iarna/toml';
+import {
+  propagateSubagentsForClaude,
+  propagateSubagentsForCursor,
+  propagateSubagentsForCodex,
+  propagateSubagentsForCopilot,
+} from '../src/core/SubagentsProcessor';
+import {
+  CLAUDE_SUBAGENTS_PATH,
+  CURSOR_SUBAGENTS_PATH,
+  CODEX_SUBAGENTS_PATH,
+  COPILOT_SUBAGENTS_PATH,
+} from '../src/constants';
+import type { SubagentInfo } from '../src/types';
+
+function makeSubagent(overrides: Partial<SubagentInfo> = {}): SubagentInfo {
+  return {
+    name: 'reviewer',
+    path: '/virtual/reviewer.md',
+    valid: true,
+    frontmatter: {
+      name: 'reviewer',
+      description: 'Reviews code',
+      ...(overrides.frontmatter ?? {}),
+    },
+    body: 'You review code.\n',
+    ...overrides,
+  };
+}
+
+function readFrontmatter(content: string): {
+  meta: Record<string, unknown>;
+  body: string;
+} {
+  const match = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/.exec(content);
+  if (!match) {
+    throw new Error(`No frontmatter found in:\n${content}`);
+  }
+  const meta = yaml.load(match[1]) as Record<string, unknown>;
+  return { meta, body: match[2] };
+}
+
+describe('Subagents per-agent propagators', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ruler-subagents-prop-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('Claude propagator', () => {
+    it('writes a passthrough markdown file with original frontmatter', async () => {
+      const sub = makeSubagent({
+        frontmatter: {
+          name: 'reviewer',
+          description: 'Reviews code',
+          tools: ['Read', 'Grep'],
+          model: 'inherit',
+          readonly: true,
+          is_background: false,
+        },
+      });
+
+      await propagateSubagentsForClaude(tmpDir, [sub], { dryRun: false });
+
+      const target = path.join(tmpDir, CLAUDE_SUBAGENTS_PATH, 'reviewer.md');
+      const content = await fs.readFile(target, 'utf8');
+      const { meta, body } = readFrontmatter(content);
+
+      expect(meta.name).toBe('reviewer');
+      expect(meta.description).toBe('Reviews code');
+      expect(meta.tools).toEqual(['Read', 'Grep']);
+      expect(meta.model).toBe('inherit');
+      expect(meta.readonly).toBeUndefined();
+      expect(meta.is_background).toBeUndefined();
+      expect(body.trim()).toBe('You review code.');
+    });
+
+    it('omits optional fields when absent in source', async () => {
+      const sub = makeSubagent();
+      await propagateSubagentsForClaude(tmpDir, [sub], { dryRun: false });
+      const target = path.join(tmpDir, CLAUDE_SUBAGENTS_PATH, 'reviewer.md');
+      const content = await fs.readFile(target, 'utf8');
+      const { meta } = readFrontmatter(content);
+      expect(meta.tools).toBeUndefined();
+      expect(meta.model).toBeUndefined();
+    });
+
+    it('does not write files in dry-run mode', async () => {
+      const sub = makeSubagent();
+      await propagateSubagentsForClaude(tmpDir, [sub], { dryRun: true });
+      await expect(
+        fs.access(path.join(tmpDir, CLAUDE_SUBAGENTS_PATH)),
+      ).rejects.toThrow();
+    });
+
+    it('replaces existing target directory atomically', async () => {
+      // First write
+      await propagateSubagentsForClaude(
+        tmpDir,
+        [makeSubagent({ name: 'old', frontmatter: { name: 'old', description: 'old' }, path: '/v/old.md' })],
+        { dryRun: false },
+      );
+      const oldTarget = path.join(tmpDir, CLAUDE_SUBAGENTS_PATH, 'old.md');
+      await expect(fs.access(oldTarget)).resolves.toBeUndefined();
+
+      // Second write replaces
+      await propagateSubagentsForClaude(tmpDir, [makeSubagent()], {
+        dryRun: false,
+      });
+      await expect(fs.access(oldTarget)).rejects.toThrow();
+      await expect(
+        fs.access(path.join(tmpDir, CLAUDE_SUBAGENTS_PATH, 'reviewer.md')),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('Cursor propagator', () => {
+    it('drops tools and applies defaults for absent fields', async () => {
+      const sub = makeSubagent({
+        frontmatter: {
+          name: 'reviewer',
+          description: 'Reviews code',
+          tools: ['Read', 'Grep'],
+        },
+      });
+
+      await propagateSubagentsForCursor(tmpDir, [sub], { dryRun: false });
+      const target = path.join(tmpDir, CURSOR_SUBAGENTS_PATH, 'reviewer.md');
+      const content = await fs.readFile(target, 'utf8');
+      const { meta, body } = readFrontmatter(content);
+
+      expect(meta.tools).toBeUndefined();
+      expect(meta.name).toBe('reviewer');
+      expect(meta.description).toBe('Reviews code');
+      expect(meta.model).toBe('inherit');
+      expect(meta.readonly).toBe(false);
+      expect(meta.is_background).toBe(false);
+      expect(body.trim()).toBe('You review code.');
+    });
+
+    it('passes readonly: true through verbatim', async () => {
+      const sub = makeSubagent({
+        frontmatter: {
+          name: 'reviewer',
+          description: 'Reviews code',
+          readonly: true,
+        },
+      });
+      await propagateSubagentsForCursor(tmpDir, [sub], { dryRun: false });
+      const content = await fs.readFile(
+        path.join(tmpDir, CURSOR_SUBAGENTS_PATH, 'reviewer.md'),
+        'utf8',
+      );
+      const { meta } = readFrontmatter(content);
+      expect(meta.readonly).toBe(true);
+    });
+  });
+
+  describe('Codex propagator', () => {
+    it('writes a self-contained TOML file with required fields', async () => {
+      const sub = makeSubagent({
+        frontmatter: {
+          name: 'reviewer',
+          description: 'Reviews code',
+          model: 'gpt-5',
+          readonly: true,
+        },
+      });
+      await propagateSubagentsForCodex(tmpDir, [sub], { dryRun: false });
+
+      const target = path.join(tmpDir, CODEX_SUBAGENTS_PATH, 'reviewer.toml');
+      const raw = await fs.readFile(target, 'utf8');
+      const parsed = parseTOML(raw) as Record<string, unknown>;
+
+      expect(parsed.name).toBe('reviewer');
+      expect(parsed.description).toBe('Reviews code');
+      expect(parsed.developer_instructions).toContain('You review code.');
+      expect(parsed.model).toBe('gpt-5');
+      expect(parsed.sandbox_mode).toBe('read-only');
+    });
+
+    it('omits model when set to inherit', async () => {
+      const sub = makeSubagent({
+        frontmatter: {
+          name: 'reviewer',
+          description: 'Reviews code',
+          model: 'inherit',
+        },
+      });
+      await propagateSubagentsForCodex(tmpDir, [sub], { dryRun: false });
+      const raw = await fs.readFile(
+        path.join(tmpDir, CODEX_SUBAGENTS_PATH, 'reviewer.toml'),
+        'utf8',
+      );
+      const parsed = parseTOML(raw) as Record<string, unknown>;
+      expect(parsed.model).toBeUndefined();
+    });
+
+    it('omits sandbox_mode when readonly is not set', async () => {
+      const sub = makeSubagent();
+      await propagateSubagentsForCodex(tmpDir, [sub], { dryRun: false });
+      const raw = await fs.readFile(
+        path.join(tmpDir, CODEX_SUBAGENTS_PATH, 'reviewer.toml'),
+        'utf8',
+      );
+      const parsed = parseTOML(raw) as Record<string, unknown>;
+      expect(parsed.sandbox_mode).toBeUndefined();
+    });
+
+    it('preserves multiline body content through TOML round-trip', async () => {
+      const body = 'Line 1\nLine 2 with "quotes"\nLine 3 with \\backslash\n';
+      const sub = makeSubagent({ body });
+      await propagateSubagentsForCodex(tmpDir, [sub], { dryRun: false });
+      const raw = await fs.readFile(
+        path.join(tmpDir, CODEX_SUBAGENTS_PATH, 'reviewer.toml'),
+        'utf8',
+      );
+      const parsed = parseTOML(raw) as Record<string, unknown>;
+      expect(parsed.developer_instructions).toBe(body);
+    });
+  });
+
+  describe('Copilot propagator', () => {
+    it('maps Claude tools to Copilot aliases and dedupes', async () => {
+      const sub = makeSubagent({
+        frontmatter: {
+          name: 'reviewer',
+          description: 'Reviews code',
+          tools: ['Read', 'Grep', 'Glob', 'Bash'],
+        },
+      });
+
+      await propagateSubagentsForCopilot(tmpDir, [sub], { dryRun: false });
+
+      const target = path.join(tmpDir, COPILOT_SUBAGENTS_PATH, 'reviewer.md');
+      const content = await fs.readFile(target, 'utf8');
+      const { meta } = readFrontmatter(content);
+
+      expect(Array.isArray(meta.tools)).toBe(true);
+      const tools = meta.tools as string[];
+      // Read→read, Grep→search, Glob→search (deduped), Bash→execute
+      expect(tools).toContain('read');
+      expect(tools).toContain('search');
+      expect(tools).toContain('execute');
+      expect(tools.filter((t) => t === 'search')).toHaveLength(1);
+    });
+
+    it('derives disable-model-invocation from readonly: true', async () => {
+      const sub = makeSubagent({
+        frontmatter: {
+          name: 'reviewer',
+          description: 'Reviews code',
+          readonly: true,
+        },
+      });
+      await propagateSubagentsForCopilot(tmpDir, [sub], { dryRun: false });
+      const content = await fs.readFile(
+        path.join(tmpDir, COPILOT_SUBAGENTS_PATH, 'reviewer.md'),
+        'utf8',
+      );
+      const { meta } = readFrontmatter(content);
+      expect(meta['disable-model-invocation']).toBe(true);
+      expect(meta['user-invocable']).toBe(true);
+    });
+
+    it('omits tools when source has none', async () => {
+      const sub = makeSubagent();
+      await propagateSubagentsForCopilot(tmpDir, [sub], { dryRun: false });
+      const content = await fs.readFile(
+        path.join(tmpDir, COPILOT_SUBAGENTS_PATH, 'reviewer.md'),
+        'utf8',
+      );
+      const { meta } = readFrontmatter(content);
+      expect(meta.tools).toBeUndefined();
+    });
+
+    it('omits model when source uses inherit', async () => {
+      const sub = makeSubagent({
+        frontmatter: {
+          name: 'reviewer',
+          description: 'Reviews code',
+          model: 'inherit',
+        },
+      });
+      await propagateSubagentsForCopilot(tmpDir, [sub], { dryRun: false });
+      const content = await fs.readFile(
+        path.join(tmpDir, COPILOT_SUBAGENTS_PATH, 'reviewer.md'),
+        'utf8',
+      );
+      const { meta } = readFrontmatter(content);
+      expect(meta.model).toBeUndefined();
+    });
+  });
+});

--- a/tests/subagents-propagation.test.ts
+++ b/tests/subagents-propagation.test.ts
@@ -298,5 +298,55 @@ describe('Subagents per-agent propagators', () => {
       const { meta } = readFrontmatter(content);
       expect(meta.model).toBeUndefined();
     });
+
+    describe('unmapped-tool warnings', () => {
+      const subWithUnknownTool = makeSubagent({
+        frontmatter: {
+          name: 'reviewer',
+          description: 'Reviews code',
+          tools: ['Read', 'NotARealTool'],
+        },
+      });
+
+      it('stays silent on a normal apply (no verbose, no dry-run)', async () => {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+        try {
+          await propagateSubagentsForCopilot(tmpDir, [subWithUnknownTool], {
+            dryRun: false,
+          });
+          const calls = warnSpy.mock.calls.flat().join('\n');
+          expect(calls).not.toMatch(/NotARealTool/);
+        } finally {
+          warnSpy.mockRestore();
+        }
+      });
+
+      it('emits the warning when verbose is enabled', async () => {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+        try {
+          await propagateSubagentsForCopilot(tmpDir, [subWithUnknownTool], {
+            dryRun: false,
+            verbose: true,
+          });
+          const calls = warnSpy.mock.calls.flat().join('\n');
+          expect(calls).toMatch(/NotARealTool/);
+        } finally {
+          warnSpy.mockRestore();
+        }
+      });
+
+      it('emits the warning during dry-run regardless of verbose', async () => {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+        try {
+          await propagateSubagentsForCopilot(tmpDir, [subWithUnknownTool], {
+            dryRun: true,
+          });
+          const calls = warnSpy.mock.calls.flat().join('\n');
+          expect(calls).toMatch(/NotARealTool/);
+        } finally {
+          warnSpy.mockRestore();
+        }
+      });
+    });
   });
 });

--- a/tests/subagents-propagation.test.ts
+++ b/tests/subagents-propagation.test.ts
@@ -56,7 +56,7 @@ describe('Subagents per-agent propagators', () => {
   });
 
   describe('Claude propagator', () => {
-    it('writes a passthrough markdown file with original frontmatter', async () => {
+    it('writes a passthrough markdown file preserving all source frontmatter', async () => {
       const sub = makeSubagent({
         frontmatter: {
           name: 'reviewer',
@@ -78,8 +78,8 @@ describe('Subagents per-agent propagators', () => {
       expect(meta.description).toBe('Reviews code');
       expect(meta.tools).toEqual(['Read', 'Grep']);
       expect(meta.model).toBe('inherit');
-      expect(meta.readonly).toBeUndefined();
-      expect(meta.is_background).toBeUndefined();
+      expect(meta.readonly).toBe(true);
+      expect(meta.is_background).toBe(false);
       expect(body.trim()).toBe('You review code.');
     });
 

--- a/tests/unit/cli/handlers.test.ts
+++ b/tests/unit/cli/handlers.test.ts
@@ -67,6 +67,7 @@ describe('CLI Handlers', () => {
         true,
         undefined,
         undefined,
+        undefined,
       );
     });
 
@@ -96,6 +97,7 @@ describe('CLI Handlers', () => {
         false,
         false,
         true,
+        undefined,
         undefined,
         undefined,
       );
@@ -130,6 +132,7 @@ describe('CLI Handlers', () => {
         true,
         undefined,
         undefined,
+        undefined,
       );
     });
 
@@ -159,6 +162,7 @@ describe('CLI Handlers', () => {
         false,
         false,
         true,
+        undefined,
         undefined,
         undefined,
       );
@@ -193,6 +197,7 @@ describe('CLI Handlers', () => {
         true,
         undefined,
         true,
+        undefined,
       );
     });
 
@@ -222,6 +227,7 @@ describe('CLI Handlers', () => {
         false,
         true, // nested should be true from CLI
         true,
+        undefined,
         undefined,
         undefined,
       );
@@ -270,6 +276,7 @@ describe('CLI Handlers', () => {
         true,
         undefined,
         undefined,
+        undefined,
       );
     });
 
@@ -308,6 +315,7 @@ describe('CLI Handlers', () => {
         false,
         false, // nested should default to false
         true,
+        undefined,
         undefined,
         undefined,
       );
@@ -350,6 +358,7 @@ describe('CLI Handlers', () => {
         false,
         true, // nested should be true from CLI, ignoring TOML
         true,
+        undefined,
         undefined,
         undefined,
       );


### PR DESCRIPTION
## What

Adds subagent propagation, mirroring the existing skills propagation feature.

Source format lives in `.ruler/agents/<name>.md` with YAML frontmatter. Ruler discovers these files and propagates them to the four agents that have shipped native subagent primitives:

- Claude Code → `.claude/agents/<name>.md`
- Cursor → `.cursor/agents/<name>.md`
- OpenAI Codex CLI → `.codex/agents/<name>.toml` (one self-contained TOML file per agent)
- GitHub Copilot → `.github/agents/<name>.md`

Other agents (Windsurf, RooCode, Aider, Gemini CLI, etc.) do not yet have a comparable native subagent primitive and are skipped with a warning. Propagation will be added when those agents ship a comparable file format.

## Why

Subagents are now first-class in all four agents above. Users running multi-agent workflows currently maintain four parallel copies of each subagent definition. This brings subagents under Ruler's single-source-of-truth model, the same way skills are.

## Design notes

- Mirrors `SkillsProcessor.ts` end-to-end: atomic temp-dir + rename writes, once-per-process experimental warning, single dispatcher selecting per-agent propagators.
- No `revert.ts` changes — cleanup happens on `[subagents] enabled = false` (or `--no-subagents`), matching skills' current behavior. Happy to add explicit revert support in a follow-up if desired.
- No new runtime dependencies; uses existing `js-yaml` and `@iarna/toml`.
- **Codex:** each subagent is one self-contained `.codex/agents/<name>.toml` file (per the Codex CLI subagents documentation — `developer_instructions` is required and inline). No merging into `config.toml`.
- **Copilot:** source `tools` (Claude vocabulary like `Read`, `Grep`, `Bash`) are mapped to Copilot's tool aliases (`read`, `search`, `execute`, ...). Tools that do not have a Copilot equivalent are dropped with a `--verbose` warning.
- **Cursor:** `readonly` is taken verbatim from source. No inference from tools list (explicit > magic).

## How verified

- 36 new unit + integration tests covering discovery, per-agent transformers, orchestrator, CLI flags, and TOML config (132 suites, 841 tests total — 805 baseline + 36 new, all green).
- `npm run lint` passes with no warnings.
- `npm run build` produces no errors.
- Manual smoke test in a scratch project confirmed all four target shapes are correct and `--no-subagents` cleans them up.

## Risk

- Marked **experimental** in README, same as skills — behavior may change.
- No changes to existing skills, MCP, or instruction-concatenation features.

## Out of scope (future work)

- Subagent support for additional agents pending native primitives.
- Explicit `ruler revert` integration for subagents (see Design notes).
- Cross-agent subagent translation beyond the four listed.
 