### PR TITLE
fix(cli): avoid double-prefixing revert errors

### DIFF
--- a/src/cli/handlers.ts
+++ b/src/cli/handlers.ts
@@ -265,7 +265,7 @@ export async function revertHandler(argv: RevertArgs): Promise<void> {
     );
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
-    console.error(`${ERROR_PREFIX} ${message}`);
+    console.error(formatCliError(message));
     process.exit(1);
   }
 }

--- a/tests/unit/cli/handlers.test.ts
+++ b/tests/unit/cli/handlers.test.ts
@@ -681,6 +681,40 @@ describe('CLI Handlers', () => {
       errorSpy.mockRestore();
     });
 
+    it('should not double-prefix formatted Ruler errors', async () => {
+      (revertAllAgentConfigs as jest.Mock).mockRejectedValue(
+        new Error(
+          '[ruler] .ruler directory not found (Context: Searched from: /mock/project/root)',
+        ),
+      );
+
+      const exitSpy = jest
+        .spyOn(process, 'exit')
+        .mockImplementation((code?: string | number | null | undefined) => {
+          throw new Error(`process.exit: ${code}`);
+        });
+
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      const argv = {
+        'project-root': mockProjectRoot,
+        'keep-backups': false,
+        verbose: false,
+        'dry-run': false,
+        'local-only': false,
+      };
+
+      await expect(revertHandler(argv)).rejects.toThrow('process.exit: 1');
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        '[ruler] .ruler directory not found (Context: Searched from: /mock/project/root)',
+      );
+      expect(exitSpy).toHaveBeenCalledWith(1);
+
+      exitSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
+
     it('should fail fast when running revert from inside a .ruler directory', async () => {
       const exitSpy = jest
         .spyOn(process, 'exit')


### PR DESCRIPTION
Closes #450

## Summary
- Reuse the existing CLI error formatter in `revertHandler`
- Add a regression test for already-formatted Ruler errors from missing `.ruler` handling

## Tests
- `npm run format`
- `npm run lint`
- `npm test -- --runInBand`
- `npm run build`