### PR TITLE
build: emit package declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.3.41",
   "description": "Ruler — apply the same rules to all coding agents",
   "main": "dist/lib.js",
+  "types": "dist/lib.d.ts",
   "scripts": {
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "format": "prettier --write \"src/**/*.{ts,tsx,json,md}\"",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -52,7 +52,7 @@
     // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
 
     /* Emit */
-    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
     // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */


### PR DESCRIPTION
## Summary\n- enable TypeScript declaration output\n- advertise the package entry declaration via the `types` field\n\nCloses #462\n\n## Verification\n- `npm ci`\n- `npm run lint`\n- `npm test -- --runInBand`\n- `npm run build`\n- `npm pack --dry-run --json` includes `dist/lib.d.ts`