### PR TITLE
Expand CI Node matrix and package verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,22 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    name: Node ${{ matrix.node-version }}
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['20.19.0', '22.12.0', '24.x']
     steps:
       - uses: actions/checkout@v4
-      - name: Setup Node.js (latest LTS)
+      - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: lts/*
+          node-version: ${{ matrix.node-version }}
           cache: 'npm'
       - run: npm ci
+      - run: npm run format:check
       - run: npm run lint
       - run: npm test
       - run: npm run build
+      - run: npm audit --omit=dev --audit-level=moderate
+      - run: npm pack --dry-run

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,6 +9,7 @@ module.exports = {
   coverageThreshold: {
     global: {
       statements: 90,
+      branches: 80,
       functions: 90,
       lines: 90,
     },

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "format": "prettier --write \"src/**/*.{ts,tsx,json,md}\"",
+    "format:check": "prettier --check package.json package-lock.json .github/workflows/ci.yml .github/workflows/release.yml",
     "test": "jest --coverage",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",


### PR DESCRIPTION
## Summary
- run CI on Node 20.19.0, 22.12.0, and 24.x
- add a format:check script for package/workflow metadata and run it in CI
- add a global branch coverage threshold
- add production audit and npm pack dry-run verification to CI

Closes #493

## Verification
- npm ci
- npm run format:check
- npm run lint
- npm test
- npm run build
- npm audit --omit=dev --audit-level=moderate
- npm pack --dry-run
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/ci.yml