### PR TITLE
fix(apply): preserve nested backup config

### DIFF
--- a/src/core/apply-engine.ts
+++ b/src/core/apply-engine.ts
@@ -190,6 +190,7 @@ function cloneLoadedConfig(config: LoadedConfig): LoadedConfig {
     cliAgents: config.cliAgents ? [...config.cliAgents] : undefined,
     mcp: config.mcp ? { ...config.mcp } : undefined,
     gitignore: config.gitignore ? { ...config.gitignore } : undefined,
+    backup: config.backup ? { ...config.backup } : undefined,
     skills: config.skills ? { ...config.skills } : undefined,
     subagents: config.subagents ? { ...config.subagents } : undefined,
     nested: config.nested,

--- a/tests/backup-option.test.ts
+++ b/tests/backup-option.test.ts
@@ -21,13 +21,16 @@ describe('backup option', () => {
     const { projectRoot } = testProject;
     const targetFile = path.join(projectRoot, 'AGENTS.md');
     const backupFile = path.join(projectRoot, 'AGENTS.md.bak');
-    
+
     runRuler('apply', projectRoot);
-    
+
     // Check that backup file was created
-    const backupExists = await fs.access(backupFile).then(() => true).catch(() => false);
+    const backupExists = await fs
+      .access(backupFile)
+      .then(() => true)
+      .catch(() => false);
     expect(backupExists).toBe(true);
-    
+
     // Check backup file content matches original
     const backupContent = await fs.readFile(backupFile, 'utf8');
     expect(backupContent).toBe('# Existing file\nThis should be backed up.');
@@ -37,13 +40,16 @@ describe('backup option', () => {
     const { projectRoot } = testProject;
     const targetFile = path.join(projectRoot, 'AGENTS.md');
     const backupFile = path.join(projectRoot, 'AGENTS.md.bak');
-    
+
     runRuler('apply --backup', projectRoot);
-    
+
     // Check that backup file was created
-    const backupExists = await fs.access(backupFile).then(() => true).catch(() => false);
+    const backupExists = await fs
+      .access(backupFile)
+      .then(() => true)
+      .catch(() => false);
     expect(backupExists).toBe(true);
-    
+
     // Check backup file content matches original
     const backupContent = await fs.readFile(backupFile, 'utf8');
     expect(backupContent).toBe('# Existing file\nThis should be backed up.');
@@ -53,13 +59,16 @@ describe('backup option', () => {
     const { projectRoot } = testProject;
     const targetFile = path.join(projectRoot, 'AGENTS.md');
     const backupFile = path.join(projectRoot, 'AGENTS.md.bak');
-    
+
     runRuler('apply --no-backup', projectRoot);
-    
+
     // Check that backup file was NOT created
-    const backupExists = await fs.access(backupFile).then(() => true).catch(() => false);
+    const backupExists = await fs
+      .access(backupFile)
+      .then(() => true)
+      .catch(() => false);
     expect(backupExists).toBe(false);
-    
+
     // Check that the target file was still updated
     const targetContent = await fs.readFile(targetFile, 'utf8');
     expect(targetContent).toContain('# Test Rules');
@@ -95,6 +104,30 @@ describe('backup option', () => {
     }
   });
 
+  it('does not create .bak files in nested mode when [backup] enabled=false in TOML', async () => {
+    const customProject = await setupTestProject({
+      '.ruler/AGENTS.md': '# Test Rules\n\nSome test rules here.',
+      '.ruler/ruler.toml':
+        'default_agents = ["claude"]\nnested = true\n\n[backup]\nenabled = false\n',
+      'CLAUDE.md': '# Existing file\nThis should not be backed up.',
+    });
+
+    try {
+      const { projectRoot } = customProject;
+      const backupFile = path.join(projectRoot, 'CLAUDE.md.bak');
+
+      runRuler('apply --nested', projectRoot);
+
+      const backupExists = await fs
+        .access(backupFile)
+        .then(() => true)
+        .catch(() => false);
+      expect(backupExists).toBe(false);
+    } finally {
+      await teardownTestProject(customProject.projectRoot);
+    }
+  });
+
   it('CLI --backup overrides [backup] enabled=false in TOML', async () => {
     const customProject = await setupTestProject({
       '.ruler/AGENTS.md': '# Test Rules\n\nSome test rules here.',
@@ -122,15 +155,15 @@ describe('backup option', () => {
   it('does not add .bak paths to .gitignore with --no-backup', async () => {
     const { projectRoot } = testProject;
     const gitignoreFile = path.join(projectRoot, '.gitignore');
-    
+
     runRuler('apply --no-backup', projectRoot);
-    
+
     // Check .gitignore content
     const gitignoreContent = await fs.readFile(gitignoreFile, 'utf8');
-    
+
     // Should not contain *.bak pattern
     expect(gitignoreContent).not.toContain('*.bak');
-    
+
     // Should still contain the main generated file path
     expect(gitignoreContent).toContain('AGENTS.md');
   });
@@ -138,12 +171,12 @@ describe('backup option', () => {
   it('adds .bak paths to .gitignore with --backup (default)', async () => {
     const { projectRoot } = testProject;
     const gitignoreFile = path.join(projectRoot, '.gitignore');
-    
+
     runRuler('apply --backup', projectRoot);
-    
+
     // Check .gitignore content
     const gitignoreContent = await fs.readFile(gitignoreFile, 'utf8');
-    
+
     // Should contain specific backup paths but NOT the broad *.bak pattern
     expect(gitignoreContent).toContain('/AGENTS.md.bak');
     expect(gitignoreContent).not.toContain('*.bak');
@@ -152,23 +185,30 @@ describe('backup option', () => {
   describe('agents with custom applyRulerConfig implementations', () => {
     it('AgentsMdAgent respects --no-backup flag', async () => {
       const testProject = await setupTestProject({
-        '.ruler/AGENTS.md': '# Test Rules for AgentsMd\nCustom rules for AGENTS.md',
+        '.ruler/AGENTS.md':
+          '# Test Rules for AgentsMd\nCustom rules for AGENTS.md',
         '.ruler/ruler.toml': 'default_agents = ["agentsmd"]\n',
         'AGENTS.md': '# Existing AGENTS.md\nThis should not be backed up.',
       });
-      
+
       try {
         const { projectRoot } = testProject;
         const backupFile = path.join(projectRoot, 'AGENTS.md.bak');
-        
+
         runRuler('apply --no-backup', projectRoot);
-        
+
         // Check that backup file was NOT created
-        const backupExists = await fs.access(backupFile).then(() => true).catch(() => false);
+        const backupExists = await fs
+          .access(backupFile)
+          .then(() => true)
+          .catch(() => false);
         expect(backupExists).toBe(false);
-        
+
         // Check that the target file was still updated
-        const targetContent = await fs.readFile(path.join(projectRoot, 'AGENTS.md'), 'utf8');
+        const targetContent = await fs.readFile(
+          path.join(projectRoot, 'AGENTS.md'),
+          'utf8',
+        );
         expect(targetContent).toContain('<!-- Generated by Ruler -->');
         expect(targetContent).toContain('Test Rules for AgentsMd');
       } finally {
@@ -181,21 +221,27 @@ describe('backup option', () => {
         '.ruler/AGENTS.md': '# Test Rules for Windsurf\nCustom windsurf rules',
         '.ruler/ruler.toml': 'default_agents = ["windsurf"]\n',
       });
-      
+
       try {
         const { projectRoot } = testProject;
         const targetFile = path.join(projectRoot, 'AGENTS.md');
         const backupFile = path.join(projectRoot, 'AGENTS.md.bak');
-        
+
         // Create existing file to be potentially backed up
-        await fs.writeFile(targetFile, '# Existing Windsurf Rules\nShould not be backed up.');
-        
+        await fs.writeFile(
+          targetFile,
+          '# Existing Windsurf Rules\nShould not be backed up.',
+        );
+
         runRuler('apply --no-backup', projectRoot);
-        
+
         // Check that backup file was NOT created
-        const backupExists = await fs.access(backupFile).then(() => true).catch(() => false);
+        const backupExists = await fs
+          .access(backupFile)
+          .then(() => true)
+          .catch(() => false);
         expect(backupExists).toBe(false);
-        
+
         // Check that the target file was still updated
         const targetContent = await fs.readFile(targetFile, 'utf8');
         expect(targetContent).toContain('<!-- Generated by Ruler -->');
@@ -217,12 +263,18 @@ describe('backup option', () => {
         const backupFile = path.join(projectRoot, 'AGENTS.md.bak');
 
         // Create existing file to be potentially backed up
-        await fs.writeFile(targetFile, '# Existing Cursor Rules\nShould not be backed up.');
+        await fs.writeFile(
+          targetFile,
+          '# Existing Cursor Rules\nShould not be backed up.',
+        );
 
         runRuler('apply --no-backup', projectRoot);
 
         // Check that backup file was NOT created
-        const backupExists = await fs.access(backupFile).then(() => true).catch(() => false);
+        const backupExists = await fs
+          .access(backupFile)
+          .then(() => true)
+          .catch(() => false);
         expect(backupExists).toBe(false);
 
         // Check that the target file was still updated
@@ -236,25 +288,42 @@ describe('backup option', () => {
 
     it('AugmentCodeAgent respects --no-backup flag', async () => {
       const testProject = await setupTestProject({
-        '.ruler/AGENTS.md': '# Test Rules for AugmentCode\nCustom augmentcode rules',
+        '.ruler/AGENTS.md':
+          '# Test Rules for AugmentCode\nCustom augmentcode rules',
         '.ruler/ruler.toml': 'default_agents = ["augmentcode"]\n',
       });
-      
+
       try {
         const { projectRoot } = testProject;
-        const targetFile = path.join(projectRoot, '.augment', 'rules', 'ruler_augment_instructions.md');
-        const backupFile = path.join(projectRoot, '.augment', 'rules', 'ruler_augment_instructions.md.bak');
-        
+        const targetFile = path.join(
+          projectRoot,
+          '.augment',
+          'rules',
+          'ruler_augment_instructions.md',
+        );
+        const backupFile = path.join(
+          projectRoot,
+          '.augment',
+          'rules',
+          'ruler_augment_instructions.md.bak',
+        );
+
         // Create existing file to be potentially backed up
         await fs.mkdir(path.dirname(targetFile), { recursive: true });
-        await fs.writeFile(targetFile, '# Existing AugmentCode Rules\nShould not be backed up.');
-        
+        await fs.writeFile(
+          targetFile,
+          '# Existing AugmentCode Rules\nShould not be backed up.',
+        );
+
         runRuler('apply --no-backup', projectRoot);
-        
+
         // Check that backup file was NOT created
-        const backupExists = await fs.access(backupFile).then(() => true).catch(() => false);
+        const backupExists = await fs
+          .access(backupFile)
+          .then(() => true)
+          .catch(() => false);
         expect(backupExists).toBe(false);
-        
+
         // Check that the target file was still updated
         const targetContent = await fs.readFile(targetFile, 'utf8');
         expect(targetContent).toContain('Test Rules for AugmentCode');
@@ -270,26 +339,41 @@ describe('backup option', () => {
         'AGENTS.md': '# Existing AGENTS.md\nShould not be backed up.',
         '.aider.conf.yml': 'read:\n  - "existing_file.md"\n',
       });
-      
+
       try {
         const { projectRoot } = testProject;
         const agentsMdBackupFile = path.join(projectRoot, 'AGENTS.md.bak');
-        const aiderConfBackupFile = path.join(projectRoot, '.aider.conf.yml.bak');
-        
+        const aiderConfBackupFile = path.join(
+          projectRoot,
+          '.aider.conf.yml.bak',
+        );
+
         runRuler('apply --no-backup', projectRoot);
-        
+
         // Check that neither backup file was created
-        const agentsMdBackupExists = await fs.access(agentsMdBackupFile).then(() => true).catch(() => false);
-        const aiderConfBackupExists = await fs.access(aiderConfBackupFile).then(() => true).catch(() => false);
+        const agentsMdBackupExists = await fs
+          .access(agentsMdBackupFile)
+          .then(() => true)
+          .catch(() => false);
+        const aiderConfBackupExists = await fs
+          .access(aiderConfBackupFile)
+          .then(() => true)
+          .catch(() => false);
         expect(agentsMdBackupExists).toBe(false);
         expect(aiderConfBackupExists).toBe(false);
-        
+
         // Check that files were still updated
-        const agentsMdContent = await fs.readFile(path.join(projectRoot, 'AGENTS.md'), 'utf8');
+        const agentsMdContent = await fs.readFile(
+          path.join(projectRoot, 'AGENTS.md'),
+          'utf8',
+        );
         expect(agentsMdContent).toContain('<!-- Generated by Ruler -->');
         expect(agentsMdContent).toContain('Test Rules for Aider');
-        
-        const aiderConfContent = await fs.readFile(path.join(projectRoot, '.aider.conf.yml'), 'utf8');
+
+        const aiderConfContent = await fs.readFile(
+          path.join(projectRoot, '.aider.conf.yml'),
+          'utf8',
+        );
         expect(aiderConfContent).toContain('AGENTS.md');
         expect(aiderConfContent).toContain('existing_file.md'); // Preserved existing config
       } finally {
@@ -300,26 +384,37 @@ describe('backup option', () => {
     it('all agents create backups by default', async () => {
       const testProject = await setupTestProject({
         '.ruler/AGENTS.md': '# Test Rules\nGeneric test rules',
-        '.ruler/ruler.toml': 'default_agents = ["agentsmd", "windsurf", "cursor", "augmentcode", "aider"]\n',
+        '.ruler/ruler.toml':
+          'default_agents = ["agentsmd", "windsurf", "cursor", "augmentcode", "aider"]\n',
         'AGENTS.md': '# Existing AGENTS.md\nShould be backed up.',
       });
-      
+
       try {
         const { projectRoot } = testProject;
-        
+
         // Create existing files for agents that need them (Windsurf uses AGENTS.md now)
-        const cursorFile = path.join(projectRoot, '.cursor', 'rules', 'ruler_cursor_instructions.mdc');
-        const augmentFile = path.join(projectRoot, '.augment', 'rules', 'ruler_augment_instructions.md');
+        const cursorFile = path.join(
+          projectRoot,
+          '.cursor',
+          'rules',
+          'ruler_cursor_instructions.mdc',
+        );
+        const augmentFile = path.join(
+          projectRoot,
+          '.augment',
+          'rules',
+          'ruler_augment_instructions.md',
+        );
         const aiderConfFile = path.join(projectRoot, '.aider.conf.yml');
-        
+
         await fs.mkdir(path.dirname(cursorFile), { recursive: true });
         await fs.writeFile(cursorFile, 'Existing cursor content');
         await fs.mkdir(path.dirname(augmentFile), { recursive: true });
         await fs.writeFile(augmentFile, 'Existing augment content');
         await fs.writeFile(aiderConfFile, 'read: ["old.md"]');
-        
+
         runRuler('apply', projectRoot); // Default behavior should create backups
-        
+
         // Check that all backup files were created
         // Note: Windsurf and Cursor now use AGENTS.md, so their backup is AGENTS.md.bak
         const expectedBackups = [
@@ -327,10 +422,13 @@ describe('backup option', () => {
           '.augment/rules/ruler_augment_instructions.md.bak',
           '.aider.conf.yml.bak',
         ];
-        
+
         for (const backupPath of expectedBackups) {
           const fullPath = path.join(projectRoot, backupPath);
-          const exists = await fs.access(fullPath).then(() => true).catch(() => false);
+          const exists = await fs
+            .access(fullPath)
+            .then(() => true)
+            .catch(() => false);
           expect(exists).toBe(true);
         }
       } finally {


### PR DESCRIPTION
Fixes #507

## Summary
- preserve `[backup]` settings when cloning loaded configs for nested apply
- add a nested-mode regression test for `[backup] enabled = false`
- run Prettier on the touched test file

## Verification
- `npx jest tests/backup-option.test.ts --runInBand`
- `npm run lint`
- `npm run build`
- `npm test`