### PR TITLE
Fix init filesystem error formatting

### DIFF
--- a/src/cli/handlers.ts
+++ b/src/cli/handlers.ts
@@ -160,25 +160,26 @@ export async function initHandler(argv: InitArgs): Promise<void> {
   const projectRoot = argv['project-root'];
   const isGlobal = argv['global'];
 
-  const rulerDir = isGlobal
-    ? path.join(
-        process.env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config'),
-        'ruler',
-      )
-    : path.join(projectRoot, '.ruler');
-  await fs.mkdir(rulerDir, { recursive: true });
-  const instructionsPath = path.join(rulerDir, DEFAULT_RULES_FILENAME); // .ruler/AGENTS.md
-  const tomlPath = path.join(rulerDir, 'ruler.toml');
-  const exists = async (p: string) => {
-    try {
-      await fs.access(p);
-      return true;
-    } catch {
-      return false;
-    }
-  };
-  const DEFAULT_INSTRUCTIONS = `# AGENTS.md\n\nCentralised AI agent instructions. Add coding guidelines, style guides, and project context here.\n\nRuler concatenates all .md files in this directory (and subdirectories), starting with AGENTS.md (if present), then remaining files in sorted order.\n`;
-  const DEFAULT_TOML = `# Ruler Configuration File
+  try {
+    const rulerDir = isGlobal
+      ? path.join(
+          process.env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config'),
+          'ruler',
+        )
+      : path.join(projectRoot, '.ruler');
+    await fs.mkdir(rulerDir, { recursive: true });
+    const instructionsPath = path.join(rulerDir, DEFAULT_RULES_FILENAME); // .ruler/AGENTS.md
+    const tomlPath = path.join(rulerDir, 'ruler.toml');
+    const exists = async (p: string) => {
+      try {
+        await fs.access(p);
+        return true;
+      } catch {
+        return false;
+      }
+    };
+    const DEFAULT_INSTRUCTIONS = `# AGENTS.md\n\nCentralised AI agent instructions. Add coding guidelines, style guides, and project context here.\n\nRuler concatenates all .md files in this directory (and subdirectories), starting with AGENTS.md (if present), then remaining files in sorted order.\n`;
+    const DEFAULT_TOML = `# Ruler Configuration File
 # See https://ai.intellectronica.net/ruler for documentation.
 
 # To specify which agents are active by default when --agents is not used,
@@ -223,18 +224,23 @@ export async function initHandler(argv: InitArgs): Promise<void> {
 # url = "https://api.example.com/mcp"
 # headers = { Authorization = "Bearer REPLACE_ME" }
 `;
-  if (!(await exists(instructionsPath))) {
-    // Create new AGENTS.md regardless of legacy presence.
-    await fs.writeFile(instructionsPath, DEFAULT_INSTRUCTIONS);
-    console.log(`[ruler] Created ${instructionsPath}`);
-  } else {
-    console.log(`[ruler] ${DEFAULT_RULES_FILENAME} already exists, skipping`);
-  }
-  if (!(await exists(tomlPath))) {
-    await fs.writeFile(tomlPath, DEFAULT_TOML);
-    console.log(`[ruler] Created ${tomlPath}`);
-  } else {
-    console.log(`[ruler] ruler.toml already exists, skipping`);
+    if (!(await exists(instructionsPath))) {
+      // Create new AGENTS.md regardless of legacy presence.
+      await fs.writeFile(instructionsPath, DEFAULT_INSTRUCTIONS);
+      console.log(`[ruler] Created ${instructionsPath}`);
+    } else {
+      console.log(`[ruler] ${DEFAULT_RULES_FILENAME} already exists, skipping`);
+    }
+    if (!(await exists(tomlPath))) {
+      await fs.writeFile(tomlPath, DEFAULT_TOML);
+      console.log(`[ruler] Created ${tomlPath}`);
+    } else {
+      console.log(`[ruler] ruler.toml already exists, skipping`);
+    }
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(formatCliError(message));
+    process.exit(1);
   }
 }
 

--- a/tests/unit/cli/handlers.test.ts
+++ b/tests/unit/cli/handlers.test.ts
@@ -604,6 +604,60 @@ describe('CLI Handlers', () => {
       ).toBe(false);
       logSpy.mockRestore();
     });
+
+    it('should exit with a concise error when directory creation fails', async () => {
+      const initError = new Error('EACCES: permission denied, mkdir .ruler');
+      (fs.mkdir as jest.Mock).mockRejectedValue(initError);
+      const exitSpy = jest
+        .spyOn(process, 'exit')
+        .mockImplementation((code?: string | number | null | undefined) => {
+          throw new Error(`process.exit: ${code}`);
+        });
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      const argv = {
+        'project-root': mockProjectRoot,
+        global: false,
+      };
+
+      await expect(initHandler(argv)).rejects.toThrow('process.exit: 1');
+
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      expect(errorSpy).toHaveBeenCalledWith(
+        '[ruler] EACCES: permission denied, mkdir .ruler',
+      );
+      expect(exitSpy).toHaveBeenCalledWith(1);
+
+      exitSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
+
+    it('should exit with a concise error when writing default files fails', async () => {
+      const initError = new Error('ENOSPC: no space left on device');
+      (fs.writeFile as jest.Mock).mockRejectedValue(initError);
+      const exitSpy = jest
+        .spyOn(process, 'exit')
+        .mockImplementation((code?: string | number | null | undefined) => {
+          throw new Error(`process.exit: ${code}`);
+        });
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      const argv = {
+        'project-root': mockProjectRoot,
+        global: false,
+      };
+
+      await expect(initHandler(argv)).rejects.toThrow('process.exit: 1');
+
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      expect(errorSpy).toHaveBeenCalledWith(
+        '[ruler] ENOSPC: no space left on device',
+      );
+      expect(exitSpy).toHaveBeenCalledWith(1);
+
+      exitSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
   });
 
   describe('revertHandler', () => {


### PR DESCRIPTION
## Summary
- wrap `initHandler` filesystem work in the existing concise CLI error formatter
- add focused unit coverage for mkdir and write failures exiting with one `[ruler]` error

## Tests
- `npm run format`
- `npx prettier --write tests/unit/cli/handlers.test.ts`
- `npm run lint`
- `npm test -- --runInBand`
- `npm run build`

Closes #451