### PR TITLE
fix(mcp): preserve settings on overwrite

### DIFF
--- a/src/mcp/merge.ts
+++ b/src/mcp/merge.ts
@@ -1,5 +1,7 @@
 import { McpStrategy } from '../types';
 
+const MCP_SERVER_KEYS = ['servers', 'mcpServers', 'mcp', 'mcp_servers'];
+
 /**
  * Merge native and incoming MCP server configurations according to strategy.
  * @param base Existing native MCP config object.
@@ -22,8 +24,14 @@ export function mergeMcp(
       (incoming.mcpServers as Record<string, unknown>) ||
       (incoming.mcp as Record<string, unknown>) ||
       {};
+    const preservedBase = { ...base };
+    for (const key of MCP_SERVER_KEYS) {
+      if (key !== serverKey) {
+        delete preservedBase[key];
+      }
+    }
     return {
-      ...base,
+      ...preservedBase,
       [serverKey]: incomingServers,
     };
   }

--- a/src/mcp/merge.ts
+++ b/src/mcp/merge.ts
@@ -23,6 +23,7 @@ export function mergeMcp(
       (incoming.mcp as Record<string, unknown>) ||
       {};
     return {
+      ...base,
       [serverKey]: incomingServers,
     };
   }

--- a/tests/unit/mcp/KiloCodeMcp.test.ts
+++ b/tests/unit/mcp/KiloCodeMcp.test.ts
@@ -143,6 +143,32 @@ describe('KiloCode MCP Integration', () => {
       });
     });
 
+    it('preserves non-MCP properties during overwrite', async () => {
+      const existing = {
+        mcpServers: {
+          existing: { command: 'existing-cmd' },
+        },
+        model: 'gpt-test',
+      };
+
+      const newConfig = {
+        mcpServers: {
+          filesystem: { command: 'npx' },
+        },
+      };
+
+      const merged = mergeMcp(
+        existing,
+        newConfig,
+        'overwrite',
+        'mcpServers',
+      ) as McpConfig;
+
+      expect(merged.model).toBe('gpt-test');
+      expect(merged.mcpServers.existing).toBeUndefined();
+      expect(merged.mcpServers.filesystem).toEqual({ command: 'npx' });
+    });
+
     it('overwrites servers with same name during merge', async () => {
       const existing = {
         mcpServers: {

--- a/tests/unit/mcp/KiloCodeMcp.test.ts
+++ b/tests/unit/mcp/KiloCodeMcp.test.ts
@@ -169,6 +169,39 @@ describe('KiloCode MCP Integration', () => {
       expect(merged.mcpServers.filesystem).toEqual({ command: 'npx' });
     });
 
+    it('removes stale server aliases during overwrite', async () => {
+      const existing = {
+        servers: {
+          stale: { command: 'stale-cmd' },
+        },
+        mcpServers: {
+          legacy: { command: 'legacy-cmd' },
+        },
+        mcp: {
+          other: { command: 'other-cmd' },
+        },
+        setting: 'preserved',
+      };
+
+      const newConfig = {
+        mcpServers: {
+          filesystem: { command: 'npx' },
+        },
+      };
+
+      const merged = mergeMcp(existing, newConfig, 'overwrite', 'servers') as {
+        servers: Record<string, unknown>;
+        mcpServers?: Record<string, unknown>;
+        mcp?: Record<string, unknown>;
+        setting?: string;
+      };
+
+      expect(merged.setting).toBe('preserved');
+      expect(merged.servers).toEqual({ filesystem: { command: 'npx' } });
+      expect(merged.mcpServers).toBeUndefined();
+      expect(merged.mcp).toBeUndefined();
+    });
+
     it('overwrites servers with same name during merge', async () => {
       const existing = {
         mcpServers: {


### PR DESCRIPTION
## Summary\n- preserve unrelated native config properties when MCP overwrite replaces server entries\n- add a regression test for non-MCP settings surviving overwrite\n\nCloses #454\n\n## Verification\n- `npm ci`\n- `npm run lint`\n- `npm test -- --runInBand`\n- `npm run build`