### PR TITLE
fix(agents): track multipath output path

### DIFF
--- a/src/agents/CrushAgent.ts
+++ b/src/agents/CrushAgent.ts
@@ -65,7 +65,9 @@ export class CrushAgent implements IAgent {
   ): Promise<void> {
     const outputPaths = this.getDefaultOutputPath(projectRoot);
     const instructionsPath =
-      agentConfig?.outputPathInstructions ?? outputPaths['instructions'];
+      agentConfig?.outputPath ??
+      agentConfig?.outputPathInstructions ??
+      outputPaths['instructions'];
     const mcpPath = agentConfig?.outputPathConfig ?? outputPaths['mcp'];
 
     await fs.writeFile(instructionsPath, concatenatedRules);

--- a/src/agents/OpenCodeAgent.ts
+++ b/src/agents/OpenCodeAgent.ts
@@ -27,7 +27,9 @@ export class OpenCodeAgent implements IAgent {
     const outputPaths = this.getDefaultOutputPath(projectRoot);
     const instructionsPath = path.resolve(
       projectRoot,
-      agentConfig?.outputPathInstructions ?? outputPaths['instructions'],
+      agentConfig?.outputPath ??
+        agentConfig?.outputPathInstructions ??
+        outputPaths['instructions'],
     );
     const mcpPath = path.resolve(
       projectRoot,

--- a/src/agents/agent-utils.ts
+++ b/src/agents/agent-utils.ts
@@ -22,7 +22,9 @@ export function getAgentOutputPaths(
     // Handle instructions path
     if ('instructions' in defaultPaths) {
       const instructionsPath =
-        agentConfig?.outputPathInstructions ?? defaultPaths.instructions;
+        agentConfig?.outputPath ??
+        agentConfig?.outputPathInstructions ??
+        defaultPaths.instructions;
       paths.push(instructionsPath);
     }
 

--- a/tests/e2e/ruler.test.ts
+++ b/tests/e2e/ruler.test.ts
@@ -363,6 +363,25 @@ output_path = "custom-claude.md"`;
       expect(gitignoreContent).toContain('custom-claude.md');
       expect(gitignoreContent).not.toContain('CLAUDE.md');
     });
+
+    it('tracks generic output_path for multi-path agent instructions in .gitignore', async () => {
+      const toml = `[agents.Aider]
+output_path = "custom-aider.md"`;
+      await fs.writeFile(
+        path.join(testProject.projectRoot, '.ruler', 'ruler.toml'),
+        toml,
+      );
+
+      runRulerWithInheritedStdio(
+        'apply --agents aider',
+        testProject.projectRoot,
+      );
+
+      const gitignorePath = path.join(testProject.projectRoot, '.gitignore');
+      const gitignoreContent = await fs.readFile(gitignorePath, 'utf8');
+      expect(gitignoreContent).toContain('custom-aider.md');
+      expect(gitignoreContent).not.toContain('/AGENTS.md');
+    });
   });
 
   describe('gitignore generation for all configs', () => {

--- a/tests/unit/agents/CrushAgent.test.ts
+++ b/tests/unit/agents/CrushAgent.test.ts
@@ -84,6 +84,22 @@ describe('CrushAgent', () => {
     await expect(fs.access(mcpPath)).rejects.toThrow();
   });
 
+  it('should use outputPath as the instructions path when provided', async () => {
+    const rules = 'some rules';
+
+    await agent.applyRulerConfig(rules, projectRoot, null, {
+      outputPath: path.join(projectRoot, 'CUSTOM.md'),
+      outputPathInstructions: path.join(projectRoot, 'IGNORED.md'),
+    });
+
+    await expect(
+      fs.readFile(path.join(projectRoot, 'CUSTOM.md'), 'utf-8'),
+    ).resolves.toBe(rules);
+    await expect(
+      fs.access(path.join(projectRoot, 'IGNORED.md')),
+    ).rejects.toThrow();
+  });
+
   it('should transform MCP server type from "remote" to "http"', async () => {
     const rules = 'some rules';
     const mcpJson = {

--- a/tests/unit/agents/OpenCodeAgent.test.ts
+++ b/tests/unit/agents/OpenCodeAgent.test.ts
@@ -116,4 +116,15 @@ describe('OpenCodeAgent', () => {
       }, null, 2)
     );
   });
+
+  it('should use outputPath as the instructions path when provided', async () => {
+    mockedFs.readFile.mockRejectedValue(new Error('File not found'));
+
+    await agent.applyRulerConfig('rules', '/root', null, {
+      outputPath: 'CUSTOM.md',
+      outputPathInstructions: 'IGNORED.md',
+    });
+
+    expect(mockedFs.writeFile).toHaveBeenCalledWith('/root/CUSTOM.md', 'rules');
+  });
 });

--- a/tests/unit/agents/agent-utils.test.ts
+++ b/tests/unit/agents/agent-utils.test.ts
@@ -210,17 +210,32 @@ describe('getAgentOutputPaths', () => {
       ]);
     });
 
-    it('ignores outputPath for multi-path agents', () => {
+    it('uses outputPath as the instructions path for multi-path agents', () => {
       const agent = new MockMultiPathAgent();
       const agentConfig: IAgentConfig = {
-        outputPath: '/ignored/path.md',
+        outputPath: '/custom/output.md',
+      };
+
+      const result = getAgentOutputPaths(agent, tmpDir, agentConfig);
+
+      expect(result).toEqual([
+        '/custom/output.md',
+        path.join(tmpDir, '.mock.conf.yml'),
+        path.join(tmpDir, 'extra.txt'),
+      ]);
+    });
+
+    it('prefers outputPath over outputPathInstructions for multi-path agents', () => {
+      const agent = new MockMultiPathAgent();
+      const agentConfig: IAgentConfig = {
+        outputPath: '/custom/output.md',
         outputPathInstructions: '/custom/instructions.md',
       };
-      
+
       const result = getAgentOutputPaths(agent, tmpDir, agentConfig);
-      
+
       expect(result).toEqual([
-        '/custom/instructions.md',
+        '/custom/output.md',
         path.join(tmpDir, '.mock.conf.yml'),
         path.join(tmpDir, 'extra.txt'),
       ]);


### PR DESCRIPTION
Closes #458.

## Summary
- Treat generic `outputPath` as the instructions path override when collecting tracked paths for multi-path agents.
- Add unit coverage for multi-path outputPath precedence.
- Add e2e coverage that Aider with `output_path` tracks the custom instructions path in `.gitignore`.

## Testing
- `npm run format`
- `npm run lint`
- `npm test -- --runInBand`
- `npm run build`