### PR TITLE
Prioritize exact agent identifiers over fuzzy matches

### DIFF
--- a/src/core/agent-selection.ts
+++ b/src/core/agent-selection.ts
@@ -2,6 +2,21 @@ import { IAgent } from '../agents/IAgent';
 import { LoadedConfig } from './ConfigLoader';
 import { createRulerError } from '../constants';
 
+export function agentMatchesFilter(
+  agent: IAgent,
+  filter: string,
+  validAgentIdentifiers: Set<string>,
+): boolean {
+  const identifier = agent.getIdentifier().toLowerCase();
+
+  // Exact identifier matches take precedence over fuzzy display-name matching.
+  if (validAgentIdentifiers.has(filter)) {
+    return identifier === filter;
+  }
+
+  return agent.getName().toLowerCase().includes(filter);
+}
+
 /**
  * Resolves which agents should be selected based on configuration.
  * Handles precedence: CLI agents > default_agents > per-agent enabled flags > all agents
@@ -42,11 +57,7 @@ export function resolveSelectedAgents(
     }
 
     selected = allAgents.filter((agent) =>
-      filters.some(
-        (f) =>
-          agent.getIdentifier() === f ||
-          agent.getName().toLowerCase().includes(f),
-      ),
+      filters.some((f) => agentMatchesFilter(agent, f, validAgentIdentifiers)),
     );
   } else if (config.defaultAgents && config.defaultAgents.length > 0) {
     const defaults = config.defaultAgents.map((n) => n.toLowerCase());
@@ -78,8 +89,8 @@ export function resolveSelectedAgents(
       if (override !== undefined) {
         return override;
       }
-      return defaults.some(
-        (d) => identifier === d || agent.getName().toLowerCase().includes(d),
+      return defaults.some((d) =>
+        agentMatchesFilter(agent, d, validAgentIdentifiers),
       );
     });
   } else {

--- a/src/core/config-utils.ts
+++ b/src/core/config-utils.ts
@@ -20,13 +20,21 @@ export function mapRawAgentConfigs(
 
   for (const [key, cfg] of Object.entries(raw)) {
     const lowerKey = key.toLowerCase();
+    const exactMatches = agents.filter(
+      (agent) => agent.getIdentifier().toLowerCase() === lowerKey,
+    );
+
+    // Exact identifier matches take precedence over fuzzy display-name matching.
+    if (exactMatches.length > 0) {
+      for (const agent of exactMatches) {
+        mappedConfigs[agent.getIdentifier()] = cfg;
+      }
+      continue;
+    }
+
     for (const agent of agents) {
       const identifier = agent.getIdentifier();
-      // Exact match with identifier or substring match with display name for backwards compatibility
-      if (
-        identifier === lowerKey ||
-        agent.getName().toLowerCase().includes(lowerKey)
-      ) {
+      if (agent.getName().toLowerCase().includes(lowerKey)) {
         mappedConfigs[identifier] = cfg;
       }
     }

--- a/src/revert.ts
+++ b/src/revert.ts
@@ -9,7 +9,10 @@ import {
   revertAgentConfiguration,
   cleanUpAuxiliaryFiles,
 } from './core/revert-engine';
-import { resolveSelectedAgents } from './core/agent-selection';
+import {
+  agentMatchesFilter,
+  resolveSelectedAgents,
+} from './core/agent-selection';
 import { mapRawAgentConfigs } from './core/config-utils';
 
 const agents: IAgent[] = allAgents;
@@ -70,24 +73,27 @@ export async function revertAllAgentConfigs(
       // Fall back to the old logic without validation
       if (config.cliAgents && config.cliAgents.length > 0) {
         const filters = config.cliAgents.map((n) => n.toLowerCase());
+        const validAgentIdentifiers = new Set(
+          agents.map((agent) => agent.getIdentifier()),
+        );
         selected = agents.filter((agent) =>
-          filters.some(
-            (f) =>
-              agent.getIdentifier() === f ||
-              agent.getName().toLowerCase().includes(f),
+          filters.some((f) =>
+            agentMatchesFilter(agent, f, validAgentIdentifiers),
           ),
         );
       } else if (config.defaultAgents && config.defaultAgents.length > 0) {
         const defaults = config.defaultAgents.map((n) => n.toLowerCase());
+        const validAgentIdentifiers = new Set(
+          agents.map((agent) => agent.getIdentifier()),
+        );
         selected = agents.filter((agent) => {
           const identifier = agent.getIdentifier();
           const override = config.agentConfigs[identifier]?.enabled;
           if (override !== undefined) {
             return override;
           }
-          return defaults.some(
-            (d) =>
-              identifier === d || agent.getName().toLowerCase().includes(d),
+          return defaults.some((d) =>
+            agentMatchesFilter(agent, d, validAgentIdentifiers),
           );
         });
       } else {

--- a/tests/unit/core/agent-selection.test.ts
+++ b/tests/unit/core/agent-selection.test.ts
@@ -152,6 +152,21 @@ describe('resolveSelectedAgents', () => {
     expect(result[0].getIdentifier()).toBe('claude');
   });
 
+  it('should prioritize exact CLI identifier matches over fuzzy display name matches', () => {
+    const agents = [
+      new MockAgent('GitHub Copilot', 'copilot'),
+      new MockAgent('Pi Coding Agent', 'pi'),
+    ];
+    const config: LoadedConfig = {
+      cliAgents: ['pi'],
+      agentConfigs: {},
+    };
+
+    const result = resolveSelectedAgents(config, agents);
+
+    expect(result.map(a => a.getIdentifier())).toEqual(['pi']);
+  });
+
   it('should handle partial name matches in default_agents', () => {
     const config: LoadedConfig = {
       defaultAgents: ['code'], // Should match "Claude Code"
@@ -162,6 +177,21 @@ describe('resolveSelectedAgents', () => {
 
     expect(result).toHaveLength(1);
     expect(result[0].getIdentifier()).toBe('claude');
+  });
+
+  it('should prioritize exact default_agents identifier matches over fuzzy display name matches', () => {
+    const agents = [
+      new MockAgent('GitHub Copilot', 'copilot'),
+      new MockAgent('Pi Coding Agent', 'pi'),
+    ];
+    const config: LoadedConfig = {
+      defaultAgents: ['pi'],
+      agentConfigs: {},
+    };
+
+    const result = resolveSelectedAgents(config, agents);
+
+    expect(result.map(a => a.getIdentifier())).toEqual(['pi']);
   });
 
   it('should include agents with explicit enabled=true even when not in default_agents', () => {

--- a/tests/unit/core/config-utils.test.ts
+++ b/tests/unit/core/config-utils.test.ts
@@ -89,6 +89,22 @@ describe('config-utils', () => {
       expect(Object.keys(result)).toContain('claude');
     });
 
+    it('should prioritize exact identifier matches over fuzzy display name matches', () => {
+      const agents = [
+        new MockAgent('copilot', 'GitHub Copilot'),
+        new MockAgent('pi', 'Pi Coding Agent'),
+      ];
+      const rawConfigs = {
+        pi: { enabled: true },
+      };
+
+      const result = mapRawAgentConfigs(rawConfigs, agents);
+
+      expect(result).toEqual({
+        pi: { enabled: true },
+      });
+    });
+
     it('should ignore keys that do not match any agent', () => {
       const rawConfigs = {
         copilot: { enabled: true },


### PR DESCRIPTION
# Summary

`pi` agent identifier was mapping to Github Copilot due to the fuzzy match. Prioritize the exact match over any fuzzy matches.

Supports `default_agents` and `agents.<name>` in config as well as `--agents` flag via CLI.

# Verification

Relevant unit tests that cover the match cases.

Ran ruler on a local repo and confirmed the desired behavior.