### PR TITLE
fix(gitignore): resolve worktree exclude path

### DIFF
--- a/src/core/GitignoreUtils.ts
+++ b/src/core/GitignoreUtils.ts
@@ -17,7 +17,7 @@ export async function updateGitignore(
   paths: string[],
   ignoreFile = '.gitignore',
 ): Promise<void> {
-  const gitignorePath = path.join(projectRoot, ignoreFile);
+  const gitignorePath = await resolveIgnoreFilePath(projectRoot, ignoreFile);
 
   // Read existing .gitignore or start with empty content
   let existingContent = '';
@@ -76,6 +76,41 @@ export async function updateGitignore(
   // Write the updated content
   await fs.mkdir(path.dirname(gitignorePath), { recursive: true });
   await fs.writeFile(gitignorePath, newContent);
+}
+
+/**
+ * Resolves ignore files Ruler manages. Linked worktrees store `.git` as a
+ * file containing a `gitdir:` pointer, so `.git/info/exclude` must be resolved
+ * through that pointer.
+ */
+export async function resolveIgnoreFilePath(
+  projectRoot: string,
+  ignoreFile: string,
+): Promise<string> {
+  if (ignoreFile !== '.git/info/exclude') {
+    return path.join(projectRoot, ignoreFile);
+  }
+
+  const dotGitPath = path.join(projectRoot, '.git');
+  try {
+    const dotGitStat = await fs.lstat(dotGitPath);
+    if (dotGitStat.isFile()) {
+      const dotGitContent = await fs.readFile(dotGitPath, 'utf8');
+      const gitDirMatch = dotGitContent.match(/^gitdir:\s*(.+)\s*$/m);
+      if (gitDirMatch) {
+        const gitDir = gitDirMatch[1];
+        const resolvedGitDir = path.isAbsolute(gitDir)
+          ? gitDir
+          : path.resolve(projectRoot, gitDir);
+        return path.join(resolvedGitDir, 'info', 'exclude');
+      }
+    }
+  } catch {
+    // Fall back to the historical project-root path for non-git test fixtures
+    // and unusual repositories where `.git` cannot be inspected.
+  }
+
+  return path.join(projectRoot, ignoreFile);
 }
 
 /**

--- a/src/core/revert-engine.ts
+++ b/src/core/revert-engine.ts
@@ -5,6 +5,7 @@ import { IAgentConfig } from './ConfigLoader';
 import { getAgentOutputPaths } from '../agents/agent-utils';
 import { getNativeMcpPath } from '../paths/mcp';
 import { logVerbose, actionPrefix } from '../constants';
+import { resolveIgnoreFilePath } from './GitignoreUtils';
 import {
   readVSCodeSettings,
   writeVSCodeSettings,
@@ -93,8 +94,8 @@ async function hasRulerGeneratedProvenance(
 
   const relativePath = `/${path.relative(projectRoot, filePath).replace(/\\/g, '/')}`;
   const ignoreFiles = [
-    path.join(projectRoot, '.gitignore'),
-    path.join(projectRoot, '.git', 'info', 'exclude'),
+    await resolveIgnoreFilePath(projectRoot, '.gitignore'),
+    await resolveIgnoreFilePath(projectRoot, '.git/info/exclude'),
   ];
 
   for (const ignoreFile of ignoreFiles) {

--- a/src/revert.ts
+++ b/src/revert.ts
@@ -1,4 +1,3 @@
-import * as path from 'path';
 import { promises as fs } from 'fs';
 import * as FileSystemUtils from './core/FileSystemUtils';
 import { loadConfig } from './core/ConfigLoader';
@@ -14,6 +13,7 @@ import {
   resolveSelectedAgents,
 } from './core/agent-selection';
 import { mapRawAgentConfigs } from './core/config-utils';
+import { resolveIgnoreFilePath } from './core/GitignoreUtils';
 
 const agents: IAgent[] = allAgents;
 const RULER_IGNORE_START_MARKER = '# START Ruler Generated Files';
@@ -206,7 +206,7 @@ async function cleanIgnoreFile(
   verbose: boolean,
   dryRun: boolean,
 ): Promise<boolean> {
-  const ignorePath = path.join(projectRoot, ignoreFile);
+  const ignorePath = await resolveIgnoreFilePath(projectRoot, ignoreFile);
 
   try {
     await fs.access(ignorePath);

--- a/tests/unit/core/GitignoreUtils.test.ts
+++ b/tests/unit/core/GitignoreUtils.test.ts
@@ -174,6 +174,24 @@ CLAUDE.md
       expect(content).not.toContain(tmpDir);
     });
 
+    it('writes local ignores to the real gitdir for linked worktrees', async () => {
+      const actualGitDir = path.join(tmpDir, '.git-worktree');
+      await fs.mkdir(actualGitDir, { recursive: true });
+      await fs.writeFile(
+        path.join(tmpDir, '.git'),
+        `gitdir: ${actualGitDir}\n`,
+      );
+
+      await updateGitignore(tmpDir, ['CLAUDE.md'], '.git/info/exclude');
+
+      const excludePath = path.join(actualGitDir, 'info', 'exclude');
+      const content = await fs.readFile(excludePath, 'utf8');
+      expect(content).toContain('/CLAUDE.md');
+      await expect(
+        fs.access(path.join(tmpDir, '.git', 'info', 'exclude')),
+      ).rejects.toThrow();
+    });
+
     it('handles multiple Ruler blocks by updating the first one', async () => {
       const paths = ['CLAUDE.md'];
       const gitignorePath = path.join(tmpDir, '.gitignore');

--- a/tests/unit/core/revert.test.ts
+++ b/tests/unit/core/revert.test.ts
@@ -473,6 +473,36 @@ describe('Revert Core Functions', () => {
         consoleLogSpy.mockRestore();
       }
     });
+
+    it('recognises generated files listed in the real worktree exclude file', async () => {
+      const actualGitDir = path.join(tmpDir, '.git-worktree');
+      await fs.mkdir(path.join(actualGitDir, 'info'), { recursive: true });
+      await fs.writeFile(
+        path.join(tmpDir, '.git'),
+        `gitdir: ${actualGitDir}\n`,
+      );
+      await fs.writeFile(
+        path.join(actualGitDir, 'info', 'exclude'),
+        [
+          '# START Ruler Generated Files',
+          '/CLAUDE.md',
+          '# END Ruler Generated Files',
+          '',
+        ].join('\n'),
+      );
+      await fs.writeFile(path.join(tmpDir, 'CLAUDE.md'), 'Claude content');
+
+      await revertAllAgentConfigs(
+        tmpDir,
+        ['claude'],
+        undefined,
+        false,
+        false,
+        false,
+      );
+
+      await expect(fs.access(path.join(tmpDir, 'CLAUDE.md'))).rejects.toThrow();
+    });
   });
 
   describe('dry-run logging patterns', () => {


### PR DESCRIPTION
Fixes #515.

## Summary
- resolve `.git/info/exclude` through linked worktree `gitdir:` files
- use the resolved exclude path for revert provenance and managed-block cleanup
- add regression tests for local ignore writes and revert behaviour in linked worktrees

## Verification
- npm ci
- npx jest tests/unit/core/GitignoreUtils.test.ts tests/unit/core/revert.test.ts --runInBand
- npm run format:check
- npm run lint
- npm run build
- npm test
- npm audit --omit=dev --audit-level=moderate
- npm pack --dry-run