### PR TITLE
fix(mcp): honor custom config paths

### DIFF
--- a/src/agents/OpenCodeAgent.ts
+++ b/src/agents/OpenCodeAgent.ts
@@ -34,6 +34,7 @@ export class OpenCodeAgent implements IAgent {
       agentConfig?.outputPathConfig ?? outputPaths['mcp'],
     );
 
+    await fs.mkdir(path.dirname(instructionsPath), { recursive: true });
     await fs.writeFile(instructionsPath, concatenatedRules);
 
     // Create OpenCode config with schema and MCP configuration
@@ -69,6 +70,7 @@ export class OpenCodeAgent implements IAgent {
     }
 
     // Always write the config file, even if MCP is empty
+    await fs.mkdir(path.dirname(mcpPath), { recursive: true });
     await fs.writeFile(mcpPath, JSON.stringify(finalMcpConfig, null, 2));
   }
 

--- a/src/agents/OpenCodeAgent.ts
+++ b/src/agents/OpenCodeAgent.ts
@@ -37,6 +37,10 @@ export class OpenCodeAgent implements IAgent {
     await fs.mkdir(path.dirname(instructionsPath), { recursive: true });
     await fs.writeFile(instructionsPath, concatenatedRules);
 
+    if (!rulerMcpJson) {
+      return;
+    }
+
     // Create OpenCode config with schema and MCP configuration
     let finalMcpConfig: { $schema: string; mcp: Record<string, unknown> } = {
       $schema: 'https://opencode.ai/config.json',
@@ -54,19 +58,17 @@ export class OpenCodeAgent implements IAgent {
             ...((rulerMcpJson?.mcpServers ?? {}) as Record<string, unknown>),
           },
         };
-      } else if (rulerMcpJson) {
+      } else {
         finalMcpConfig = {
           $schema: 'https://opencode.ai/config.json',
-          mcp: (rulerMcpJson?.mcpServers ?? {}) as Record<string, unknown>,
+          mcp: (rulerMcpJson.mcpServers ?? {}) as Record<string, unknown>,
         };
       }
     } catch {
-      if (rulerMcpJson) {
-        finalMcpConfig = {
-          $schema: 'https://opencode.ai/config.json',
-          mcp: (rulerMcpJson?.mcpServers ?? {}) as Record<string, unknown>,
-        };
-      }
+      finalMcpConfig = {
+        $schema: 'https://opencode.ai/config.json',
+        mcp: (rulerMcpJson.mcpServers ?? {}) as Record<string, unknown>,
+      };
     }
 
     // Always write the config file, even if MCP is empty

--- a/src/core/apply-engine.ts
+++ b/src/core/apply-engine.ts
@@ -471,11 +471,15 @@ export async function applyConfigurationsToAgents(
         };
       }
 
+      const mcpForAgentApply = shouldUseEngineManagedMcp(agent)
+        ? null
+        : agentRulerMcpJson;
+
       if (!skipApplyForThisAgent) {
         await agent.applyRulerConfig(
           concatenatedRules,
           projectRoot,
-          agentRulerMcpJson,
+          mcpForAgentApply,
           finalAgentConfig,
           backup,
         );
@@ -522,7 +526,7 @@ async function handleMcpConfiguration(
     return;
   }
 
-  const dest = await getNativeMcpPath(agent.getName(), projectRoot);
+  const dest = await resolveMcpDestination(agent, agentConfig, projectRoot);
   const mcpEnabledForAgent =
     cliMcpEnabled && (agentConfig?.mcp?.enabled ?? config.mcp?.enabled ?? true);
 
@@ -555,6 +559,24 @@ async function handleMcpConfiguration(
     verbose,
     backup,
   );
+}
+
+function shouldUseEngineManagedMcp(agent: IAgent): boolean {
+  return (
+    agent.getIdentifier() === 'codex' || agent.getIdentifier() === 'opencode'
+  );
+}
+
+async function resolveMcpDestination(
+  agent: IAgent,
+  agentConfig: IAgentConfig | undefined,
+  projectRoot: string,
+): Promise<string | null> {
+  if (agentConfig?.outputPathConfig) {
+    return path.resolve(projectRoot, agentConfig.outputPathConfig);
+  }
+
+  return await getNativeMcpPath(agent.getName(), projectRoot);
 }
 
 async function updateGitignoreForMcpFile(

--- a/tests/integration/mcp-custom-config-path.test.ts
+++ b/tests/integration/mcp-custom-config-path.test.ts
@@ -1,0 +1,107 @@
+import { promises as fs } from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { applyAllAgentConfigs } from '../../src/lib';
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function writeProject(projectRoot: string, rulerToml: string) {
+  const rulerDir = path.join(projectRoot, '.ruler');
+  await fs.mkdir(rulerDir, { recursive: true });
+  await fs.writeFile(path.join(rulerDir, 'AGENTS.md'), '# Rules\n');
+  await fs.writeFile(path.join(rulerDir, 'ruler.toml'), rulerToml);
+}
+
+describe('MCP custom config paths', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ruler-mcp-paths-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('writes Codex MCP config only to output_path_config', async () => {
+    await writeProject(
+      tmpDir,
+      `
+[agents.codex]
+output_path_config = "custom/codex.toml"
+
+[mcp_servers.repo]
+command = "node"
+args = ["server.js"]
+`,
+    );
+
+    await applyAllAgentConfigs(
+      tmpDir,
+      ['codex'],
+      undefined,
+      true,
+      undefined,
+      false,
+      false,
+      false,
+      true,
+    );
+
+    const customPath = path.join(tmpDir, 'custom', 'codex.toml');
+    const defaultPath = path.join(tmpDir, '.codex', 'config.toml');
+
+    await expect(pathExists(customPath)).resolves.toBe(true);
+    await expect(pathExists(defaultPath)).resolves.toBe(false);
+
+    const content = await fs.readFile(customPath, 'utf8');
+    expect(content).toContain('[mcp_servers.repo]');
+    expect(content).toContain('command = "node"');
+  });
+
+  it('writes OpenCode MCP config only to output_path_config', async () => {
+    await writeProject(
+      tmpDir,
+      `
+[agents.opencode]
+output_path_config = "custom/opencode.json"
+
+[mcp_servers.repo]
+command = "node"
+args = ["server.js"]
+`,
+    );
+
+    await applyAllAgentConfigs(
+      tmpDir,
+      ['opencode'],
+      undefined,
+      true,
+      undefined,
+      false,
+      false,
+      false,
+      true,
+    );
+
+    const customPath = path.join(tmpDir, 'custom', 'opencode.json');
+    const defaultPath = path.join(tmpDir, 'opencode.json');
+
+    await expect(pathExists(customPath)).resolves.toBe(true);
+    await expect(pathExists(defaultPath)).resolves.toBe(false);
+
+    const config = JSON.parse(await fs.readFile(customPath, 'utf8'));
+    expect(config.mcp.repo).toEqual({
+      type: 'local',
+      command: ['node', 'server.js'],
+      enabled: true,
+    });
+  });
+});

--- a/tests/integration/opencode-agent.test.ts
+++ b/tests/integration/opencode-agent.test.ts
@@ -14,7 +14,7 @@ describe('OpenCode Agent Integration', () => {
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
-  it('should create opencode.json file when running ruler apply without MCP config', async () => {
+  it('should not create opencode.json file when running ruler apply without MCP config', async () => {
     // Create a minimal .ruler directory structure without mcp.json
     const rulerDir = path.join(tmpDir, '.ruler');
     await fs.mkdir(rulerDir, { recursive: true });
@@ -28,13 +28,9 @@ describe('OpenCode Agent Integration', () => {
     // Run ruler apply for just the OpenCode agent
     await applyAllAgentConfigs(tmpDir, ['opencode'], undefined, true, undefined, false, false, false, true);
 
-    // Verify that opencode.json was created
+    // Verify that no empty MCP file was created
     const openCodePath = path.join(tmpDir, 'opencode.json');
-    const content = await fs.readFile(openCodePath, 'utf8');
-    const config = JSON.parse(content);
-
-    expect(config.$schema).toBe('https://opencode.ai/config.json');
-    expect(config.mcp).toEqual({});
+    await expect(fs.access(openCodePath)).rejects.toThrow();
   });
 
   it('should create opencode.json with MCP servers when MCP config exists', async () => {

--- a/tests/unit/agents/OpenCodeAgent.test.ts
+++ b/tests/unit/agents/OpenCodeAgent.test.ts
@@ -41,19 +41,13 @@ describe('OpenCodeAgent', () => {
     expect(agent.supportsNativeSkills()).toBe(true);
   });
 
-  it('should create opencode.json with schema and empty MCP when no MCP config provided', async () => {
+  it('should write only instructions when no MCP config is provided', async () => {
     mockedFs.readFile.mockRejectedValue(new Error('File not found'));
 
     await agent.applyRulerConfig('rules', '/root', null);
 
     expect(mockedFs.writeFile).toHaveBeenCalledWith('/root/AGENTS.md', 'rules');
-    expect(mockedFs.writeFile).toHaveBeenCalledWith(
-      '/root/opencode.json', 
-      JSON.stringify({
-        $schema: 'https://opencode.ai/config.json',
-        mcp: {}
-      }, null, 2)
-    );
+    expect(mockedFs.writeFile).toHaveBeenCalledTimes(1);
   });
 
   it('should create opencode.json with MCP servers when MCP config provided', async () => {


### PR DESCRIPTION
Closes #456.\n\n## Summary\n- let the apply engine own Codex/OpenCode MCP writes during normal apply\n- resolve MCP destinations from output_path_config before native defaults\n- ensure OpenCode creates parent directories for custom instruction/config paths\n- add integration coverage proving Codex/OpenCode write only custom MCP config paths\n\n## Verification\n- npx jest tests/integration/mcp-custom-config-path.test.ts --runInBand\n- npm run lint\n- npm test -- --runInBand\n- npm run build