### PR TITLE
fix(agents): forward AGENTS backup option

### DIFF
--- a/src/agents/GeminiCliAgent.ts
+++ b/src/agents/GeminiCliAgent.ts
@@ -17,11 +17,18 @@ export class GeminiCliAgent extends AgentsMdAgent {
     projectRoot: string,
     rulerMcpJson: Record<string, unknown> | null,
     agentConfig?: IAgentConfig,
+    backup = true,
   ): Promise<void> {
     // First, perform idempotent write of AGENTS.md via base class
-    await super.applyRulerConfig(concatenatedRules, projectRoot, null, {
-      outputPath: agentConfig?.outputPath,
-    });
+    await super.applyRulerConfig(
+      concatenatedRules,
+      projectRoot,
+      null,
+      {
+        outputPath: agentConfig?.outputPath,
+      },
+      backup,
+    );
 
     // Prepare .gemini/settings.json with contextFileName and MCP configuration
     const settingsPath = path.join(projectRoot, '.gemini', 'settings.json');

--- a/src/agents/QwenCodeAgent.ts
+++ b/src/agents/QwenCodeAgent.ts
@@ -17,11 +17,18 @@ export class QwenCodeAgent extends AgentsMdAgent {
     projectRoot: string,
     _rulerMcpJson: Record<string, unknown> | null,
     agentConfig?: IAgentConfig,
+    backup = true,
   ): Promise<void> {
     // First, perform idempotent write of AGENTS.md via base class
-    await super.applyRulerConfig(concatenatedRules, projectRoot, null, {
-      outputPath: agentConfig?.outputPath,
-    });
+    await super.applyRulerConfig(
+      concatenatedRules,
+      projectRoot,
+      null,
+      {
+        outputPath: agentConfig?.outputPath,
+      },
+      backup,
+    );
 
     // Ensure .qwen/settings.json has contextFileName set to AGENTS.md
     const settingsPath = path.join(projectRoot, '.qwen', 'settings.json');

--- a/src/agents/ZedAgent.ts
+++ b/src/agents/ZedAgent.ts
@@ -22,11 +22,18 @@ export class ZedAgent extends AgentsMdAgent {
     projectRoot: string,
     rulerMcpJson: Record<string, unknown> | null,
     agentConfig?: IAgentConfig,
+    backup = true,
   ): Promise<void> {
     // First, perform idempotent AGENTS.md write via base class
-    await super.applyRulerConfig(concatenatedRules, projectRoot, null, {
-      outputPath: agentConfig?.outputPath,
-    });
+    await super.applyRulerConfig(
+      concatenatedRules,
+      projectRoot,
+      null,
+      {
+        outputPath: agentConfig?.outputPath,
+      },
+      backup,
+    );
 
     // Handle MCP server configuration if enabled and provided
     const mcpEnabled = agentConfig?.mcp?.enabled ?? true;

--- a/tests/unit/agents/AgentBackupForwarding.test.ts
+++ b/tests/unit/agents/AgentBackupForwarding.test.ts
@@ -1,0 +1,71 @@
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import { GeminiCliAgent } from '../../../src/agents/GeminiCliAgent';
+import { IAgent } from '../../../src/agents/IAgent';
+import { QwenCodeAgent } from '../../../src/agents/QwenCodeAgent';
+import { ZedAgent } from '../../../src/agents/ZedAgent';
+import { setupTestProject, teardownTestProject } from '../../harness';
+
+const agents: Array<[string, () => IAgent]> = [
+  ['Gemini CLI', () => new GeminiCliAgent()],
+  ['Qwen Code', () => new QwenCodeAgent()],
+  ['Zed', () => new ZedAgent()],
+];
+
+describe('agent AGENTS.md backup forwarding', () => {
+  it.each(agents)(
+    '%s respects disabled AGENTS.md backups',
+    async (_name, createAgent) => {
+      const { projectRoot } = await setupTestProject({
+        '.ruler/AGENTS.md': 'Rule A',
+        'AGENTS.md': 'Existing AGENTS.md content',
+      });
+
+      try {
+        await createAgent().applyRulerConfig(
+          'Combined rules\n- Rule A',
+          projectRoot,
+          null,
+          undefined,
+          false,
+        );
+
+        await expect(
+          fs.access(path.join(projectRoot, 'AGENTS.md.bak')),
+        ).rejects.toThrow();
+        await expect(
+          fs.readFile(path.join(projectRoot, 'AGENTS.md'), 'utf8'),
+        ).resolves.toContain('Rule A');
+      } finally {
+        await teardownTestProject(projectRoot);
+      }
+    },
+  );
+
+  it.each(agents)(
+    '%s creates AGENTS.md backups by default',
+    async (_name, createAgent) => {
+      const { projectRoot } = await setupTestProject({
+        '.ruler/AGENTS.md': 'Rule A',
+        'AGENTS.md': 'Existing AGENTS.md content',
+      });
+
+      try {
+        await createAgent().applyRulerConfig(
+          'Combined rules\n- Rule A',
+          projectRoot,
+          null,
+        );
+
+        await expect(
+          fs.readFile(path.join(projectRoot, 'AGENTS.md.bak'), 'utf8'),
+        ).resolves.toBe('Existing AGENTS.md content');
+        await expect(
+          fs.readFile(path.join(projectRoot, 'AGENTS.md'), 'utf8'),
+        ).resolves.toContain('Rule A');
+      } finally {
+        await teardownTestProject(projectRoot);
+      }
+    },
+  );
+});


### PR DESCRIPTION
## Summary
- Forward the apply backup flag from Gemini CLI, Qwen Code, and Zed agent overrides to the shared AGENTS.md writer.
- Add focused unit coverage for disabled and default AGENTS.md backup behavior across those agents.

Closes #457

## Tests
- npm run format
- npx prettier --write tests/unit/agents/AgentBackupForwarding.test.ts
- npm run lint
- npm test -- --runInBand
- npm run build