### PR TITLE
fix(cli): honor local-only config lookup

### DIFF
--- a/src/cli/handlers.ts
+++ b/src/cli/handlers.ts
@@ -60,6 +60,7 @@ async function resolveNestedPreference(
   argv: ApplyArgs,
   projectRoot: string,
   configPath: string | undefined,
+  localOnly: boolean,
 ): Promise<boolean> {
   if (argv.nested !== undefined) {
     // CLI explicitly set nested (either --nested or --no-nested)
@@ -70,6 +71,7 @@ async function resolveNestedPreference(
   const config = await loadConfig({
     projectRoot,
     configPath,
+    checkGlobal: !localOnly,
   });
   // Use TOML setting if available, otherwise default to false
   return config.nested ?? false;
@@ -127,7 +129,12 @@ export async function applyHandler(argv: ApplyArgs): Promise<void> {
 
   try {
     // Determine nested preference: CLI > TOML > Default (false)
-    const nested = await resolveNestedPreference(argv, projectRoot, configPath);
+    const nested = await resolveNestedPreference(
+      argv,
+      projectRoot,
+      configPath,
+      localOnly,
+    );
 
     await applyAllAgentConfigs(
       projectRoot,

--- a/src/core/ConfigLoader.ts
+++ b/src/core/ConfigLoader.ts
@@ -171,6 +171,8 @@ export interface ConfigOptions {
   configPath?: string;
   /** CLI filters from --agents option. */
   cliAgents?: string[];
+  /** Whether implicit config discovery may fall back to XDG_CONFIG_HOME/ruler. */
+  checkGlobal?: boolean;
 }
 
 /**
@@ -182,9 +184,10 @@ export async function loadConfig(
   options: ConfigOptions,
 ): Promise<LoadedConfig> {
   const { projectRoot, configPath, cliAgents } = options;
+  const checkGlobal = options.checkGlobal ?? true;
   const configFile = configPath
     ? path.resolve(configPath)
-    : await resolveImplicitConfigFile(projectRoot);
+    : await resolveImplicitConfigFile(projectRoot, checkGlobal);
 
   const raw = configFile ? await readConfigFile(configFile) : {};
 
@@ -341,10 +344,15 @@ export async function loadConfig(
 
 async function resolveImplicitConfigFile(
   projectRoot: string,
+  checkGlobal: boolean,
 ): Promise<string | undefined> {
   const localConfigFile = path.join(projectRoot, '.ruler', 'ruler.toml');
   if (await configFileExists(localConfigFile)) {
     return localConfigFile;
+  }
+
+  if (!checkGlobal) {
+    return undefined;
   }
 
   const xdgConfigDir =

--- a/src/core/UnifiedConfigLoader.ts
+++ b/src/core/UnifiedConfigLoader.ts
@@ -21,6 +21,7 @@ export interface UnifiedLoadOptions {
   cliAgents?: string[];
   cliMcpEnabled?: boolean;
   cliMcpStrategy?: string;
+  checkGlobal?: boolean;
 }
 
 export async function loadUnifiedConfig(
@@ -28,8 +29,10 @@ export async function loadUnifiedConfig(
 ): Promise<RulerUnifiedConfig> {
   // Resolve the effective .ruler directory (local or global), mirroring the main loader behavior
   const resolvedRulerDir =
-    (await FileSystemUtils.findRulerDir(options.projectRoot, true)) ||
-    path.join(options.projectRoot, '.ruler');
+    (await FileSystemUtils.findRulerDir(
+      options.projectRoot,
+      options.checkGlobal ?? true,
+    )) || path.join(options.projectRoot, '.ruler');
 
   const meta: ConfigMeta = {
     projectRoot: options.projectRoot,

--- a/src/core/apply-engine.ts
+++ b/src/core/apply-engine.ts
@@ -66,6 +66,7 @@ async function loadNestedConfigurations(
       rulerDir,
       configPath,
       resolvedNested,
+      localOnly,
     );
     const files = await FileSystemUtils.readMarkdownFiles(rulerDir, {
       includeAgents: shouldIncludeAgentsInRules(config),
@@ -76,6 +77,7 @@ async function loadNestedConfigurations(
         files,
         config,
         configPath,
+        localOnly,
       ),
     );
   }
@@ -96,6 +98,7 @@ async function createHierarchicalConfiguration(
   files: { path: string; content: string }[],
   config: LoadedConfig,
   cliConfigPath: string | undefined,
+  localOnly: boolean,
 ): Promise<HierarchicalRulerConfiguration> {
   await warnAboutLegacyMcpJson(rulerDir);
 
@@ -115,6 +118,7 @@ async function createHierarchicalConfiguration(
   const unifiedConfig = await loadUnifiedConfig({
     projectRoot: directoryRoot,
     configPath: configPathToUse,
+    checkGlobal: !localOnly,
   });
 
   let rulerMcpJson: Record<string, unknown> | null = null;
@@ -136,6 +140,7 @@ async function loadConfigForRulerDir(
   rulerDir: string,
   cliConfigPath: string | undefined,
   resolvedNested: boolean,
+  localOnly: boolean,
 ): Promise<LoadedConfig> {
   const directoryRoot = path.dirname(rulerDir);
   const localConfigPath = path.join(rulerDir, 'ruler.toml');
@@ -151,6 +156,7 @@ async function loadConfigForRulerDir(
   const loaded = await loadConfig({
     projectRoot: directoryRoot,
     configPath: hasLocalConfig ? localConfigPath : cliConfigPath,
+    checkGlobal: !localOnly,
   });
 
   const cloned = cloneLoadedConfig(loaded);
@@ -274,6 +280,7 @@ async function loadSingleConfiguration(
   const config = await loadConfig({
     projectRoot,
     configPath,
+    checkGlobal: !localOnly,
   });
 
   // Read rule files. `.ruler/agents/` is only included when
@@ -287,7 +294,11 @@ async function loadSingleConfiguration(
 
   // Load unified config to get merged MCP configuration
   const { loadUnifiedConfig } = await import('./UnifiedConfigLoader');
-  const unifiedConfig = await loadUnifiedConfig({ projectRoot, configPath });
+  const unifiedConfig = await loadUnifiedConfig({
+    projectRoot,
+    configPath,
+    checkGlobal: !localOnly,
+  });
 
   // Synthesize rulerMcpJson from unified MCP bundle for backward compatibility
   let rulerMcpJson: Record<string, unknown> | null = null;

--- a/src/revert.ts
+++ b/src/revert.ts
@@ -40,6 +40,7 @@ export async function revertAllAgentConfigs(
     projectRoot,
     cliAgents: includedAgents,
     configPath,
+    checkGlobal: !localOnly,
   });
 
   const rulerDir = await FileSystemUtils.findRulerDir(projectRoot, !localOnly);

--- a/tests/unit/cli/handlers.test.ts
+++ b/tests/unit/cli/handlers.test.ts
@@ -261,6 +261,7 @@ describe('CLI Handlers', () => {
       expect(loadConfig).toHaveBeenCalledWith({
         projectRoot: mockProjectRoot,
         configPath: undefined,
+        checkGlobal: true,
       });
       expect(applyAllAgentConfigs).toHaveBeenCalledWith(
         mockProjectRoot,
@@ -314,6 +315,42 @@ describe('CLI Handlers', () => {
         false,
         false,
         false, // nested should default to false
+        true,
+        undefined,
+        undefined,
+        undefined,
+      );
+    });
+
+    it('should not read global config while resolving nested for local-only apply', async () => {
+      const argv = {
+        'project-root': mockProjectRoot,
+        mcp: true,
+        'mcp-overwrite': false,
+        verbose: false,
+        'dry-run': false,
+        'local-only': true,
+        backup: true,
+      };
+
+      await applyHandler(argv);
+
+      expect(loadConfig).toHaveBeenCalledWith({
+        projectRoot: mockProjectRoot,
+        configPath: undefined,
+        checkGlobal: false,
+      });
+      expect(applyAllAgentConfigs).toHaveBeenCalledWith(
+        mockProjectRoot,
+        undefined,
+        undefined,
+        true,
+        undefined,
+        undefined,
+        false,
+        false,
+        true,
+        false,
         true,
         undefined,
         undefined,

--- a/tests/unit/core/ConfigLoader.test.ts
+++ b/tests/unit/core/ConfigLoader.test.ts
@@ -75,6 +75,24 @@ describe('ConfigLoader', () => {
     );
   });
 
+  it('ignores implicit global config when global lookup is disabled', async () => {
+    const globalRulerDir = path.join(
+      process.env.XDG_CONFIG_HOME as string,
+      'ruler',
+    );
+    await fs.mkdir(globalRulerDir, { recursive: true });
+    await fs.writeFile(path.join(globalRulerDir, 'ruler.toml'), 'nested = ');
+
+    const config = await loadConfig({
+      projectRoot: tmpDir,
+      checkGlobal: false,
+    });
+
+    expect(config.defaultAgents).toBeUndefined();
+    expect(config.agentConfigs).toEqual({});
+    expect(config.nested).toBe(false);
+  });
+
   it('throws when an existing implicit local config is unreadable', async () => {
     const configPath = path.join(rulerDir, 'ruler.toml');
     await fs.mkdir(configPath);


### PR DESCRIPTION
Closes #447.\n\n## Summary\n- prevent implicit global ruler.toml discovery when apply/revert run with --local-only\n- keep explicit --config behavior unchanged\n- add unit coverage for local-only nested resolution and global config suppression\n\n## Verification\n- npm run lint\n- npm test -- --runInBand\n- npm run build