### PR TITLE
fix(revert): clean local exclude blocks

### DIFF
--- a/src/revert.ts
+++ b/src/revert.ts
@@ -16,6 +16,9 @@ import {
 import { mapRawAgentConfigs } from './core/config-utils';
 
 const agents: IAgent[] = allAgents;
+const RULER_IGNORE_START_MARKER = '# START Ruler Generated Files';
+const RULER_IGNORE_END_MARKER = '# END Ruler Generated Files';
+const MANAGED_IGNORE_FILES = ['.gitignore', '.git/info/exclude'];
 
 export { allAgents };
 
@@ -146,11 +149,11 @@ export async function revertAllAgentConfigs(
   );
   totalFilesRemoved += cleanupResult.additionalFilesRemoved;
 
-  // Clean .gitignore if reverting all agents
-  const gitignoreCleaned =
+  // Clean managed ignore blocks if reverting all agents.
+  const cleanedIgnoreFiles =
     !config.cliAgents || config.cliAgents.length === 0
-      ? await cleanGitignore(projectRoot, verbose, dryRun)
-      : false;
+      ? await cleanManagedIgnoreFiles(projectRoot, verbose, dryRun)
+      : [];
 
   // Display summary
   const prefix = actionPrefix(dryRun);
@@ -172,57 +175,77 @@ export async function revertAllAgentConfigs(
       `  Empty directories removed: ${cleanupResult.directoriesRemoved}`,
     );
   }
-  if (gitignoreCleaned) {
-    console.log(`  .gitignore cleaned: yes`);
+  for (const ignoreFile of cleanedIgnoreFiles) {
+    console.log(`  ${ignoreFile} cleaned: yes`);
   }
 }
 
 /**
- * Removes the ruler-managed block from .gitignore file.
+ * Removes the ruler-managed block from ignore files Ruler can update.
  */
-async function cleanGitignore(
+async function cleanManagedIgnoreFiles(
   projectRoot: string,
   verbose: boolean,
   dryRun: boolean,
+): Promise<string[]> {
+  const cleanedFiles: string[] = [];
+
+  for (const ignoreFile of MANAGED_IGNORE_FILES) {
+    if (await cleanIgnoreFile(projectRoot, ignoreFile, verbose, dryRun)) {
+      cleanedFiles.push(ignoreFile);
+    }
+  }
+
+  return cleanedFiles;
+}
+
+async function cleanIgnoreFile(
+  projectRoot: string,
+  ignoreFile: string,
+  verbose: boolean,
+  dryRun: boolean,
 ): Promise<boolean> {
-  const gitignorePath = path.join(projectRoot, '.gitignore');
+  const ignorePath = path.join(projectRoot, ignoreFile);
 
   try {
-    await fs.access(gitignorePath);
+    await fs.access(ignorePath);
   } catch {
-    logVerbose('No .gitignore file found', verbose);
+    logVerbose(`No ${ignoreFile} file found`, verbose);
     return false;
   }
 
-  const content = await fs.readFile(gitignorePath, 'utf8');
-  const startMarker = '# START Ruler Generated Files';
-  const endMarker = '# END Ruler Generated Files';
+  const content = await fs.readFile(ignorePath, 'utf8');
 
-  const startIndex = content.indexOf(startMarker);
-  const endIndex = content.indexOf(endMarker);
+  const startIndex = content.indexOf(RULER_IGNORE_START_MARKER);
+  const endIndex = content.indexOf(RULER_IGNORE_END_MARKER);
 
   if (startIndex === -1 || endIndex === -1) {
-    logVerbose('No ruler-managed block found in .gitignore', verbose);
+    logVerbose(`No ruler-managed block found in ${ignoreFile}`, verbose);
     return false;
   }
 
   const prefix = actionPrefix(dryRun);
 
   if (dryRun) {
-    logVerbose(`${prefix} Would remove ruler block from .gitignore`, verbose);
+    logVerbose(
+      `${prefix} Would remove ruler block from ${ignoreFile}`,
+      verbose,
+    );
   } else {
     const beforeBlock = content.substring(0, startIndex);
-    const afterBlock = content.substring(endIndex + endMarker.length);
+    const afterBlock = content.substring(
+      endIndex + RULER_IGNORE_END_MARKER.length,
+    );
 
     let newContent = beforeBlock + afterBlock;
     newContent = newContent.replace(/\n{3,}/g, '\n\n'); // Replace 3+ newlines with 2
 
     if (newContent.trim() === '') {
-      await fs.unlink(gitignorePath);
-      logVerbose(`${prefix} Removed empty .gitignore file`, verbose);
+      await fs.unlink(ignorePath);
+      logVerbose(`${prefix} Removed empty ${ignoreFile} file`, verbose);
     } else {
-      await fs.writeFile(gitignorePath, newContent);
-      logVerbose(`${prefix} Removed ruler block from .gitignore`, verbose);
+      await fs.writeFile(ignorePath, newContent);
+      logVerbose(`${prefix} Removed ruler block from ${ignoreFile}`, verbose);
     }
   }
 

--- a/tests/e2e/ruler.test.ts
+++ b/tests/e2e/ruler.test.ts
@@ -55,6 +55,10 @@ describe('End-to-End Ruler CLI', () => {
       force: true,
     });
     await fs.rm(path.join(projectRoot, '.gitignore'), { force: true });
+    await fs.rm(path.join(projectRoot, '.git'), {
+      recursive: true,
+      force: true,
+    });
     // Clean up any custom files from previous tests
     await fs.rm(path.join(projectRoot, 'awesome.md'), { force: true });
     await fs.rm(path.join(projectRoot, 'custom-claude.md'), { force: true });
@@ -329,6 +333,27 @@ enabled = true`;
 
       expect(excludeContent).toContain('# START Ruler Generated Files');
       expect(excludeContent).toContain('CLAUDE.md');
+    });
+
+    it('removes generated paths from .git/info/exclude after local apply and revert', async () => {
+      runRulerWithInheritedStdio(
+        'apply --gitignore-local',
+        testProject.projectRoot,
+      );
+
+      const excludePath = path.join(
+        testProject.projectRoot,
+        '.git',
+        'info',
+        'exclude',
+      );
+      await expect(fs.readFile(excludePath, 'utf8')).resolves.toContain(
+        '# START Ruler Generated Files',
+      );
+
+      runRulerWithInheritedStdio('revert', testProject.projectRoot);
+
+      await expect(fs.access(excludePath)).rejects.toThrow();
     });
 
     it('updates existing .gitignore preserving other content', async () => {

--- a/tests/unit/core/revert.test.ts
+++ b/tests/unit/core/revert.test.ts
@@ -342,6 +342,37 @@ describe('Revert Core Functions', () => {
       expect(content).toBe('node_modules/\n\n*.log\n');
     });
 
+    it('removes the ruler-managed block from .git/info/exclude', async () => {
+      const excludePath = path.join(tmpDir, '.git', 'info', 'exclude');
+      await fs.mkdir(path.dirname(excludePath), { recursive: true });
+      await fs.writeFile(
+        excludePath,
+        [
+          '*.local',
+          '',
+          '# START Ruler Generated Files',
+          '/AGENTS.md',
+          '/CLAUDE.md',
+          '# END Ruler Generated Files',
+          '',
+          '*.secret',
+          '',
+        ].join('\n'),
+      );
+
+      await revertAllAgentConfigs(
+        tmpDir,
+        undefined,
+        undefined,
+        false,
+        false,
+        false,
+      );
+
+      const content = await fs.readFile(excludePath, 'utf8');
+      expect(content).toBe('*.local\n\n*.secret\n');
+    });
+
     it('removes .gitignore when it only contains the ruler-managed block', async () => {
       await fs.writeFile(
         path.join(tmpDir, '.gitignore'),


### PR DESCRIPTION
## Summary
- clean Ruler-managed ignore blocks from both `.gitignore` and `.git/info/exclude` during full revert
- keep focused-agent revert behavior unchanged by only running ignore cleanup for full revert
- add unit and e2e regressions for `.git/info/exclude` cleanup after `--gitignore-local`

Closes #449

## Testing
- npm run format
- npm run lint
- npm test -- --runInBand
- npm run build