### PR TITLE
fix(mcp): normalize mixed TOML servers

### DIFF
--- a/src/core/UnifiedConfigLoader.ts
+++ b/src/core/UnifiedConfigLoader.ts
@@ -240,6 +240,12 @@ export async function loadUnifiedConfig(
           });
         }
 
+        if (hasCommand && hasUrl) {
+          delete server.command;
+          delete server.args;
+          delete server.env;
+        }
+
         // Derive type - remote takes precedence if both are present
         if (server.url) {
           server.type = 'remote';

--- a/tests/apply-mcp.toml-remote.test.ts
+++ b/tests/apply-mcp.toml-remote.test.ts
@@ -56,4 +56,41 @@ url = "https://api.example.com/mcp"
       type: 'remote'
     });
   });
+
+  it('propagates mixed command/url TOML servers as remote', async () => {
+    const mixedProject = await setupTestProject({
+      '.ruler/ruler.toml': `[mcp]
+enabled = true
+merge_strategy = "merge"
+
+[mcp_servers.search]
+command = "npx"
+args = ["-y", "local-search"]
+url = "https://mcp.example.com/search"
+
+[mcp_servers.search.env]
+TOKEN = "stdio-only"
+`,
+      '.vscode/mcp.json': '{"mcpServers": {}}',
+    });
+
+    try {
+      runRuler('apply --agents copilot', mixedProject.projectRoot);
+
+      const nativePath = path.join(
+        mixedProject.projectRoot,
+        '.vscode',
+        'mcp.json',
+      );
+      const content = await fs.readFile(nativePath, 'utf8');
+      const config = JSON.parse(content);
+
+      expect(config.servers.search).toEqual({
+        url: 'https://mcp.example.com/search',
+        type: 'remote',
+      });
+    } finally {
+      await teardownTestProject(mixedProject.projectRoot);
+    }
+  });
 });


### PR DESCRIPTION
Closes #453

## Summary
- normalize TOML MCP servers that define both `command` and `url` by dropping stdio-only fields when `url` wins
- add an apply-level regression test proving mixed TOML servers propagate as remote MCP servers

## Tests
- npm run format
- npm run lint
- npx jest tests/apply-mcp.toml-remote.test.ts --runInBand
- npm test -- --runInBand
- npm run build