### PR TITLE
ci(release): run quality checks before publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ jobs:
           node-version: '22.12.0'
           registry-url: 'https://registry.npmjs.org/'
       - run: npm ci
+      - run: npm run lint
+      - run: npm test
       - run: npm run build
       - run: npm publish --access public
         env:


### PR DESCRIPTION
Closes #461.

## Summary
- run lint in the release workflow before build and publish
- run the test suite in the release workflow before build and publish

## Verification
- npm run lint
- npm test -- --runInBand
- npm run build
- focused subagent review: no findings