### PR TITLE
fix(config): load ancestor ruler config

### DIFF
--- a/src/core/ConfigLoader.ts
+++ b/src/core/ConfigLoader.ts
@@ -364,7 +364,10 @@ async function resolveImplicitConfigFile(
   projectRoot: string,
   checkGlobal: boolean,
 ): Promise<string | undefined> {
-  const localConfigFile = path.join(projectRoot, '.ruler', 'ruler.toml');
+  const localRulerDir = await findNearestLocalRulerDir(projectRoot);
+  const localConfigFile = localRulerDir
+    ? path.join(localRulerDir, 'ruler.toml')
+    : path.join(projectRoot, '.ruler', 'ruler.toml');
   if (await configFileExists(localConfigFile)) {
     return localConfigFile;
   }
@@ -378,6 +381,32 @@ async function resolveImplicitConfigFile(
   const globalConfigFile = path.join(xdgConfigDir, 'ruler', 'ruler.toml');
   if (await configFileExists(globalConfigFile)) {
     return globalConfigFile;
+  }
+
+  return undefined;
+}
+
+async function findNearestLocalRulerDir(
+  startPath: string,
+): Promise<string | undefined> {
+  let current = path.resolve(startPath);
+
+  while (current) {
+    const candidate = path.join(current, '.ruler');
+    try {
+      const stat = await fs.stat(candidate);
+      if (stat.isDirectory()) {
+        return candidate;
+      }
+    } catch {
+      // Keep walking; missing or inaccessible candidates simply do not match.
+    }
+
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return undefined;
+    }
+    current = parent;
   }
 
   return undefined;

--- a/tests/unit/core/ConfigLoader.test.ts
+++ b/tests/unit/core/ConfigLoader.test.ts
@@ -116,6 +116,22 @@ describe('ConfigLoader', () => {
     expect(config.defaultAgents).toEqual(['A', 'B']);
   });
 
+  it('loads implicit config from the nearest ancestor .ruler directory', async () => {
+    const childDir = path.join(tmpDir, 'packages', 'app');
+    await fs.mkdir(childDir, { recursive: true });
+    await fs.writeFile(
+      path.join(rulerDir, 'ruler.toml'),
+      `default_agents = ["claude"]`,
+    );
+
+    const config = await loadConfig({
+      projectRoot: childDir,
+      checkGlobal: false,
+    });
+
+    expect(config.defaultAgents).toEqual(['claude']);
+  });
+
   it('parses nested configuration option', async () => {
     const content = `nested = true`;
     await fs.writeFile(path.join(rulerDir, 'ruler.toml'), content);


### PR DESCRIPTION
Fixes #505

## Summary
- make implicit `ruler.toml` discovery walk upward to the nearest `.ruler` directory
- add regression coverage for loading config when `projectRoot` is a subdirectory

## Verification
- `npx jest tests/unit/core/ConfigLoader.test.ts --runInBand`
- `npm run lint`
- `npm run build`
- `npm test`