### PR TITLE
ci(release): use supported Node for publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,11 +9,11 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '18.x'
+          node-version: '22.12.0'
           registry-url: 'https://registry.npmjs.org/'
       - run: npm ci
       - run: npm run build


### PR DESCRIPTION
Closes #460.

## Summary
- update release workflow checkout/setup-node actions to v4
- publish with Node 22.12.0, matching the package engine range

## Verification
- npm run lint
- npm test -- --runInBand
- npm run build
- focused subagent review: no findings