### PR TITLE
Honor MCP overwrite for OpenHands and OpenCode

### DIFF
--- a/src/core/apply-engine.ts
+++ b/src/core/apply-engine.ts
@@ -646,6 +646,7 @@ async function applyMcpConfiguration(
     return await applyOpenHandsMcpConfiguration(
       agentMcpJson,
       dest,
+      cliMcpStrategy ?? agentConfig?.mcp?.strategy ?? config.mcp?.strategy,
       dryRun,
       verbose,
       backup,
@@ -656,6 +657,7 @@ async function applyMcpConfiguration(
     return await applyOpenCodeMcpConfiguration(
       agentMcpJson,
       dest,
+      cliMcpStrategy ?? agentConfig?.mcp?.strategy ?? config.mcp?.strategy,
       dryRun,
       verbose,
       backup,
@@ -692,6 +694,7 @@ async function applyMcpConfiguration(
 async function applyOpenHandsMcpConfiguration(
   filteredMcpJson: Record<string, unknown>,
   dest: string,
+  strategy: McpStrategy | undefined,
   dryRun: boolean,
   verbose: boolean,
   backup = true,
@@ -702,13 +705,14 @@ async function applyOpenHandsMcpConfiguration(
       verbose,
     );
   } else {
-    await propagateMcpToOpenHands(filteredMcpJson, dest, backup);
+    await propagateMcpToOpenHands(filteredMcpJson, dest, backup, strategy);
   }
 }
 
 async function applyOpenCodeMcpConfiguration(
   filteredMcpJson: Record<string, unknown>,
   dest: string,
+  strategy: McpStrategy | undefined,
   dryRun: boolean,
   verbose: boolean,
   backup = true,
@@ -719,7 +723,7 @@ async function applyOpenCodeMcpConfiguration(
       verbose,
     );
   } else {
-    await propagateMcpToOpenCode(filteredMcpJson, dest, backup);
+    await propagateMcpToOpenCode(filteredMcpJson, dest, backup, strategy);
   }
 }
 

--- a/src/mcp/propagateOpenCodeMcp.ts
+++ b/src/mcp/propagateOpenCodeMcp.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs/promises';
 import { ensureDirExists } from '../core/FileSystemUtils';
 import * as path from 'path';
+import { McpStrategy } from '../types';
 
 interface OpenCodeMcpServer {
   type: 'local' | 'remote';
@@ -100,6 +101,7 @@ export async function propagateMcpToOpenCode(
   rulerMcpData: Record<string, unknown> | null,
   openCodeConfigPath: string,
   backup = true,
+  strategy: McpStrategy = 'merge',
 ): Promise<void> {
   const rulerMcp: RulerMcp = rulerMcpData || {};
 
@@ -119,10 +121,13 @@ export async function propagateMcpToOpenCode(
   const finalConfig = {
     ...existingConfig,
     $schema: transformedConfig.$schema,
-    mcp: {
-      ...existingConfig.mcp,
-      ...transformedConfig.mcp,
-    },
+    mcp:
+      strategy === 'overwrite'
+        ? transformedConfig.mcp
+        : {
+            ...existingConfig.mcp,
+            ...transformedConfig.mcp,
+          },
   };
 
   await ensureDirExists(path.dirname(openCodeConfigPath));

--- a/src/mcp/propagateOpenHandsMcp.ts
+++ b/src/mcp/propagateOpenHandsMcp.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs/promises';
 import { parse as parseTOML, stringify } from '@iarna/toml';
 import { ensureDirExists } from '../core/FileSystemUtils';
 import * as path from 'path';
+import { McpStrategy } from '../types';
 
 interface StdioServer {
   name: string;
@@ -98,6 +99,7 @@ export async function propagateMcpToOpenHands(
   rulerMcpData: Record<string, unknown> | null,
   openHandsConfigPath: string,
   backup = true,
+  strategy: McpStrategy = 'merge',
 ): Promise<void> {
   const rulerMcp: Record<string, unknown> = rulerMcpData || {};
 
@@ -140,22 +142,28 @@ export async function propagateMcpToOpenHands(
     config.mcp.shttp_servers = [];
   }
 
-  // Build maps for merging existing servers
+  // Build maps for merging existing servers, or start fresh when overwriting.
   const existingStdioServers = new Map<string, StdioServer>(
-    config.mcp.stdio_servers.map((s: StdioServer) => [s.name, s]),
+    strategy === 'overwrite'
+      ? []
+      : config.mcp.stdio_servers.map((s: StdioServer) => [s.name, s]),
   );
 
   const existingSseServers = new Map<string, string | RemoteServerEntry>();
-  config.mcp.sse_servers.forEach((entry: string | RemoteServerEntry) => {
-    const url = typeof entry === 'string' ? entry : entry.url;
-    existingSseServers.set(url, entry);
-  });
+  if (strategy !== 'overwrite') {
+    config.mcp.sse_servers.forEach((entry: string | RemoteServerEntry) => {
+      const url = typeof entry === 'string' ? entry : entry.url;
+      existingSseServers.set(url, entry);
+    });
+  }
 
   const existingShttpServers = new Map<string, string | RemoteServerEntry>();
-  config.mcp.shttp_servers.forEach((entry: string | RemoteServerEntry) => {
-    const url = typeof entry === 'string' ? entry : entry.url;
-    existingShttpServers.set(url, entry);
-  });
+  if (strategy !== 'overwrite') {
+    config.mcp.shttp_servers.forEach((entry: string | RemoteServerEntry) => {
+      const url = typeof entry === 'string' ? entry : entry.url;
+      existingShttpServers.set(url, entry);
+    });
+  }
 
   for (const [name, serverDef] of Object.entries(rulerServers)) {
     if (isRulerMcpServer(serverDef)) {

--- a/tests/apply-mcp.overwrite.test.ts
+++ b/tests/apply-mcp.overwrite.test.ts
@@ -1,8 +1,11 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
-import os from 'os';
-import { execSync } from 'child_process';
-import { setupTestProject, teardownTestProject, runRulerWithInheritedStdio } from './harness';
+import { parse as parseTOML } from '@iarna/toml';
+import {
+  setupTestProject,
+  teardownTestProject,
+  runRulerWithInheritedStdio,
+} from './harness';
 
 describe('apply-mcp.overwrite', () => {
   let testProject: { projectRoot: string };
@@ -13,7 +16,7 @@ describe('apply-mcp.overwrite', () => {
 
     testProject = await setupTestProject({
       '.ruler/mcp.json': JSON.stringify(mcp, null, 2) + '\n',
-      '.vscode/mcp.json': JSON.stringify(native, null, 2) + '\n'
+      '.vscode/mcp.json': JSON.stringify(native, null, 2) + '\n',
     });
   });
 
@@ -23,14 +26,86 @@ describe('apply-mcp.overwrite', () => {
 
   it('overwrites existing native config when --mcp-overwrite is used', async () => {
     const { projectRoot } = testProject;
-    
+
     runRulerWithInheritedStdio('apply --mcp-overwrite', projectRoot);
-    
+
     const resultText = await fs.readFile(
       path.join(projectRoot, '.vscode', 'mcp.json'),
       'utf8',
     );
     const result = JSON.parse(resultText);
     expect(Object.keys(result.servers).sort()).toEqual(['foo']);
+  });
+
+  it('overwrites OpenHands MCP servers when --mcp-overwrite is used', async () => {
+    const { projectRoot } = testProject;
+    await fs.writeFile(
+      path.join(projectRoot, 'config.toml'),
+      `
+theme = "dark"
+
+[mcp]
+enable_editor = true
+stdio_servers = [
+  { name = "old", command = "old-command" }
+]
+shttp_servers = ["http://old.com"]
+`,
+    );
+
+    runRulerWithInheritedStdio(
+      'apply --agents openhands --mcp-overwrite',
+      projectRoot,
+    );
+
+    const resultText = await fs.readFile(
+      path.join(projectRoot, 'config.toml'),
+      'utf8',
+    );
+    const result: any = parseTOML(resultText);
+    expect(result.theme).toBe('dark');
+    expect(result.mcp.enable_editor).toBe(true);
+    expect(result.mcp.stdio_servers).toEqual([]);
+    expect(result.mcp.shttp_servers).toEqual(['http://foo.com']);
+  });
+
+  it('overwrites OpenCode MCP servers when --mcp-overwrite is used', async () => {
+    const { projectRoot } = testProject;
+    await fs.writeFile(
+      path.join(projectRoot, 'opencode.json'),
+      JSON.stringify(
+        {
+          $schema: 'https://opencode.ai/config.json',
+          theme: 'dark',
+          mcp: {
+            old: {
+              type: 'remote',
+              url: 'http://old.com',
+              enabled: true,
+            },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    runRulerWithInheritedStdio(
+      'apply --agents opencode --mcp-overwrite',
+      projectRoot,
+    );
+
+    const resultText = await fs.readFile(
+      path.join(projectRoot, 'opencode.json'),
+      'utf8',
+    );
+    const result = JSON.parse(resultText);
+    expect(result.theme).toBe('dark');
+    expect(Object.keys(result.mcp)).toEqual(['foo']);
+    expect(result.mcp.foo).toEqual({
+      type: 'remote',
+      url: 'http://foo.com',
+      enabled: true,
+    });
   });
 });

--- a/tests/unit/mcp/OpenCodeMcp.test.ts
+++ b/tests/unit/mcp/OpenCodeMcp.test.ts
@@ -165,6 +165,43 @@ describe('OpenCode MCP Integration', () => {
       });
     });
 
+    it('overwrites existing OpenCode MCP servers while preserving unrelated settings', async () => {
+      const openCodePath = path.join(tmpDir, 'opencode.json');
+
+      const existingConfig = {
+        $schema: 'https://opencode.ai/config.json',
+        mcp: {
+          'existing-server': {
+            type: 'local',
+            command: ['existing-command'],
+            enabled: true,
+          },
+        },
+        otherSetting: 'preserved',
+      };
+      await fs.writeFile(openCodePath, JSON.stringify(existingConfig));
+
+      const rulerMcp = {
+        mcpServers: {
+          'new-server': {
+            command: 'new-command',
+          },
+        },
+      };
+
+      await propagateMcpToOpenCode(rulerMcp, openCodePath, false, 'overwrite');
+
+      const result = JSON.parse(await fs.readFile(openCodePath, 'utf8'));
+
+      expect(result.otherSetting).toBe('preserved');
+      expect(Object.keys(result.mcp)).toEqual(['new-server']);
+      expect(result.mcp['new-server']).toEqual({
+        type: 'local',
+        command: ['new-command'],
+        enabled: true,
+      });
+    });
+
     it('creates minimal opencode.json when no ruler MCP config exists', async () => {
       const openCodePath = path.join(tmpDir, 'opencode.json');
 

--- a/tests/unit/mcp/OpenHandsMcp.test.ts
+++ b/tests/unit/mcp/OpenHandsMcp.test.ts
@@ -68,6 +68,48 @@ stdio_servers = [
     });
   });
 
+  it('overwrites MCP server sections while preserving unrelated settings', async () => {
+    const rulerMcp = {
+      mcpServers: {
+        git: { command: 'npx', args: ['mcp-git'] },
+        api: { url: 'https://api.example.com/mcp' },
+      },
+    };
+
+    const existingToml = `
+theme = "dark"
+
+[mcp]
+enable_editor = true
+stdio_servers = [
+  { name = "fs", command = "npx", args = ["mcp-fs"] }
+]
+shttp_servers = ["https://old.example.com/mcp"]
+    `;
+    await fs.writeFile(openHandsConfigPath, existingToml);
+
+    await propagateMcpToOpenHands(
+      rulerMcp,
+      openHandsConfigPath,
+      false,
+      'overwrite',
+    );
+
+    const content = await fs.readFile(openHandsConfigPath, 'utf8');
+    const parsed: any = parseTOML(content);
+    expect(parsed.theme).toBe('dark');
+    expect(parsed.mcp.enable_editor).toBe(true);
+    expect(parsed.mcp.stdio_servers).toEqual([
+      {
+        name: 'git',
+        command: 'npx',
+        args: ['mcp-git'],
+      },
+    ]);
+    expect(parsed.mcp.shttp_servers).toEqual(['https://api.example.com/mcp']);
+    expect(parsed.mcp.sse_servers).toEqual([]);
+  });
+
   it('should not add duplicate servers', async () => {
     const rulerMcp = {
       mcpServers: { fs: { command: 'uvx', args: ['mcp-fs-new'] } },
@@ -165,9 +207,9 @@ stdio_servers = [
 
   it('should propagate remote servers to shttp_servers by default', async () => {
     const rulerMcp = {
-      mcpServers: { 
+      mcpServers: {
         api: { url: 'https://api.example.com/mcp' },
-        search: { url: 'https://search.example.com' }
+        search: { url: 'https://search.example.com' },
       },
     };
 
@@ -176,7 +218,7 @@ stdio_servers = [
     const content = await fs.readFile(openHandsConfigPath, 'utf8');
     const parsed = parseTOML(content);
     const mcp: any = parsed.mcp;
-    
+
     expect(mcp.shttp_servers).toHaveLength(2);
     expect(mcp.shttp_servers).toContain('https://api.example.com/mcp');
     expect(mcp.shttp_servers).toContain('https://search.example.com');
@@ -185,9 +227,9 @@ stdio_servers = [
 
   it('should classify URLs with /sse path as sse_servers', async () => {
     const rulerMcp = {
-      mcpServers: { 
+      mcpServers: {
         sse_api: { url: 'https://api.example.com/sse/mcp' },
-        realtime: { url: 'https://realtime.example.com/mcp/sse' }
+        realtime: { url: 'https://realtime.example.com/mcp/sse' },
       },
     };
 
@@ -196,7 +238,7 @@ stdio_servers = [
     const content = await fs.readFile(openHandsConfigPath, 'utf8');
     const parsed = parseTOML(content);
     const mcp: any = parsed.mcp;
-    
+
     expect(mcp.sse_servers).toHaveLength(2);
     expect(mcp.sse_servers).toContain('https://api.example.com/sse/mcp');
     expect(mcp.sse_servers).toContain('https://realtime.example.com/mcp/sse');
@@ -205,11 +247,11 @@ stdio_servers = [
 
   it('should extract api_key from Authorization Bearer header when it is the only header', async () => {
     const rulerMcp = {
-      mcpServers: { 
-        auth_api: { 
+      mcpServers: {
+        auth_api: {
           url: 'https://secure.example.com/mcp',
-          headers: { Authorization: 'Bearer secret-token-123' }
-        }
+          headers: { Authorization: 'Bearer secret-token-123' },
+        },
       },
     };
 
@@ -218,25 +260,25 @@ stdio_servers = [
     const content = await fs.readFile(openHandsConfigPath, 'utf8');
     const parsed = parseTOML(content);
     const mcp: any = parsed.mcp;
-    
+
     expect(mcp.shttp_servers).toHaveLength(1);
     expect(mcp.shttp_servers[0]).toEqual({
       url: 'https://secure.example.com/mcp',
-      api_key: 'secret-token-123'
+      api_key: 'secret-token-123',
     });
   });
 
   it('should fallback to simple URL when headers contain non-auth headers', async () => {
     const rulerMcp = {
-      mcpServers: { 
-        complex_api: { 
+      mcpServers: {
+        complex_api: {
           url: 'https://complex.example.com/mcp',
-          headers: { 
+          headers: {
             Authorization: 'Bearer token-123',
             'X-Custom-Header': 'custom-value',
-            'X-Another': 'another-value'
-          }
-        }
+            'X-Another': 'another-value',
+          },
+        },
       },
     };
 
@@ -245,7 +287,7 @@ stdio_servers = [
     const content = await fs.readFile(openHandsConfigPath, 'utf8');
     const parsed = parseTOML(content);
     const mcp: any = parsed.mcp;
-    
+
     expect(mcp.shttp_servers).toHaveLength(1);
     // Should be simple URL string (no api_key extraction due to extra headers)
     expect(mcp.shttp_servers[0]).toBe('https://complex.example.com/mcp');
@@ -253,8 +295,8 @@ stdio_servers = [
 
   it('should merge remote servers with existing OpenHands config', async () => {
     const rulerMcp = {
-      mcpServers: { 
-        new_api: { url: 'https://new.example.com/mcp' }
+      mcpServers: {
+        new_api: { url: 'https://new.example.com/mcp' },
       },
     };
 
@@ -277,24 +319,30 @@ args = ["mcp-fs"]
     const content = await fs.readFile(openHandsConfigPath, 'utf8');
     const parsed = parseTOML(content);
     const mcp: any = parsed.mcp;
-    
+
     expect(mcp.shttp_servers).toHaveLength(2);
-    expect(mcp.shttp_servers).toContainEqual({ url: 'https://existing.example.com' });
-    expect(mcp.shttp_servers).toContainEqual({ url: 'https://new.example.com/mcp' });
-    
+    expect(mcp.shttp_servers).toContainEqual({
+      url: 'https://existing.example.com',
+    });
+    expect(mcp.shttp_servers).toContainEqual({
+      url: 'https://new.example.com/mcp',
+    });
+
     expect(mcp.sse_servers).toHaveLength(1);
-    expect(mcp.sse_servers).toContainEqual({ url: 'https://existing-sse.example.com/sse' });
-    
+    expect(mcp.sse_servers).toContainEqual({
+      url: 'https://existing-sse.example.com/sse',
+    });
+
     expect(mcp.stdio_servers).toHaveLength(1);
     expect(mcp.stdio_servers[0].name).toBe('fs');
   });
 
   it('should handle mixed stdio and remote servers', async () => {
     const rulerMcp = {
-      mcpServers: { 
+      mcpServers: {
         fs: { command: 'npx', args: ['mcp-fs'] },
         api: { url: 'https://api.example.com/mcp' },
-        sse_service: { url: 'https://realtime.example.com/sse' }
+        sse_service: { url: 'https://realtime.example.com/sse' },
       },
     };
 
@@ -303,28 +351,28 @@ args = ["mcp-fs"]
     const content = await fs.readFile(openHandsConfigPath, 'utf8');
     const parsed = parseTOML(content);
     const mcp: any = parsed.mcp;
-    
+
     expect(mcp.stdio_servers).toHaveLength(1);
     expect(mcp.stdio_servers[0]).toEqual({
       name: 'fs',
       command: 'npx',
-      args: ['mcp-fs']
+      args: ['mcp-fs'],
     });
-    
+
     expect(mcp.shttp_servers).toHaveLength(1);
     expect(mcp.shttp_servers[0]).toBe('https://api.example.com/mcp');
-    
+
     expect(mcp.sse_servers).toHaveLength(1);
     expect(mcp.sse_servers[0]).toBe('https://realtime.example.com/sse');
   });
 
   it('should overwrite remote servers with same URL', async () => {
     const rulerMcp = {
-      mcpServers: { 
-        updated_api: { 
+      mcpServers: {
+        updated_api: {
           url: 'https://api.example.com/mcp',
-          headers: { Authorization: 'Bearer new-token' }
-        }
+          headers: { Authorization: 'Bearer new-token' },
+        },
       },
     };
 
@@ -339,12 +387,12 @@ url = "https://api.example.com/mcp"
     const content = await fs.readFile(openHandsConfigPath, 'utf8');
     const parsed = parseTOML(content);
     const mcp: any = parsed.mcp;
-    
+
     expect(mcp.shttp_servers).toHaveLength(1);
     // Should be updated with api_key object
     expect(mcp.shttp_servers[0]).toEqual({
       url: 'https://api.example.com/mcp',
-      api_key: 'new-token'
+      api_key: 'new-token',
     });
   });
 });


### PR DESCRIPTION
Closes #452.

## Summary
- Pass the resolved MCP merge strategy into the OpenHands and OpenCode propagation paths.
- Make OpenHands overwrite replace stdio/sse/shttp server sections while preserving unrelated TOML settings.
- Make OpenCode overwrite replace the MCP server map while preserving unrelated top-level config.
- Add direct helper coverage and CLI regression tests for `--mcp-overwrite`.

## Tests
- `npm run lint`
- `npm test -- --runInBand`
- `npm run build`