### PR TITLE
fix(mcp): clean stale server alias keys

### DIFF
--- a/src/mcp/merge.ts
+++ b/src/mcp/merge.ts
@@ -1,6 +1,12 @@
 import { McpStrategy } from '../types';
 
-const MCP_SERVER_KEYS = ['servers', 'mcpServers', 'mcp', 'mcp_servers'];
+const MCP_SERVER_KEYS = [
+  'mcp',
+  'mcpServers',
+  'servers',
+  'mcp_servers',
+  'context_servers',
+];
 
 /**
  * Merge native and incoming MCP server configurations according to strategy.
@@ -50,7 +56,11 @@ export function mergeMcp(
   const mergedServers = { ...baseServers, ...incomingServers };
 
   const newBase = { ...base };
-  delete newBase.mcpServers; // Remove old key if present
+  for (const key of MCP_SERVER_KEYS) {
+    if (key !== serverKey) {
+      delete newBase[key];
+    }
+  }
 
   return {
     ...newBase,

--- a/tests/unit/mcp/merge.test.ts
+++ b/tests/unit/mcp/merge.test.ts
@@ -1,0 +1,29 @@
+import { mergeMcp } from '../../../src/mcp/merge';
+
+describe('mergeMcp', () => {
+  it('removes alternate server aliases when writing the target key', () => {
+    const result = mergeMcp(
+      {
+        mcp: {
+          existing: { command: 'existing-command' },
+        },
+        otherSetting: true,
+      },
+      {
+        mcpServers: {
+          incoming: { command: 'incoming-command' },
+        },
+      },
+      'merge',
+      'servers',
+    );
+
+    expect(result).toEqual({
+      otherSetting: true,
+      servers: {
+        existing: { command: 'existing-command' },
+        incoming: { command: 'incoming-command' },
+      },
+    });
+  });
+});


### PR DESCRIPTION
Closes #455

## Summary
- remove known stale MCP server alias keys when mergeMcp writes the target server key
- add a focused unit test for merging from base.mcp into target servers without leaving the alias behind

## Testing
- npm run format
- npm run lint
- npm test -- --runInBand
- npm run build