### PR TITLE
fix(revert): preserve root config toml [#436]

### DIFF
--- a/src/core/revert-engine.ts
+++ b/src/core/revert-engine.ts
@@ -11,6 +11,10 @@ import {
   getVSCodeSettingsPath,
 } from '../vscode/settings';
 
+const ROOT_CONFIG_TOML = 'config.toml';
+const RULER_START_MARKER = '# START Ruler Generated Files';
+const RULER_END_MARKER = '# END Ruler Generated Files';
+
 /**
  * Result of reverting an agent configuration
  */
@@ -38,6 +42,65 @@ async function fileExists(filePath: string): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+function isRootConfigToml(filePath: string, projectRoot: string): boolean {
+  return (
+    path.resolve(filePath) ===
+    path.join(path.resolve(projectRoot), ROOT_CONFIG_TOML)
+  );
+}
+
+async function ignoreFileHasRulerGeneratedPath(
+  ignoreFilePath: string,
+  generatedPath: string,
+): Promise<boolean> {
+  try {
+    const content = await fs.readFile(ignoreFilePath, 'utf8');
+    const lines = content.split('\n');
+    let inRulerBlock = false;
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (trimmed === RULER_START_MARKER) {
+        inRulerBlock = true;
+        continue;
+      }
+      if (trimmed === RULER_END_MARKER) {
+        inRulerBlock = false;
+        continue;
+      }
+      if (
+        inRulerBlock &&
+        (trimmed === generatedPath || trimmed === generatedPath.slice(1))
+      ) {
+        return true;
+      }
+    }
+  } catch {
+    return false;
+  }
+
+  return false;
+}
+
+async function hasRulerGeneratedProvenance(
+  filePath: string,
+  projectRoot: string,
+): Promise<boolean> {
+  const relativePath = `/${path.relative(projectRoot, filePath).replace(/\\/g, '/')}`;
+  const ignoreFiles = [
+    path.join(projectRoot, '.gitignore'),
+    path.join(projectRoot, '.git', 'info', 'exclude'),
+  ];
+
+  for (const ignoreFile of ignoreFiles) {
+    if (await ignoreFileHasRulerGeneratedPath(ignoreFile, relativePath)) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 /**
@@ -75,6 +138,7 @@ async function removeGeneratedFile(
   filePath: string,
   verbose: boolean,
   dryRun: boolean,
+  projectRoot?: string,
 ): Promise<boolean> {
   const fileExistsFlag = await fileExists(filePath);
   const backupExists = await fileExists(`${filePath}.bak`);
@@ -86,6 +150,18 @@ async function removeGeneratedFile(
 
   if (backupExists) {
     logVerbose(`File has backup, skipping removal: ${filePath}`, verbose);
+    return false;
+  }
+
+  if (
+    projectRoot &&
+    isRootConfigToml(filePath, projectRoot) &&
+    !(await hasRulerGeneratedProvenance(filePath, projectRoot))
+  ) {
+    logVerbose(
+      `Preserving root config.toml without backup or Ruler provenance: ${filePath}`,
+      verbose,
+    );
     return false;
   }
 
@@ -336,6 +412,14 @@ async function removeAdditionalAgentFiles(
         if (restored) {
           filesRemoved++;
         }
+      } else if (
+        isRootConfigToml(fullPath, projectRoot) &&
+        !(await hasRulerGeneratedProvenance(fullPath, projectRoot))
+      ) {
+        logVerbose(
+          `Preserving root config.toml without backup or Ruler provenance: ${fullPath}`,
+          verbose,
+        );
       } else {
         if (dryRun) {
           logVerbose(
@@ -470,7 +554,12 @@ export async function revertAgentConfiguration(
         }
       }
     } else {
-      const removed = await removeGeneratedFile(outputPath, verbose, dryRun);
+      const removed = await removeGeneratedFile(
+        outputPath,
+        verbose,
+        dryRun,
+        projectRoot,
+      );
       if (removed) {
         result.removed++;
       }
@@ -504,7 +593,12 @@ export async function revertAgentConfiguration(
           }
         }
       } else {
-        const mcpRemoved = await removeGeneratedFile(mcpPath, verbose, dryRun);
+        const mcpRemoved = await removeGeneratedFile(
+          mcpPath,
+          verbose,
+          dryRun,
+          projectRoot,
+        );
         if (mcpRemoved) {
           result.removed++;
         }

--- a/tests/unit/core/revert-engine.test.ts
+++ b/tests/unit/core/revert-engine.test.ts
@@ -42,6 +42,16 @@ class MockAgent implements IAgent {
   }
 }
 
+class MockOpenHandsAgent extends MockAgent {
+  constructor() {
+    super('Open Hands', 'openhands');
+  }
+
+  getDefaultOutputPath(projectRoot: string): string {
+    return path.join(projectRoot, '.openhands', 'microagents', 'repo.md');
+  }
+}
+
 describe('revert-engine', () => {
   let tmpDir: string;
 
@@ -70,7 +80,7 @@ describe('revert-engine', () => {
         undefined,
         false,
         false,
-        false
+        false,
       );
 
       expect(result.restored).toBe(1);
@@ -82,7 +92,10 @@ describe('revert-engine', () => {
       expect(restoredContent).toBe('backup content');
 
       // Check that backup was removed
-      const backupExists = await fs.access(backupPath).then(() => true).catch(() => false);
+      const backupExists = await fs
+        .access(backupPath)
+        .then(() => true)
+        .catch(() => false);
       expect(backupExists).toBe(false);
     });
 
@@ -100,7 +113,7 @@ describe('revert-engine', () => {
         undefined,
         false,
         false,
-        false
+        false,
       );
 
       expect(result.restored).toBe(0);
@@ -108,7 +121,10 @@ describe('revert-engine', () => {
       expect(result.backupsRemoved).toBe(0);
 
       // Check that file was removed
-      const fileExists = await fs.access(configPath).then(() => true).catch(() => false);
+      const fileExists = await fs
+        .access(configPath)
+        .then(() => true)
+        .catch(() => false);
       expect(fileExists).toBe(false);
     });
 
@@ -128,7 +144,7 @@ describe('revert-engine', () => {
         undefined,
         true, // keepBackups
         false,
-        false
+        false,
       );
 
       expect(result.restored).toBe(1);
@@ -136,7 +152,10 @@ describe('revert-engine', () => {
       expect(result.backupsRemoved).toBe(0);
 
       // Check that backup still exists
-      const backupExists = await fs.access(backupPath).then(() => true).catch(() => false);
+      const backupExists = await fs
+        .access(backupPath)
+        .then(() => true)
+        .catch(() => false);
       expect(backupExists).toBe(true);
     });
 
@@ -156,7 +175,7 @@ describe('revert-engine', () => {
         undefined,
         false,
         false,
-        true // dryRun
+        true, // dryRun
       );
 
       expect(result.restored).toBe(1);
@@ -167,7 +186,10 @@ describe('revert-engine', () => {
       const currentContent = await fs.readFile(configPath, 'utf8');
       expect(currentContent).toBe('current content');
 
-      const backupExists = await fs.access(backupPath).then(() => true).catch(() => false);
+      const backupExists = await fs
+        .access(backupPath)
+        .then(() => true)
+        .catch(() => false);
       expect(backupExists).toBe(true);
     });
 
@@ -180,12 +202,65 @@ describe('revert-engine', () => {
         undefined,
         false,
         false,
-        false
+        false,
       );
 
       expect(result.restored).toBe(0);
       expect(result.removed).toBe(0);
       expect(result.backupsRemoved).toBe(0);
+    });
+
+    it('should preserve Open Hands root config.toml when no backup exists', async () => {
+      const agent = new MockOpenHandsAgent();
+      const configPath = path.join(tmpDir, 'config.toml');
+      const originalContent = '[core]\nworkspace_base = "/tmp/project"\n';
+
+      await fs.writeFile(configPath, originalContent);
+
+      const result = await revertAgentConfiguration(
+        agent,
+        tmpDir,
+        undefined,
+        false,
+        false,
+        false,
+      );
+
+      expect(result.restored).toBe(0);
+      expect(result.removed).toBe(0);
+      expect(result.backupsRemoved).toBe(0);
+      await expect(fs.readFile(configPath, 'utf8')).resolves.toBe(
+        originalContent,
+      );
+    });
+
+    it('should restore Open Hands root config.toml from backup when backup exists', async () => {
+      const agent = new MockOpenHandsAgent();
+      const configPath = path.join(tmpDir, 'config.toml');
+      const backupPath = `${configPath}.bak`;
+
+      await fs.writeFile(configPath, '[mcp]\nstdio_servers = []\n');
+      await fs.writeFile(
+        backupPath,
+        '[core]\nworkspace_base = "/tmp/project"\n',
+      );
+
+      const result = await revertAgentConfiguration(
+        agent,
+        tmpDir,
+        undefined,
+        false,
+        false,
+        false,
+      );
+
+      expect(result.restored).toBe(1);
+      expect(result.removed).toBe(0);
+      expect(result.backupsRemoved).toBe(1);
+      await expect(fs.readFile(configPath, 'utf8')).resolves.toBe(
+        '[core]\nworkspace_base = "/tmp/project"\n',
+      );
+      await expect(fs.access(backupPath)).rejects.toThrow();
     });
   });
 
@@ -221,7 +296,10 @@ describe('revert-engine', () => {
       expect(result.additionalFilesRemoved).toBeGreaterThan(0);
 
       // Check that file still exists in dry run
-      const fileExists = await fs.access(mcpFile).then(() => true).catch(() => false);
+      const fileExists = await fs
+        .access(mcpFile)
+        .then(() => true)
+        .catch(() => false);
       expect(fileExists).toBe(true);
     });
 
@@ -230,6 +308,20 @@ describe('revert-engine', () => {
 
       expect(result.additionalFilesRemoved).toBeGreaterThanOrEqual(0);
       expect(result.directoriesRemoved).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should preserve root config.toml during auxiliary cleanup when no backup exists', async () => {
+      const configPath = path.join(tmpDir, 'config.toml');
+      const originalContent = '[core]\nworkspace_base = "/tmp/project"\n';
+
+      await fs.writeFile(configPath, originalContent);
+
+      const result = await cleanUpAuxiliaryFiles(tmpDir, false, false);
+
+      expect(result.additionalFilesRemoved).toBe(0);
+      await expect(fs.readFile(configPath, 'utf8')).resolves.toBe(
+        originalContent,
+      );
     });
   });
 
@@ -240,36 +332,39 @@ describe('revert-engine', () => {
 
     it('should use [ruler:dry-run] prefix when dryRun is true', async () => {
       const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
-      
+
       // Create a test file to trigger removal in removeAdditionalAgentFiles
       const mcpFile = path.join(tmpDir, '.mcp.json');
       await fs.writeFile(mcpFile, '{}');
 
       await cleanUpAuxiliaryFiles(tmpDir, true, true); // verbose=true, dryRun=true
-      
+
       const errorCalls = consoleErrorSpy.mock.calls.flat();
-      const hasRulerDryRunPrefix = errorCalls.some(call => 
-        typeof call === 'string' && call.includes('[ruler:dry-run]')
+      const hasRulerDryRunPrefix = errorCalls.some(
+        (call) => typeof call === 'string' && call.includes('[ruler:dry-run]'),
       );
-      
+
       expect(hasRulerDryRunPrefix).toBe(true);
       consoleErrorSpy.mockRestore();
     });
 
     it('should use [ruler] prefix when dryRun is false', async () => {
       const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
-      
+
       // Create a test file to trigger removal in removeAdditionalAgentFiles
       const mcpFile = path.join(tmpDir, '.mcp.json');
       await fs.writeFile(mcpFile, '{}');
 
       await cleanUpAuxiliaryFiles(tmpDir, true, false); // verbose=true, dryRun=false
-      
+
       const errorCalls = consoleErrorSpy.mock.calls.flat();
-      const hasRulerPrefix = errorCalls.some(call => 
-        typeof call === 'string' && call.includes('[ruler]') && !call.includes('[ruler:dry-run]')
+      const hasRulerPrefix = errorCalls.some(
+        (call) =>
+          typeof call === 'string' &&
+          call.includes('[ruler]') &&
+          !call.includes('[ruler:dry-run]'),
       );
-      
+
       expect(hasRulerPrefix).toBe(true);
       consoleErrorSpy.mockRestore();
     });


### PR DESCRIPTION
Fixes #436.

## Summary

- Preserve root `config.toml` during revert cleanup when there is no backup and no Ruler provenance.
- Preserve Open Hands root MCP config without a backup instead of deleting a generic project config filename.
- Keep backup restoration behavior intact.

## Verification

- npm ci
- npx jest tests/unit/core/revert-engine.test.ts --runInBand
- npm run lint
- npm test
- npm run build
- git diff --check