### PR TITLE
fix(config): fail on invalid config files [#438]

### DIFF
--- a/src/cli/handlers.ts
+++ b/src/cli/handlers.ts
@@ -50,6 +50,31 @@ function assertNotInsideRulerDir(projectRoot: string): void {
   }
 }
 
+function formatCliError(message: string): string {
+  return message.startsWith(ERROR_PREFIX)
+    ? message
+    : `${ERROR_PREFIX} ${message}`;
+}
+
+async function resolveNestedPreference(
+  argv: ApplyArgs,
+  projectRoot: string,
+  configPath: string | undefined,
+): Promise<boolean> {
+  if (argv.nested !== undefined) {
+    // CLI explicitly set nested (either --nested or --no-nested)
+    return argv.nested;
+  }
+
+  // CLI didn't set nested, check TOML configuration
+  const config = await loadConfig({
+    projectRoot,
+    configPath,
+  });
+  // Use TOML setting if available, otherwise default to false
+  return config.nested ?? false;
+}
+
 /**
  * Handler for the 'apply' command.
  */
@@ -84,27 +109,6 @@ export async function applyHandler(argv: ApplyArgs): Promise<void> {
     gitignoreLocalPreference = undefined; // Let TOML/default decide
   }
 
-  // Determine nested preference: CLI > TOML > Default (false)
-  let nested: boolean;
-
-  if (argv.nested !== undefined) {
-    // CLI explicitly set nested (either --nested or --no-nested)
-    nested = argv.nested;
-  } else {
-    // CLI didn't set nested, check TOML configuration
-    try {
-      const config = await loadConfig({
-        projectRoot,
-        configPath,
-      });
-      // Use TOML setting if available, otherwise default to false
-      nested = config.nested ?? false;
-    } catch {
-      // If config loading fails, use default (false)
-      nested = false;
-    }
-  }
-
   // Determine skills preference: CLI > TOML > Default (enabled)
   let skillsEnabled: boolean | undefined;
   if (argv.skills !== undefined) {
@@ -122,6 +126,9 @@ export async function applyHandler(argv: ApplyArgs): Promise<void> {
   }
 
   try {
+    // Determine nested preference: CLI > TOML > Default (false)
+    const nested = await resolveNestedPreference(argv, projectRoot, configPath);
+
     await applyAllAgentConfigs(
       projectRoot,
       agents,
@@ -141,7 +148,7 @@ export async function applyHandler(argv: ApplyArgs): Promise<void> {
     console.log('Ruler apply completed successfully.');
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
-    console.error(`${ERROR_PREFIX} ${message}`);
+    console.error(formatCliError(message));
     process.exit(1);
   }
 }

--- a/src/core/ConfigLoader.ts
+++ b/src/core/ConfigLoader.ts
@@ -175,55 +175,18 @@ export interface ConfigOptions {
 
 /**
  * Loads and parses the ruler TOML configuration file, applying defaults.
- * If the file is missing or invalid, returns empty/default config.
+ * Missing implicit configs return defaults. Explicit configs and existing
+ * implicit configs fail fast when missing, unreadable, or invalid.
  */
 export async function loadConfig(
   options: ConfigOptions,
 ): Promise<LoadedConfig> {
   const { projectRoot, configPath, cliAgents } = options;
-  let configFile: string;
+  const configFile = configPath
+    ? path.resolve(configPath)
+    : await resolveImplicitConfigFile(projectRoot);
 
-  if (configPath) {
-    configFile = path.resolve(configPath);
-  } else {
-    // Try local .ruler/ruler.toml first
-    const localConfigFile = path.join(projectRoot, '.ruler', 'ruler.toml');
-    try {
-      await fs.access(localConfigFile);
-      configFile = localConfigFile;
-    } catch {
-      // If local config doesn't exist, try global config
-      const xdgConfigDir =
-        process.env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config');
-      configFile = path.join(xdgConfigDir, 'ruler', 'ruler.toml');
-    }
-  }
-  let raw: Record<string, unknown> = {};
-  try {
-    const text = await fs.readFile(configFile, 'utf8');
-    const parsed = text.trim() ? parseTOML(text) : {};
-    // Strip Symbol properties added by @iarna/toml (required for Zod v4+)
-    raw = stripSymbols(parsed) as Record<string, unknown>;
-
-    // Validate the configuration with zod
-    const validationResult = rulerConfigSchema.safeParse(raw);
-    if (!validationResult.success) {
-      throw createRulerError(
-        'Invalid configuration file format',
-        `File: ${configFile}, Errors: ${validationResult.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join(', ')}`,
-      );
-    }
-  } catch (err) {
-    if (err instanceof Error && (err as ErrnoException).code !== 'ENOENT') {
-      if (err.message.includes('[ruler]')) {
-        throw err; // Re-throw validation errors
-      }
-      console.warn(
-        `[ruler] Warning: could not read config file at ${configFile}: ${err.message}`,
-      );
-    }
-    raw = {};
-  }
+  const raw = configFile ? await readConfigFile(configFile) : {};
 
   const defaultAgents = Array.isArray(raw.default_agents)
     ? raw.default_agents.map((a) => String(a))
@@ -374,4 +337,95 @@ export async function loadConfig(
     nested,
     nestedDefined,
   };
+}
+
+async function resolveImplicitConfigFile(
+  projectRoot: string,
+): Promise<string | undefined> {
+  const localConfigFile = path.join(projectRoot, '.ruler', 'ruler.toml');
+  if (await configFileExists(localConfigFile)) {
+    return localConfigFile;
+  }
+
+  const xdgConfigDir =
+    process.env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config');
+  const globalConfigFile = path.join(xdgConfigDir, 'ruler', 'ruler.toml');
+  if (await configFileExists(globalConfigFile)) {
+    return globalConfigFile;
+  }
+
+  return undefined;
+}
+
+async function configFileExists(configFile: string): Promise<boolean> {
+  try {
+    await fs.access(configFile);
+    return true;
+  } catch (err) {
+    if ((err as ErrnoException).code === 'ENOENT') {
+      return false;
+    }
+    throw createRulerError(
+      'Could not access configuration file',
+      `File: ${configFile}, Error: ${errorMessage(err)}`,
+    );
+  }
+}
+
+async function readConfigFile(
+  configFile: string,
+): Promise<Record<string, unknown>> {
+  const text = await readConfigText(configFile);
+  const parsed = parseConfigText(text, configFile);
+  const raw = stripSymbols(parsed) as Record<string, unknown>;
+  validateConfig(raw, configFile);
+  return raw;
+}
+
+async function readConfigText(configFile: string): Promise<string> {
+  try {
+    return await fs.readFile(configFile, 'utf8');
+  } catch (err) {
+    if ((err as ErrnoException).code === 'ENOENT') {
+      throw createRulerError(
+        'Configuration file not found',
+        `File: ${configFile}`,
+      );
+    }
+    throw createRulerError(
+      'Could not read configuration file',
+      `File: ${configFile}, Error: ${errorMessage(err)}`,
+    );
+  }
+}
+
+function parseConfigText(
+  text: string,
+  configFile: string,
+): Record<string, unknown> {
+  try {
+    return text.trim() ? (parseTOML(text) as Record<string, unknown>) : {};
+  } catch (err) {
+    throw createRulerError(
+      'Invalid configuration file',
+      `File: ${configFile}, Error: ${errorMessage(err)}`,
+    );
+  }
+}
+
+function validateConfig(
+  raw: Record<string, unknown>,
+  configFile: string,
+): void {
+  const validationResult = rulerConfigSchema.safeParse(raw);
+  if (!validationResult.success) {
+    throw createRulerError(
+      'Invalid configuration file format',
+      `File: ${configFile}, Errors: ${validationResult.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join(', ')}`,
+    );
+  }
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
 }

--- a/tests/unit/cli/handlers.test.ts
+++ b/tests/unit/cli/handlers.test.ts
@@ -321,6 +321,40 @@ describe('CLI Handlers', () => {
       );
     });
 
+    it('should fail fast when nested config resolution fails', async () => {
+      (loadConfig as jest.Mock).mockRejectedValue(
+        new Error('Invalid configuration file'),
+      );
+
+      const exitSpy = jest
+        .spyOn(process, 'exit')
+        .mockImplementation((code?: string | number | null | undefined) => {
+          throw new Error(`process.exit: ${code}`);
+        });
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      const argv = {
+        'project-root': mockProjectRoot,
+        mcp: true,
+        'mcp-overwrite': false,
+        verbose: false,
+        'dry-run': false,
+        'local-only': false,
+        backup: true,
+      };
+
+      await expect(applyHandler(argv)).rejects.toThrow('process.exit: 1');
+
+      expect(applyAllAgentConfigs).not.toHaveBeenCalled();
+      expect(errorSpy).toHaveBeenCalledWith(
+        '[ruler] Invalid configuration file',
+      );
+      expect(exitSpy).toHaveBeenCalledWith(1);
+
+      exitSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
+
     it('should prefer CLI --nested over TOML nested = false', async () => {
       (loadConfig as jest.Mock).mockResolvedValue({
         defaultAgents: undefined,

--- a/tests/unit/core/ConfigLoader.test.ts
+++ b/tests/unit/core/ConfigLoader.test.ts
@@ -11,14 +11,22 @@ import {
 describe('ConfigLoader', () => {
   let tmpDir: string;
   let rulerDir: string;
+  let originalXdgConfigHome: string | undefined;
 
   beforeEach(async () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ruler-config-'));
     rulerDir = path.join(tmpDir, '.ruler');
     await fs.mkdir(rulerDir, { recursive: true });
+    originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+    process.env.XDG_CONFIG_HOME = path.join(tmpDir, 'xdg-config');
   });
 
   afterEach(async () => {
+    if (originalXdgConfigHome === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
+    }
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
@@ -27,6 +35,53 @@ describe('ConfigLoader', () => {
     expect(config.defaultAgents).toBeUndefined();
     expect(config.agentConfigs).toEqual({});
     expect(config.cliAgents).toBeUndefined();
+  });
+
+  it('throws when an explicit config file is missing', async () => {
+    const missingConfigPath = path.join(tmpDir, 'missing.toml');
+
+    await expect(
+      loadConfig({ projectRoot: tmpDir, configPath: missingConfigPath }),
+    ).rejects.toThrow(/Configuration file not found/i);
+  });
+
+  it('throws when an explicit config file has invalid TOML', async () => {
+    const configPath = path.join(tmpDir, 'invalid.toml');
+    await fs.writeFile(configPath, 'default_agents = [');
+
+    await expect(
+      loadConfig({ projectRoot: tmpDir, configPath }),
+    ).rejects.toThrow(/Invalid configuration file/i);
+  });
+
+  it('throws when an existing implicit local config has invalid TOML', async () => {
+    await fs.writeFile(path.join(rulerDir, 'ruler.toml'), 'nested = ');
+
+    await expect(loadConfig({ projectRoot: tmpDir })).rejects.toThrow(
+      /Invalid configuration file/i,
+    );
+  });
+
+  it('throws when an existing implicit global config has invalid TOML', async () => {
+    const globalRulerDir = path.join(
+      process.env.XDG_CONFIG_HOME as string,
+      'ruler',
+    );
+    await fs.mkdir(globalRulerDir, { recursive: true });
+    await fs.writeFile(path.join(globalRulerDir, 'ruler.toml'), 'nested = ');
+
+    await expect(loadConfig({ projectRoot: tmpDir })).rejects.toThrow(
+      /Invalid configuration file/i,
+    );
+  });
+
+  it('throws when an existing implicit local config is unreadable', async () => {
+    const configPath = path.join(rulerDir, 'ruler.toml');
+    await fs.mkdir(configPath);
+
+    await expect(loadConfig({ projectRoot: tmpDir })).rejects.toThrow(
+      /Could not read configuration file/i,
+    );
   });
 
   it('returns empty config when file is empty', async () => {


### PR DESCRIPTION
Fixes #438.

## Summary

- Fail fast for explicit missing, unreadable, or invalid config files.
- Fail when existing implicit local or global configs are unreadable or invalid.
- Preserve default config behavior when no implicit config exists.
- Stop swallowing config-load failures during `apply` nested resolution.
- Add regression coverage for loader and handler failure behavior.

## Verification

- npm ci
- npm run lint
- npm test
- npm run build