### PR TITLE
Align unified config loading with apply behavior

### DIFF
--- a/src/core/UnifiedConfigLoader.ts
+++ b/src/core/UnifiedConfigLoader.ts
@@ -53,11 +53,16 @@ export async function loadUnifiedConfig(
     tomlRaw = text.trim() ? parseTOML(text) : {};
     meta.configFile = tomlFile;
   } catch (err) {
-    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+    if (
+      options.configPath ||
+      (err as NodeJS.ErrnoException).code !== 'ENOENT'
+    ) {
       diagnostics.push({
-        severity: 'warning',
+        severity: options.configPath ? 'error' : 'warning',
         code: 'TOML_READ_ERROR',
-        message: 'Failed to read ruler.toml',
+        message: options.configPath
+          ? 'Failed to read explicit config file'
+          : 'Failed to read ruler.toml',
         file: tomlFile,
         detail: (err as Error).message,
       });
@@ -106,36 +111,44 @@ export async function loadUnifiedConfig(
     skills: skillsConfig,
   };
 
+  const includeAgentsInRules = (() => {
+    if (!tomlRaw || typeof tomlRaw !== 'object') return false;
+    const raw = tomlRaw as Record<string, unknown>;
+    const agents = raw.agents as Record<string, unknown> | undefined;
+    const subagents = raw.subagents as Record<string, unknown> | undefined;
+    return (
+      (agents &&
+        typeof agents === 'object' &&
+        agents.include_in_rules === true) ||
+      (subagents &&
+        typeof subagents === 'object' &&
+        subagents.include_in_rules === true)
+    );
+  })();
+
   // Collect rule markdown files
   let ruleFiles: RuleFile[] = [];
   try {
-    const dirEntries = await fs.readdir(meta.rulerDir, { withFileTypes: true });
-    const mdFiles = dirEntries
-      .filter((e) => e.isFile() && e.name.toLowerCase().endsWith('.md'))
-      .map((e) => path.join(meta.rulerDir, e.name));
-    // Sort lexicographically then ensure AGENTS.md first
-    mdFiles.sort((a, b) => a.localeCompare(b));
-    mdFiles.sort((a, b) => {
-      const aIs = /agents\.md$/i.test(a);
-      const bIs = /agents\.md$/i.test(b);
-      if (aIs && !bIs) return -1;
-      if (bIs && !aIs) return 1;
-      return 0;
+    const mdFiles = await FileSystemUtils.readMarkdownFiles(meta.rulerDir, {
+      includeAgents: includeAgentsInRules,
     });
     let order = 0;
     ruleFiles = await Promise.all(
       mdFiles.map(async (file) => {
-        const content = await fs.readFile(file, 'utf8');
-        const stat = await fs.stat(file);
+        const stat = await fs.stat(file.path);
+        const relativeFromRuler = path.relative(meta.rulerDir, file.path);
+        const relativePath = relativeFromRuler.startsWith('..')
+          ? path.relative(path.dirname(meta.rulerDir), file.path)
+          : relativeFromRuler;
         return {
-          path: file,
-          relativePath: path.basename(file),
-          content,
-          contentHash: sha256(content),
+          path: file.path,
+          relativePath: relativePath.replace(/\\/g, '/'),
+          content: file.content,
+          contentHash: sha256(file.content),
           mtimeMs: stat.mtimeMs,
           size: stat.size,
           order: order++,
-          primary: /agents\.md$/i.test(file),
+          primary: /(^|[/\\])agents\.md$/i.test(relativePath),
         } as RuleFile;
       }),
     );
@@ -315,14 +328,36 @@ export async function loadUnifiedConfig(
 
       const parsedObj = parsed as Record<string, unknown>;
       const serversRaw =
-        (parsedObj.mcpServers as unknown) ||
-        (parsedObj.servers as unknown) ||
-        {};
-      if (serversRaw && typeof serversRaw === 'object') {
+        'mcpServers' in parsedObj
+          ? parsedObj.mcpServers
+          : 'servers' in parsedObj
+            ? parsedObj.servers
+            : undefined;
+      if (
+        !serversRaw ||
+        typeof serversRaw !== 'object' ||
+        Array.isArray(serversRaw)
+      ) {
+        diagnostics.push({
+          severity: 'warning',
+          code: 'MCP_INVALID_SHAPE',
+          message:
+            'mcp.json must contain a non-array object in "mcpServers" or "servers"',
+          file: mcpFile,
+        });
+      } else {
         for (const [name, def] of Object.entries(
           serversRaw as Record<string, Record<string, unknown>>,
         )) {
-          if (!def || typeof def !== 'object') continue;
+          if (!def || typeof def !== 'object' || Array.isArray(def)) {
+            diagnostics.push({
+              severity: 'warning',
+              code: 'MCP_INVALID_SERVER',
+              message: `MCP server '${name}' must be an object`,
+              file: mcpFile,
+            });
+            continue;
+          }
           const server: McpServerDef = {};
           if (typeof def.command === 'string') server.command = def.command;
           if (Array.isArray(def.command)) server.command = def.command[0];

--- a/src/mcp/validate.ts
+++ b/src/mcp/validate.ts
@@ -5,11 +5,18 @@
  * @throws Error if validation fails.
  */
 export function validateMcp(data: unknown): void {
+  const mcpServers =
+    data && typeof data === 'object'
+      ? (data as Record<string, unknown>).mcpServers
+      : undefined;
+
   if (
     !data ||
     typeof data !== 'object' ||
     !('mcpServers' in data) ||
-    typeof (data as Record<string, unknown>).mcpServers !== 'object'
+    !mcpServers ||
+    typeof mcpServers !== 'object' ||
+    Array.isArray(mcpServers)
   ) {
     throw new Error(
       '[ruler] Invalid MCP config: must contain an object property "mcpServers" (Ruler style)',

--- a/tests/unit/core/unified-config-loader.test.ts
+++ b/tests/unit/core/unified-config-loader.test.ts
@@ -1,31 +1,64 @@
 import { promises as fs } from 'fs';
 import * as path from 'path';
+import os from 'os';
 import { loadUnifiedConfig } from '../../../src/core/UnifiedConfigLoader';
 
 describe('UnifiedConfigLoader (basic)', () => {
-  const tmpRoot = path.join(__dirname, '..', '..', '..', 'tmp-fixtures', 'unified-basic');
-  const rulerDir = path.join(tmpRoot, '.ruler');
-  const tomlPath = path.join(rulerDir, 'ruler.toml');
+  let tmpRoot: string;
+  let rulerDir: string;
+  let tomlPath: string;
 
   beforeAll(async () => {
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'ruler-unified-basic-'));
+    rulerDir = path.join(tmpRoot, '.ruler');
+    tomlPath = path.join(rulerDir, 'ruler.toml');
     await fs.mkdir(rulerDir, { recursive: true });
+    await fs.mkdir(path.join(rulerDir, 'nested'), { recursive: true });
+    await fs.mkdir(path.join(rulerDir, 'skills'), { recursive: true });
     await fs.writeFile(tomlPath, ''); // empty TOML
     await fs.writeFile(path.join(rulerDir, 'AGENTS.md'), '# AGENTS\nMain');
     await fs.writeFile(path.join(rulerDir, 'extra.md'), 'Extra file');
+    await fs.writeFile(path.join(rulerDir, 'nested', 'deep.md'), 'Deep file');
+    await fs.writeFile(path.join(rulerDir, 'skills', 'SKILL.md'), 'Skill file');
   });
 
   test('parses empty TOML producing defaults', async () => {
     const unified = await loadUnifiedConfig({ projectRoot: tmpRoot });
     expect(unified.toml.defaultAgents).toBeUndefined();
     expect(Object.keys(unified.toml.agents)).toHaveLength(0);
-    expect(unified.rules.files.length).toBe(2);
+    expect(unified.rules.files.length).toBe(3);
   });
 
   test('orders rule files with AGENTS.md first', async () => {
     const unified = await loadUnifiedConfig({ projectRoot: tmpRoot });
     expect(unified.rules.files[0].relativePath).toMatch(/AGENTS\.md$/);
-  const rels = unified.rules.files.map((f) => f.relativePath);
-    expect(rels).toEqual(['AGENTS.md', 'extra.md']);
-  expect(unified.rules.concatenated).toMatch(/<!-- Source: \.ruler\/AGENTS.md -->[\s\S]*<!-- Source: \.ruler\/extra.md -->/);
+    const rels = unified.rules.files.map((f) => f.relativePath);
+    expect(rels).toEqual(['AGENTS.md', 'extra.md', 'nested/deep.md']);
+    expect(unified.rules.concatenated).toMatch(
+      /<!-- Source: \.ruler\/AGENTS.md -->[\s\S]*<!-- Source: \.ruler\/extra.md -->[\s\S]*<!-- Source: \.ruler\/nested\/deep.md -->/,
+    );
+    expect(unified.rules.concatenated).not.toContain('Skill file');
+  });
+
+  test('reports an error diagnostic for an explicit missing config file', async () => {
+    const missingConfig = path.join(rulerDir, 'missing.toml');
+    const unified = await loadUnifiedConfig({
+      projectRoot: tmpRoot,
+      configPath: missingConfig,
+    });
+
+    expect(unified.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          severity: 'error',
+          code: 'TOML_READ_ERROR',
+          file: missingConfig,
+        }),
+      ]),
+    );
+  });
+
+  afterAll(async () => {
+    await fs.rm(tmpRoot, { recursive: true, force: true });
   });
 });

--- a/tests/unit/core/unified-config-mcp.test.ts
+++ b/tests/unit/core/unified-config-mcp.test.ts
@@ -1,15 +1,58 @@
 import * as path from 'path';
+import { promises as fs } from 'fs';
+import os from 'os';
 import { loadUnifiedConfig } from '../../../src/core/UnifiedConfigLoader';
+import { validateMcp } from '../../../src/mcp/validate';
 
 // Uses existing integration fixture for simplicity
 
 describe('UnifiedConfigLoader MCP normalization', () => {
   // From tests/unit/core -> go up to tests, then into integration/fixtures/unified
-  const projectRoot = path.join(__dirname, '../../integration/fixtures/unified');
+  const projectRoot = path.join(
+    __dirname,
+    '../../integration/fixtures/unified',
+  );
   test('normalizes mcp.json servers', async () => {
     const unified = await loadUnifiedConfig({ projectRoot });
     // Expect non-null after implementation
     expect(unified.mcp).not.toBeNull();
     expect(unified.mcp?.servers.example.command).toBe('node');
+  });
+
+  test('warns when legacy mcp.json has an invalid server map shape', async () => {
+    const tmpRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'ruler-unified-mcp-'),
+    );
+    const rulerDir = path.join(tmpRoot, '.ruler');
+    await fs.mkdir(rulerDir, { recursive: true });
+    await fs.writeFile(path.join(rulerDir, 'AGENTS.md'), '# Rules');
+    await fs.writeFile(
+      path.join(rulerDir, 'mcp.json'),
+      JSON.stringify({ mcpServers: null }),
+    );
+
+    try {
+      const unified = await loadUnifiedConfig({ projectRoot: tmpRoot });
+      expect(unified.diagnostics).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: 'MCP_INVALID_SHAPE',
+            file: path.join(rulerDir, 'mcp.json'),
+          }),
+        ]),
+      );
+      expect(unified.mcp?.servers).toEqual({});
+    } finally {
+      await fs.rm(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('rejects null and array mcpServers in legacy validator', () => {
+    expect(() => validateMcp({ mcpServers: null })).toThrow(
+      /must contain an object property/,
+    );
+    expect(() => validateMcp({ mcpServers: [] })).toThrow(
+      /must contain an object property/,
+    );
   });
 });


### PR DESCRIPTION
## Summary
- report an error diagnostic when an explicit unified config path cannot be read
- load unified rule files through the recursive markdown reader used by apply
- warn on invalid legacy MCP JSON shapes and tighten legacy validator checks

Closes #486.
Closes #488.

## Verification
- `npx jest tests/unit/core/unified-config-loader.test.ts tests/unit/core/unified-config-mcp.test.ts tests/integration/unified-config-loader.test.ts --runInBand --coverage=false`
- `npm run lint`
