### PR TITLE
Honor effective MCP settings for internal agents

### DIFF
--- a/src/agents/CrushAgent.ts
+++ b/src/agents/CrushAgent.ts
@@ -75,6 +75,8 @@ export class CrushAgent implements IAgent {
     // Always transform from mcpServers ({ mcpServers: ... }) to { mcp: ... } for Crush
     let finalMcpConfig: { mcp: Record<string, unknown> } = { mcp: {} };
 
+    const strategy = agentConfig?.mcp?.strategy ?? 'merge';
+
     try {
       const existingMcpConfig = JSON.parse(await fs.readFile(mcpPath, 'utf-8'));
       if (existingMcpConfig && typeof existingMcpConfig === 'object') {
@@ -84,7 +86,7 @@ export class CrushAgent implements IAgent {
         finalMcpConfig = {
           ...existingMcpConfig,
           mcp: {
-            ...(existingMcpConfig.mcp || {}),
+            ...(strategy === 'merge' ? existingMcpConfig.mcp || {} : {}),
             ...transformedServers,
           },
         };

--- a/src/core/apply-engine.ts
+++ b/src/core/apply-engine.ts
@@ -456,26 +456,28 @@ export async function applyConfigurationsToAgents(
           agentsMdWritten = true;
         }
       }
-      let finalAgentConfig = agentConfig;
-      if (agent.getIdentifier() === 'augmentcode' && agentRulerMcpJson) {
-        const resolvedStrategy =
-          cliMcpStrategy ??
-          agentConfig?.mcp?.strategy ??
-          config.mcp?.strategy ??
-          'merge';
-
-        finalAgentConfig = {
-          ...agentConfig,
-          mcp: {
-            ...agentConfig?.mcp,
-            strategy: resolvedStrategy,
-          },
-        };
-      }
+      const effectiveMcpEnabled =
+        cliMcpEnabled &&
+        (agentConfig?.mcp?.enabled ?? config.mcp?.enabled ?? true);
+      const effectiveMcpStrategy =
+        cliMcpStrategy ??
+        agentConfig?.mcp?.strategy ??
+        config.mcp?.strategy ??
+        'merge';
+      const finalAgentConfig = {
+        ...agentConfig,
+        mcp: {
+          ...agentConfig?.mcp,
+          enabled: effectiveMcpEnabled,
+          strategy: effectiveMcpStrategy,
+        },
+      };
 
       const mcpForAgentApply = shouldUseEngineManagedMcp(agent)
         ? null
-        : agentRulerMcpJson;
+        : effectiveMcpEnabled
+          ? agentRulerMcpJson
+          : null;
 
       if (!skipApplyForThisAgent) {
         await agent.applyRulerConfig(

--- a/tests/mcp-key-gemini.test.ts
+++ b/tests/mcp-key-gemini.test.ts
@@ -1,6 +1,10 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
-import { setupTestProject, teardownTestProject, runRulerWithInheritedStdio } from './harness';
+import {
+  setupTestProject,
+  teardownTestProject,
+  runRulerWithInheritedStdio,
+} from './harness';
 
 describe('Gemini MCP key usage', () => {
   let projectRoot: string;
@@ -10,9 +14,9 @@ describe('Gemini MCP key usage', () => {
       '.ruler/AGENTS.md': 'Rule A',
       '.ruler/mcp.json': JSON.stringify({
         mcpServers: {
-          example: { type: 'stdio', command: 'node', args: ['server.js'] }
-        }
-      })
+          example: { type: 'stdio', command: 'node', args: ['server.js'] },
+        },
+      }),
     });
     projectRoot = tmp.projectRoot;
   });
@@ -31,5 +35,68 @@ describe('Gemini MCP key usage', () => {
     expect(json['']).toBeUndefined();
     expect(Object.keys(json.mcpServers)).toContain('example');
   });
-});
 
+  it('honors --no-mcp for Gemini MCP settings', async () => {
+    const tmp = await setupTestProject({
+      '.ruler/AGENTS.md': 'Rule A',
+      '.ruler/mcp.json': JSON.stringify({
+        mcpServers: {
+          example: { type: 'stdio', command: 'node', args: ['server.js'] },
+        },
+      }),
+      '.gemini/settings.json': JSON.stringify({
+        mcpServers: {
+          existing: { command: 'old-server' },
+        },
+      }),
+    });
+
+    try {
+      runRulerWithInheritedStdio(
+        'apply --agents gemini-cli --no-mcp',
+        tmp.projectRoot,
+      );
+      const raw = await fs.readFile(
+        path.join(tmp.projectRoot, '.gemini', 'settings.json'),
+        'utf8',
+      );
+      const json = JSON.parse(raw);
+      expect(Object.keys(json.mcpServers)).toEqual(['existing']);
+      expect(json.contextFileName).toBe('AGENTS.md');
+    } finally {
+      await teardownTestProject(tmp.projectRoot);
+    }
+  });
+
+  it('honors global overwrite strategy for Gemini MCP settings', async () => {
+    const tmp = await setupTestProject({
+      '.ruler/AGENTS.md': 'Rule A',
+      '.ruler/ruler.toml': `
+[mcp]
+merge_strategy = "overwrite"
+
+[mcp_servers.example]
+command = "node"
+args = ["server.js"]
+`,
+      '.gemini/settings.json': JSON.stringify({
+        mcpServers: {
+          existing: { command: 'old-server' },
+        },
+      }),
+    });
+
+    try {
+      runRulerWithInheritedStdio('apply --agents gemini-cli', tmp.projectRoot);
+      const raw = await fs.readFile(
+        path.join(tmp.projectRoot, '.gemini', 'settings.json'),
+        'utf8',
+      );
+      const json = JSON.parse(raw);
+      expect(Object.keys(json.mcpServers)).toEqual(['example']);
+      expect(json.contextFileName).toBe('AGENTS.md');
+    } finally {
+      await teardownTestProject(tmp.projectRoot);
+    }
+  });
+});

--- a/tests/unit/agents/CrushAgent.test.ts
+++ b/tests/unit/agents/CrushAgent.test.ts
@@ -70,6 +70,30 @@ describe('CrushAgent', () => {
     });
   });
 
+  it('should overwrite .crush.json mcp servers when configured', async () => {
+    const initialMcp = {
+      mcp: {
+        'existing-mcp': { command: 'ls' },
+      },
+    };
+    const mcpPath = path.join(projectRoot, '.crush.json');
+    await fs.writeFile(mcpPath, JSON.stringify(initialMcp, null, 2));
+
+    const rules = 'new rules';
+    const newMcpJson = { mcpServers: { 'new-mcp': { command: 'pwd' } } };
+    await agent.applyRulerConfig(rules, projectRoot, newMcpJson, {
+      mcp: { enabled: true, strategy: 'overwrite' },
+    });
+
+    const updatedMcpContent = JSON.parse(await fs.readFile(mcpPath, 'utf-8'));
+
+    expect(updatedMcpContent).toEqual({
+      mcp: {
+        'new-mcp': { command: 'pwd' },
+      },
+    });
+  });
+
   it('should not create .crush.json if no MCP config provided', async () => {
     const rules = 'some rules';
     await agent.applyRulerConfig(rules, projectRoot, null);
@@ -188,7 +212,7 @@ describe('CrushAgent', () => {
     beforeEach(async () => {
       tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'crush-agent-test-'));
       testAgent = new CrushAgent();
-      
+
       // Create .ruler directory for revert functionality
       const rulerDir = path.join(tmpDir, '.ruler');
       await fs.mkdir(rulerDir, { recursive: true });
@@ -202,19 +226,26 @@ describe('CrushAgent', () => {
     it('should be properly reverted by revertAllAgentConfigs', async () => {
       const rules = 'Crush agent rules';
       const mcpJson = { mcpServers: { 'test-server': { command: 'echo' } } };
-      
+
       await testAgent.applyRulerConfig(rules, tmpDir, mcpJson);
-      
+
       const instructionsPath = path.join(tmpDir, 'CRUSH.md');
       const mcpPath = path.join(tmpDir, '.crush.json');
-      
+
       // Verify files exist
       await expect(fs.access(instructionsPath)).resolves.toBeUndefined();
       await expect(fs.access(mcpPath)).resolves.toBeUndefined();
-      
+
       // Revert crush agent
-      await revertAllAgentConfigs(tmpDir, ['crush'], undefined, false, false, false);
-      
+      await revertAllAgentConfigs(
+        tmpDir,
+        ['crush'],
+        undefined,
+        false,
+        false,
+        false,
+      );
+
       // Verify both files are removed
       await expect(fs.access(instructionsPath)).rejects.toThrow();
       await expect(fs.access(mcpPath)).rejects.toThrow();
@@ -225,36 +256,43 @@ describe('CrushAgent', () => {
       const mcpPath = path.join(tmpDir, '.crush.json');
       const instructionsBackup = `${instructionsPath}.bak`;
       const mcpBackup = `${mcpPath}.bak`;
-      
+
       const originalInstructions = 'Original Crush instructions';
       const originalMcp = { mcp: { 'original-server': { command: 'ls' } } };
       const newInstructions = 'New Crush rules';
       const newMcp = { mcp: { 'new-server': { command: 'pwd' } } };
-      
+
       // Create original files and backups
       await fs.writeFile(instructionsPath, originalInstructions);
       await fs.writeFile(mcpPath, JSON.stringify(originalMcp, null, 2));
       await fs.writeFile(instructionsBackup, originalInstructions);
       await fs.writeFile(mcpBackup, JSON.stringify(originalMcp, null, 2));
-      
+
       // Overwrite with new content (simulating ruler apply)
       await fs.writeFile(instructionsPath, newInstructions);
       await fs.writeFile(mcpPath, JSON.stringify(newMcp, null, 2));
-      
+
       // Verify new content is in place
       expect(await fs.readFile(instructionsPath, 'utf8')).toBe(newInstructions);
       expect(JSON.parse(await fs.readFile(mcpPath, 'utf8'))).toEqual(newMcp);
-      
+
       // Revert
-      await revertAllAgentConfigs(tmpDir, ['crush'], undefined, false, false, false);
-      
+      await revertAllAgentConfigs(
+        tmpDir,
+        ['crush'],
+        undefined,
+        false,
+        false,
+        false,
+      );
+
       // Verify original content is restored
       const restoredInstructions = await fs.readFile(instructionsPath, 'utf8');
       const restoredMcp = JSON.parse(await fs.readFile(mcpPath, 'utf8'));
-      
+
       expect(restoredInstructions).toBe(originalInstructions);
       expect(restoredMcp).toEqual(originalMcp);
-      
+
       // Verify backups are cleaned up (default behavior)
       await expect(fs.access(instructionsBackup)).rejects.toThrow();
       await expect(fs.access(mcpBackup)).rejects.toThrow();
@@ -265,45 +303,53 @@ describe('CrushAgent', () => {
       const customMcpPath = 'custom-crush.json';
       const rules = 'Custom rules';
       const mcpJson = { mcpServers: { 'custom-server': { command: 'echo' } } };
-      
-      const customInstructionsFullPath = path.join(tmpDir, customInstructionsPath);
+
+      const customInstructionsFullPath = path.join(
+        tmpDir,
+        customInstructionsPath,
+      );
       const customMcpFullPath = path.join(tmpDir, customMcpPath);
-      
+
       await testAgent.applyRulerConfig(rules, tmpDir, mcpJson, {
         outputPathInstructions: customInstructionsFullPath,
-        outputPathConfig: customMcpFullPath
+        outputPathConfig: customMcpFullPath,
       });
-      
-      const instructionsContent = await fs.readFile(customInstructionsFullPath, 'utf8');
-      const mcpContent = JSON.parse(await fs.readFile(customMcpFullPath, 'utf8'));
-      
+
+      const instructionsContent = await fs.readFile(
+        customInstructionsFullPath,
+        'utf8',
+      );
+      const mcpContent = JSON.parse(
+        await fs.readFile(customMcpFullPath, 'utf8'),
+      );
+
       expect(instructionsContent).toBe(rules);
       expect(mcpContent).toEqual({ mcp: mcpJson.mcpServers });
     });
 
     it('should properly merge existing MCP configuration', async () => {
       const mcpPath = path.join(tmpDir, '.crush.json');
-      
+
       // Create existing MCP config
       const existingMcp = {
         mcp: {
-          'existing-server': { command: 'ls' }
-        }
+          'existing-server': { command: 'ls' },
+        },
       };
       await fs.writeFile(mcpPath, JSON.stringify(existingMcp, null, 2));
-      
+
       // Apply new config
       const rules = 'rules';
       const newMcpJson = { mcpServers: { 'new-server': { command: 'pwd' } } };
       await testAgent.applyRulerConfig(rules, tmpDir, newMcpJson);
-      
+
       // Verify merged result
       const mergedMcp = JSON.parse(await fs.readFile(mcpPath, 'utf8'));
       expect(mergedMcp).toEqual({
         mcp: {
           'existing-server': { command: 'ls' },
-          'new-server': { command: 'pwd' }
-        }
+          'new-server': { command: 'pwd' },
+        },
       });
     });
   });


### PR DESCRIPTION
## Summary
- pass effective MCP enabled/strategy values into agent adapters before they write MCP config
- pass null MCP data to internal agents when MCP is disabled globally or via CLI
- make Crush honor overwrite strategy

Closes #482.

## Verification
- `npx jest tests/mcp-key-gemini.test.ts tests/unit/agents/CrushAgent.test.ts --runInBand --coverage=false`
- `npm run lint`
