### PR TITLE
fix(core): ignore generated dirs in nested discovery [#437]

### DIFF
--- a/src/core/FileSystemUtils.ts
+++ b/src/core/FileSystemUtils.ts
@@ -5,11 +5,30 @@ import { SKILLS_DIR, RULER_SUBAGENTS_PATH } from '../constants';
 
 const SUBAGENTS_DIR_NAME = path.basename(RULER_SUBAGENTS_PATH);
 
+const DEFAULT_NESTED_DISCOVERY_IGNORES = new Set([
+  '__fixtures__',
+  '__generated__',
+  'build',
+  'coverage',
+  'dist',
+  'fixtures',
+  'generated',
+  'node_modules',
+  'temp',
+  'tmp',
+]);
+
 /**
  * Gets the XDG config directory path, falling back to ~/.config if XDG_CONFIG_HOME is not set.
  */
 function getXdgConfigDir(): string {
   return process.env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config');
+}
+
+function shouldSkipNestedDiscoveryDir(dirName: string): boolean {
+  return (
+    dirName.startsWith('.') || DEFAULT_NESTED_DISCOVERY_IGNORES.has(dirName)
+  );
 }
 
 /**
@@ -274,24 +293,21 @@ export async function findAllRulerDirs(startPath: string): Promise<string[]> {
         if (entry.isDirectory()) {
           if (entry.name === '.ruler') {
             rulerDirs.push(fullPath);
-          } else {
-            // Recursively search subdirectories (but skip hidden directories like .git)
-            if (!entry.name.startsWith('.')) {
-              // Do not cross git repository boundaries (except the starting root)
-              const gitDir = path.join(fullPath, '.git');
-              try {
-                const gitStat = await fs.stat(gitDir);
-                if (
-                  gitStat.isDirectory() &&
-                  path.resolve(fullPath) !== rootPath
-                ) {
-                  continue;
-                }
-              } catch {
-                // no .git boundary, continue traversal
+          } else if (!shouldSkipNestedDiscoveryDir(entry.name)) {
+            // Do not cross git repository boundaries (except the starting root)
+            const gitDir = path.join(fullPath, '.git');
+            try {
+              const gitStat = await fs.stat(gitDir);
+              if (
+                gitStat.isDirectory() &&
+                path.resolve(fullPath) !== rootPath
+              ) {
+                continue;
               }
-              await findRulerDirs(fullPath);
+            } catch {
+              // no .git boundary, continue traversal
             }
+            await findRulerDirs(fullPath);
           }
         }
       }

--- a/tests/unit/core/FileSystemUtils.nested.test.ts
+++ b/tests/unit/core/FileSystemUtils.nested.test.ts
@@ -62,5 +62,65 @@ describe('FileSystemUtils - Nested', () => {
         path.join(projectDir, '.ruler'),
       ]);
     });
+
+    it('skips .ruler directories inside generated and fixture directories', async () => {
+      const projectDir = path.join(tmpDir, 'ignored-generated-trees');
+      const moduleDir = path.join(projectDir, 'packages', 'app');
+      const generatedDirs = [
+        'node_modules',
+        'dist',
+        'build',
+        'coverage',
+        'fixtures',
+        '__fixtures__',
+        'tmp',
+        'temp',
+        'generated',
+        '__generated__',
+      ];
+
+      await fs.mkdir(path.join(projectDir, '.ruler'), { recursive: true });
+      await fs.mkdir(path.join(moduleDir, '.ruler'), { recursive: true });
+
+      await Promise.all(
+        generatedDirs.map((dirName) =>
+          fs.mkdir(path.join(projectDir, dirName, 'nested', '.ruler'), {
+            recursive: true,
+          }),
+        ),
+      );
+
+      const rulerDirs = await findAllRulerDirs(projectDir);
+
+      expect(rulerDirs).toEqual([
+        path.join(moduleDir, '.ruler'),
+        path.join(projectDir, '.ruler'),
+      ]);
+    });
+
+    it('still discovers normal nested project directories', async () => {
+      const projectDir = path.join(tmpDir, 'normal-nested-projects');
+      const nestedProjectDirs = [
+        path.join(projectDir, 'apps', 'web'),
+        path.join(projectDir, 'packages', 'core'),
+        path.join(projectDir, 'examples', 'cli'),
+      ];
+
+      await fs.mkdir(path.join(projectDir, '.ruler'), { recursive: true });
+      await Promise.all(
+        nestedProjectDirs.map((nestedProjectDir) =>
+          fs.mkdir(path.join(nestedProjectDir, '.ruler'), { recursive: true }),
+        ),
+      );
+
+      const rulerDirs = await findAllRulerDirs(projectDir);
+
+      expect(rulerDirs).toEqual([
+        path.join(projectDir, 'apps', 'web', '.ruler'),
+        path.join(projectDir, 'examples', 'cli', '.ruler'),
+        path.join(projectDir, 'packages', 'core', '.ruler'),
+        path.join(projectDir, '.ruler'),
+      ]);
+    });
   });
 });


### PR DESCRIPTION
Fixes #437.

## Summary

- Add a default ignore set for generated, fixture, dependency, and temp directories during nested `.ruler` discovery.
- Preserve normal nested project discovery and nested git boundary behavior.
- Add regression coverage for ignored directories and normal nested configs.

## Verification

- npm ci
- npm run lint
- npm test
- npm run build