### PR TITLE
fix(mcp): fail on invalid existing configs

### DIFF
--- a/src/core/apply-engine.ts
+++ b/src/core/apply-engine.ts
@@ -7,7 +7,12 @@ import { loadConfig, LoadedConfig, IAgentConfig } from './ConfigLoader';
 import { updateGitignore as updateGitignoreUtil } from './GitignoreUtils';
 import { IAgent } from '../agents/IAgent';
 import { mergeMcp } from '../mcp/merge';
-import { getNativeMcpPath, readNativeMcp, writeNativeMcp } from '../paths/mcp';
+import {
+  getNativeMcpPath,
+  readNativeMcp,
+  readNativeMcpToml,
+  writeNativeMcp,
+} from '../paths/mcp';
 import { propagateMcpToOpenHands } from '../mcp/propagateOpenHandsMcp';
 import { propagateMcpToOpenCode } from '../mcp/propagateOpenCodeMcp';
 import { getAgentOutputPaths } from '../agents/agent-utils';
@@ -929,19 +934,12 @@ async function applyStandardMcpConfiguration(
     const CODEX_AGENT_ID = 'codex';
     const isCodexToml =
       agent.getIdentifier() === CODEX_AGENT_ID && dest.endsWith('.toml');
-    let existing = await readNativeMcp(dest);
-    if (isCodexToml) {
-      try {
-        const tomlContent = await fs.readFile(dest, 'utf8');
-        existing = parseTOML(tomlContent) as Record<string, unknown>;
-      } catch (error) {
-        logVerbose(
-          `Failed to read Codex MCP TOML at ${dest}: ${(error as Error).message}`,
-          verbose,
-        );
-        // ignore missing or invalid TOML, fall back to previously read value
-      }
-    }
+    const existing = isCodexToml
+      ? await readNativeMcpToml(
+          dest,
+          (text) => parseTOML(text) as Record<string, unknown>,
+        )
+      : await readNativeMcp(dest);
     let merged = mergeMcp(existing, mcpToMerge, strategy, serverKey);
     if (isCodexToml) {
       const { [serverKey]: servers, ...rest } = merged as Record<

--- a/src/mcp/propagateOpenCodeMcp.ts
+++ b/src/mcp/propagateOpenCodeMcp.ts
@@ -107,11 +107,24 @@ export async function propagateMcpToOpenCode(
 
   // Read existing OpenCode config if it exists
   let existingConfig: Partial<OpenCodeConfig> & Record<string, unknown> = {};
+  let existingContent: string | undefined;
   try {
-    const existingContent = await fs.readFile(openCodeConfigPath, 'utf8');
-    existingConfig = JSON.parse(existingContent);
-  } catch {
-    // File doesn't exist, we'll create it
+    existingContent = await fs.readFile(openCodeConfigPath, 'utf8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw new Error(
+        `Could not read OpenCode config at ${openCodeConfigPath}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+  if (existingContent !== undefined) {
+    try {
+      existingConfig = JSON.parse(existingContent);
+    } catch (error) {
+      throw new Error(
+        `Invalid OpenCode config at ${openCodeConfigPath}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
   }
 
   // Transform ruler MCP to OpenCode format

--- a/src/mcp/propagateOpenHandsMcp.ts
+++ b/src/mcp/propagateOpenHandsMcp.ts
@@ -122,11 +122,24 @@ export async function propagateMcpToOpenHands(
       shttp_servers?: (string | RemoteServerEntry)[];
     };
   } = {};
+  let tomlContent: string | undefined;
   try {
-    const tomlContent = await fs.readFile(openHandsConfigPath, 'utf8');
-    config = parseTOML(tomlContent);
-  } catch {
-    // File doesn't exist, we'll create it.
+    tomlContent = await fs.readFile(openHandsConfigPath, 'utf8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw new Error(
+        `Could not read OpenHands config at ${openHandsConfigPath}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+  if (tomlContent !== undefined) {
+    try {
+      config = parseTOML(tomlContent);
+    } catch (error) {
+      throw new Error(
+        `Invalid OpenHands config at ${openHandsConfigPath}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
   }
 
   if (!config.mcp) {

--- a/src/paths/mcp.ts
+++ b/src/paths/mcp.ts
@@ -77,15 +77,54 @@ export async function getNativeMcpPath(
   return candidates.length > 0 ? candidates[0] : null;
 }
 
-/** Read native MCP config from disk, or return empty object if missing/invalid. */
+/** Read native MCP config from disk, or return empty object if missing. */
 export async function readNativeMcp(
   filePath: string,
 ): Promise<Record<string, unknown>> {
+  let text: string;
   try {
-    const text = await fs.readFile(filePath, 'utf8');
+    text = await fs.readFile(filePath, 'utf8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return {};
+    }
+    throw new Error(
+      `Could not read MCP config at ${filePath}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  try {
     return JSON.parse(text) as Record<string, unknown>;
-  } catch {
-    return {};
+  } catch (error) {
+    throw new Error(
+      `Invalid MCP config at ${filePath}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+/** Read native Codex TOML MCP config from disk, or return empty object if missing. */
+export async function readNativeMcpToml(
+  filePath: string,
+  parseToml: (text: string) => Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  let text: string;
+  try {
+    text = await fs.readFile(filePath, 'utf8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return {};
+    }
+    throw new Error(
+      `Could not read MCP config at ${filePath}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  try {
+    return parseToml(text);
+  } catch (error) {
+    throw new Error(
+      `Invalid MCP config at ${filePath}: ${error instanceof Error ? error.message : String(error)}`,
+    );
   }
 }
 

--- a/tests/unit/mcp/KiloCodeMcp.test.ts
+++ b/tests/unit/mcp/KiloCodeMcp.test.ts
@@ -86,6 +86,16 @@ describe('KiloCode MCP Integration', () => {
       expect(config).toEqual({});
     });
 
+    it('throws for invalid existing MCP JSON', async () => {
+      const mcpPath = path.join(tmpDir, '.kilocode', 'mcp.json');
+      await fs.mkdir(path.dirname(mcpPath), { recursive: true });
+      await fs.writeFile(mcpPath, '{ invalid json');
+
+      await expect(readNativeMcp(mcpPath)).rejects.toThrow(
+        /Invalid MCP config/i,
+      );
+    });
+
     it('merges MCP configurations correctly', async () => {
       const existing = {
         mcpServers: {

--- a/tests/unit/mcp/OpenCodeMcp.test.ts
+++ b/tests/unit/mcp/OpenCodeMcp.test.ts
@@ -122,6 +122,23 @@ describe('OpenCode MCP Integration', () => {
       expect(result.mcp['remote-with-timeout'].timeout).toBe(45);
     });
 
+    it('throws without overwriting invalid existing OpenCode config', async () => {
+      const openCodePath = path.join(tmpDir, 'opencode.json');
+      const invalidConfig = '{ invalid json';
+      await fs.writeFile(openCodePath, invalidConfig);
+
+      await expect(
+        propagateMcpToOpenCode(
+          { mcpServers: { repo: { command: 'node' } } },
+          openCodePath,
+        ),
+      ).rejects.toThrow(/Invalid OpenCode config/i);
+
+      await expect(fs.readFile(openCodePath, 'utf8')).resolves.toBe(
+        invalidConfig,
+      );
+    });
+
     it('merges with existing OpenCode configuration', async () => {
       const openCodePath = path.join(tmpDir, 'opencode.json');
 

--- a/tests/unit/mcp/OpenHandsMcp.test.ts
+++ b/tests/unit/mcp/OpenHandsMcp.test.ts
@@ -68,6 +68,22 @@ stdio_servers = [
     });
   });
 
+  it('throws without overwriting invalid existing config.toml', async () => {
+    const invalidConfig = '[mcp';
+    await fs.writeFile(openHandsConfigPath, invalidConfig);
+
+    await expect(
+      propagateMcpToOpenHands(
+        { mcpServers: { git: { command: 'npx', args: ['mcp-git'] } } },
+        openHandsConfigPath,
+      ),
+    ).rejects.toThrow(/Invalid OpenHands config/i);
+
+    await expect(fs.readFile(openHandsConfigPath, 'utf8')).resolves.toBe(
+      invalidConfig,
+    );
+  });
+
   it('overwrites MCP server sections while preserving unrelated settings', async () => {
     const rulerMcp = {
       mcpServers: {


### PR DESCRIPTION
Fixes #511.

## Summary
- fail instead of silently treating unreadable or malformed MCP config files as empty
- preserve invalid OpenCode and OpenHands configs instead of overwriting them
- add regression coverage for JSON and TOML MCP config parsing failures

## Verification
- npm ci
- npm run format:check
- npm run lint
- npm run build
- npm test