### PR TITLE
fix(revert): use prefix string in vscode logs

### DIFF
--- a/src/core/revert-engine.ts
+++ b/src/core/revert-engine.ts
@@ -447,10 +447,7 @@ async function removeAdditionalAgentFiles(
     const restored = await restoreFromBackup(settingsPath, verbose, dryRun);
     if (restored) {
       filesRemoved++;
-      logVerbose(
-        `${actionPrefix} Restored VSCode settings from backup`,
-        verbose,
-      );
+      logVerbose(`${prefix} Restored VSCode settings from backup`, verbose);
     }
   } else if (await fileExists(settingsPath)) {
     try {
@@ -461,12 +458,12 @@ async function removeAdditionalAgentFiles(
           const remainingKeys = Object.keys(settings);
           if (remainingKeys.length === 0) {
             logVerbose(
-              `${actionPrefix} Would remove empty VSCode settings file`,
+              `${prefix} Would remove empty VSCode settings file`,
               verbose,
             );
           } else {
             logVerbose(
-              `${actionPrefix} Would remove augment.advanced section from ${settingsPath}`,
+              `${prefix} Would remove augment.advanced section from ${settingsPath}`,
               verbose,
             );
           }
@@ -480,14 +477,11 @@ async function removeAdditionalAgentFiles(
           const remainingKeys = Object.keys(settings);
           if (remainingKeys.length === 0) {
             await fs.unlink(settingsPath);
-            logVerbose(
-              `${actionPrefix} Removed empty VSCode settings file`,
-              verbose,
-            );
+            logVerbose(`${prefix} Removed empty VSCode settings file`, verbose);
           } else {
             await writeVSCodeSettings(settingsPath, settings);
             logVerbose(
-              `${actionPrefix} Removed augment.advanced section from VSCode settings`,
+              `${prefix} Removed augment.advanced section from VSCode settings`,
               verbose,
             );
           }

--- a/tests/unit/core/revert-engine.test.ts
+++ b/tests/unit/core/revert-engine.test.ts
@@ -348,6 +348,36 @@ describe('revert-engine', () => {
       consoleErrorSpy.mockRestore();
     });
 
+    it('uses prefix string for verbose dry-run VSCode settings cleanup logs', async () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+      const settingsPath = path.join(tmpDir, '.vscode', 'settings.json');
+
+      await fs.mkdir(path.dirname(settingsPath), { recursive: true });
+      await fs.writeFile(
+        settingsPath,
+        JSON.stringify({
+          'augment.advanced': {
+            mcpServers: [{ name: 'test-server', command: 'test' }],
+          },
+        }),
+      );
+
+      await cleanUpAuxiliaryFiles(tmpDir, true, true);
+
+      const errorCalls = consoleErrorSpy.mock.calls.flat();
+
+      expect(errorCalls).toContain(
+        `[ruler:verbose] [ruler:dry-run] Would remove empty VSCode settings file`,
+      );
+      expect(
+        errorCalls.some(
+          (call) =>
+            typeof call === 'string' && call.includes('function actionPrefix'),
+        ),
+      ).toBe(false);
+      consoleErrorSpy.mockRestore();
+    });
+
     it('should use [ruler] prefix when dryRun is false', async () => {
       const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
 


### PR DESCRIPTION
Closes #463.

## Summary
- Use the computed revert log prefix for VS Code settings cleanup messages.
- Add a regression test for verbose dry-run VS Code settings cleanup logs.

## Tests
- npm run format
- npm run lint
- npm test -- --runInBand
- npm run build