### PR TITLE
Fix nested apply global output root

### DIFF
--- a/src/core/apply-engine.ts
+++ b/src/core/apply-engine.ts
@@ -200,23 +200,14 @@ async function findRulerDirectories(
 ): Promise<{ dirs: string[]; primaryDir: string }> {
   if (hierarchical) {
     const dirs = await FileSystemUtils.findAllRulerDirs(projectRoot);
-    const allDirs = [...dirs];
 
-    // Add global config if not local-only
-    if (!localOnly) {
-      const globalDir = await FileSystemUtils.findGlobalRulerDir();
-      if (globalDir) {
-        allDirs.push(globalDir);
-      }
-    }
-
-    if (allDirs.length === 0) {
+    if (dirs.length === 0) {
       throw createRulerError(
         `.ruler directory not found`,
         `Searched from: ${projectRoot}`,
       );
     }
-    return { dirs: allDirs, primaryDir: allDirs[0] };
+    return { dirs, primaryDir: dirs[0] };
   } else {
     const dir = await FileSystemUtils.findRulerDir(projectRoot, !localOnly);
     if (!dir) {

--- a/tests/e2e/ruler.test.ts
+++ b/tests/e2e/ruler.test.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import os from 'os';
 import { parse as parseTOML } from '@iarna/toml';
-import { execSync } from 'child_process';
+import { execFileSync, execSync } from 'child_process';
 import {
   setupTestProject,
   teardownTestProject,
@@ -211,6 +211,52 @@ output_path = "awesome.md"
     await expect(
       fs.readFile(path.join(testProject.projectRoot, 'awesome.md'), 'utf8'),
     ).resolves.toContain('Rule A');
+  });
+
+  it('does not generate nested apply outputs in XDG_CONFIG_HOME', async () => {
+    const xdgConfigHome = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'ruler-xdg-config-'),
+    );
+    const nestedProject = await setupTestProject({
+      '.ruler/AGENTS.md': '# Project Rule',
+      '.ruler/ruler.toml': `default_agents = ["claude"]\nnested = true\n`,
+    });
+    const globalRulerDir = path.join(xdgConfigHome, 'ruler');
+
+    try {
+      await fs.mkdir(globalRulerDir, { recursive: true });
+      await fs.writeFile(
+        path.join(globalRulerDir, 'AGENTS.md'),
+        '# Global Rule',
+      );
+
+      execFileSync(
+        'node',
+        [
+          'dist/cli/index.js',
+          'apply',
+          '--nested',
+          '--agents',
+          'claude',
+          '--project-root',
+          nestedProject.projectRoot,
+        ],
+        {
+          env: { ...process.env, XDG_CONFIG_HOME: xdgConfigHome },
+          stdio: 'inherit',
+        },
+      );
+
+      await expect(
+        fs.readFile(path.join(nestedProject.projectRoot, 'CLAUDE.md'), 'utf8'),
+      ).resolves.toContain('Project Rule');
+      await expect(
+        fs.stat(path.join(xdgConfigHome, 'CLAUDE.md')),
+      ).rejects.toThrow();
+    } finally {
+      await teardownTestProject(nestedProject.projectRoot);
+      await fs.rm(xdgConfigHome, { recursive: true, force: true });
+    }
   });
 
   describe('gitignore CLI flags', () => {

--- a/tests/unit/core/apply-engine.test.ts
+++ b/tests/unit/core/apply-engine.test.ts
@@ -429,6 +429,40 @@ command = "sub-cmd"
         true,
       );
     });
+
+    it('does not treat the global ruler directory as a nested output root', async () => {
+      const originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+      const xdgConfigHome = path.join(tmpDir, 'xdg-config-home');
+      const globalRulerDir = path.join(xdgConfigHome, 'ruler');
+
+      try {
+        process.env.XDG_CONFIG_HOME = xdgConfigHome;
+        await fs.mkdir(globalRulerDir, { recursive: true });
+        await fs.writeFile(
+          path.join(globalRulerDir, 'AGENTS.md'),
+          '# Global Instructions',
+        );
+        await fs.writeFile(
+          path.join(rulerDir, 'AGENTS.md'),
+          '# Project Instructions',
+        );
+
+        const configs = await loadNestedConfigurations(
+          tmpDir,
+          undefined,
+          false,
+          true,
+        );
+
+        expect(configs.map((config) => config.rulerDir)).toEqual([rulerDir]);
+      } finally {
+        if (originalXdgConfigHome === undefined) {
+          delete process.env.XDG_CONFIG_HOME;
+        } else {
+          process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
+        }
+      }
+    });
   });
 
   describe('processHierarchicalConfigurations', () => {


### PR DESCRIPTION
## Summary
- exclude the global ruler directory from hierarchical nested output roots
- keep nested apply focused on project-local `.ruler` directories
- add unit and end-to-end regressions proving XDG_CONFIG_HOME is not written during nested apply

Closes #448

## Tests
- `npx prettier --write tests/e2e/ruler.test.ts`
- `npm run lint`
- `npm test -- --runInBand`
- `npm run build`