### PR TITLE
fix(cli): reject empty --agents tokens

### DIFF
--- a/src/cli/handlers.ts
+++ b/src/cli/handlers.ts
@@ -56,6 +56,21 @@ function formatCliError(message: string): string {
     : `${ERROR_PREFIX} ${message}`;
 }
 
+function parseCliAgents(agents: string | undefined): string[] | undefined {
+  if (agents === undefined) {
+    return undefined;
+  }
+
+  const parsedAgents = agents.split(',').map((agent) => agent.trim());
+  if (parsedAgents.some((agent) => agent.length === 0)) {
+    throw new Error(
+      'Empty agent token in --agents. Remove extra commas or provide an agent name.',
+    );
+  }
+
+  return parsedAgents;
+}
+
 async function resolveNestedPreference(
   argv: ApplyArgs,
   projectRoot: string,
@@ -81,9 +96,6 @@ async function resolveNestedPreference(
 export async function applyHandler(argv: ApplyArgs): Promise<void> {
   const projectRoot = argv['project-root'];
   assertNotInsideRulerDir(projectRoot);
-  const agents = argv.agents
-    ? argv.agents.split(',').map((a) => a.trim())
-    : undefined;
   const configPath = argv.config;
   const mcpEnabled = argv.mcp;
   const mcpStrategy: McpStrategy | undefined = argv['mcp-overwrite']
@@ -126,6 +138,8 @@ export async function applyHandler(argv: ApplyArgs): Promise<void> {
   }
 
   try {
+    const agents = parseCliAgents(argv.agents);
+
     // Determine nested preference: CLI > TOML > Default (false)
     const nested = await resolveNestedPreference(argv, projectRoot, configPath);
 
@@ -244,9 +258,6 @@ export async function initHandler(argv: InitArgs): Promise<void> {
 export async function revertHandler(argv: RevertArgs): Promise<void> {
   const projectRoot = argv['project-root'];
   assertNotInsideRulerDir(projectRoot);
-  const agents = argv.agents
-    ? argv.agents.split(',').map((a) => a.trim())
-    : undefined;
   const configPath = argv.config;
   const keepBackups = argv['keep-backups'];
   const verbose = argv.verbose;
@@ -254,6 +265,8 @@ export async function revertHandler(argv: RevertArgs): Promise<void> {
   const localOnly = argv['local-only'];
 
   try {
+    const agents = parseCliAgents(argv.agents);
+
     await revertAllAgentConfigs(
       projectRoot,
       agents,

--- a/tests/unit/cli/handlers.test.ts
+++ b/tests/unit/cli/handlers.test.ts
@@ -71,6 +71,70 @@ describe('CLI Handlers', () => {
       );
     });
 
+    it('should reject trailing empty --agents tokens', async () => {
+      const exitSpy = jest
+        .spyOn(process, 'exit')
+        .mockImplementation((code?: string | number | null | undefined) => {
+          throw new Error(`process.exit: ${code}`);
+        });
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      const argv = {
+        'project-root': mockProjectRoot,
+        agents: 'copilot,',
+        mcp: true,
+        'mcp-overwrite': false,
+        verbose: false,
+        'dry-run': false,
+        'local-only': false,
+        nested: false,
+        backup: true,
+      };
+
+      await expect(applyHandler(argv)).rejects.toThrow('process.exit: 1');
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        '[ruler] Empty agent token in --agents. Remove extra commas or provide an agent name.',
+      );
+      expect(applyAllAgentConfigs).not.toHaveBeenCalled();
+      expect(exitSpy).toHaveBeenCalledWith(1);
+
+      exitSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
+
+    it('should reject whitespace-only --agents tokens', async () => {
+      const exitSpy = jest
+        .spyOn(process, 'exit')
+        .mockImplementation((code?: string | number | null | undefined) => {
+          throw new Error(`process.exit: ${code}`);
+        });
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      const argv = {
+        'project-root': mockProjectRoot,
+        agents: 'copilot,   ',
+        mcp: true,
+        'mcp-overwrite': false,
+        verbose: false,
+        'dry-run': false,
+        'local-only': false,
+        nested: false,
+        backup: true,
+      };
+
+      await expect(applyHandler(argv)).rejects.toThrow('process.exit: 1');
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        '[ruler] Empty agent token in --agents. Remove extra commas or provide an agent name.',
+      );
+      expect(applyAllAgentConfigs).not.toHaveBeenCalled();
+      expect(exitSpy).toHaveBeenCalledWith(1);
+
+      exitSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
+
     it('should handle mcp-overwrite correctly', async () => {
       const argv = {
         'project-root': mockProjectRoot,
@@ -629,6 +693,35 @@ describe('CLI Handlers', () => {
         false,
         false,
       );
+    });
+
+    it('should reject trailing empty --agents tokens', async () => {
+      const exitSpy = jest
+        .spyOn(process, 'exit')
+        .mockImplementation((code?: string | number | null | undefined) => {
+          throw new Error(`process.exit: ${code}`);
+        });
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      const argv = {
+        'project-root': mockProjectRoot,
+        agents: 'claude,',
+        'keep-backups': true,
+        verbose: true,
+        'dry-run': false,
+        'local-only': false,
+      };
+
+      await expect(revertHandler(argv)).rejects.toThrow('process.exit: 1');
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        '[ruler] Empty agent token in --agents. Remove extra commas or provide an agent name.',
+      );
+      expect(revertAllAgentConfigs).not.toHaveBeenCalled();
+      expect(exitSpy).toHaveBeenCalledWith(1);
+
+      exitSpy.mockRestore();
+      errorSpy.mockRestore();
     });
 
     it('should handle undefined agents correctly', async () => {


### PR DESCRIPTION
## Summary
- Add shared CLI parsing for comma-separated --agents values
- Reject trailing commas and whitespace-only agent tokens before apply/revert selection
- Cover apply and revert parsing with focused handler tests

Closes #446

## Testing
- npm run format
- npx prettier --write tests/unit/cli/handlers.test.ts
- npm run lint
- npm test -- --runInBand
- npm run build