### PR TITLE
feat(agents): add zed skills support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Ruler solves this by providing a **single source of truth** for all your AI agen
 | Goose                  | `.goosehints`                                  | -                                                | `.agents/skills/`         | -                            |
 | Qwen Code              | `AGENTS.md`                                    | `.qwen/settings.json`                            | -                         | -                            |
 | RooCode                | `AGENTS.md`                                    | `.roo/mcp.json`                                  | `.roo/skills/`            | -                            |
-| Zed                    | `AGENTS.md`                                    | `.zed/settings.json` (project root, never $HOME) | -                         | -                            |
+| Zed                    | `AGENTS.md`                                    | `.zed/settings.json` (project root, never $HOME) | `.agents/skills/`         | -                            |
 | Trae AI                | `.trae/rules/project_rules.md`                 | -                                                | -                         | -                            |
 | Warp                   | `WARP.md`                                      | -                                                | -                         | -                            |
 | Kiro                   | `.kiro/steering/ruler_kiro_instructions.md`    | `.kiro/settings/mcp.json`                        | -                         | -                            |
@@ -597,6 +597,7 @@ Skills are specialized knowledge packages that extend AI agent capabilities with
   - **Pi Coding Agent**: `.pi/skills/`
   - **Goose**: `.agents/skills/`
   - **Amp**: `.agents/skills/` (shared with Goose)
+  - **Zed**: `.agents/skills/` (shared with Goose)
   - **Antigravity**: `.agent/skills/`
   - **Factory Droid**: `.factory/skills/`
   - **Mistral Vibe**: `.vibe/skills/`
@@ -663,7 +664,7 @@ When skills support is enabled and gitignore integration is active, Ruler automa
 - `.codex/skills/` (for OpenAI Codex CLI)
 - `.opencode/skills/` (for OpenCode)
 - `.pi/skills/` (for Pi Coding Agent)
-- `.agents/skills/` (for Goose and Amp)
+- `.agents/skills/` (for Goose, Amp, and Zed)
 - `.agent/skills/` (for Antigravity)
 - `.factory/skills/` (for Factory Droid)
 - `.vibe/skills/` (for Mistral Vibe)
@@ -724,7 +725,7 @@ ruler apply
 #    - OpenAI Codex CLI: .codex/skills/my-skill/
 #    - OpenCode: .opencode/skills/my-skill/
 #    - Pi Coding Agent: .pi/skills/my-skill/
-#    - Goose & Amp: .agents/skills/my-skill/
+#    - Goose, Amp & Zed: .agents/skills/my-skill/
 #    - Antigravity: .agent/skills/my-skill/
 #    - Factory Droid: .factory/skills/my-skill/
 #    - Mistral Vibe: .vibe/skills/my-skill/

--- a/src/agents/ZedAgent.ts
+++ b/src/agents/ZedAgent.ts
@@ -127,6 +127,10 @@ export class ZedAgent extends AgentsMdAgent {
     return true;
   }
 
+  supportsNativeSkills(): boolean {
+    return true;
+  }
+
   /**
    * Transform MCP server configuration from ruler format to Zed format.
    * Converts "type": "stdio" to "source": "custom" and preserves other fields.

--- a/src/core/SkillsProcessor.ts
+++ b/src/core/SkillsProcessor.ts
@@ -142,7 +142,7 @@ const SKILL_TARGET_TO_IDENTIFIERS = new Map<SkillTarget, readonly string[]>([
   ['codex', ['codex']],
   ['opencode', ['opencode']],
   ['pi', ['pi']],
-  ['goose', ['goose', 'amp']],
+  ['goose', ['goose', 'amp', 'zed']],
   ['vibe', ['mistral']],
   ['roo', ['roo']],
   ['gemini', ['gemini-cli']],
@@ -413,7 +413,7 @@ export async function propagateSkills(
 
   if (selectedTargets.has('goose')) {
     logVerboseInfo(
-      `Copying skills to ${GOOSE_SKILLS_PATH} for Goose and Amp`,
+      `Copying skills to ${GOOSE_SKILLS_PATH} for Goose, Amp and Zed`,
       verbose,
       dryRun,
     );

--- a/tests/integration/skills-mcp-agent-integration.test.ts
+++ b/tests/integration/skills-mcp-agent-integration.test.ts
@@ -270,7 +270,7 @@ args = ["server.js"]
       try {
         await applyAllAgentConfigs(
           tmpDir,
-          ['codex', 'zed'],
+          ['codex', 'jules'],
           undefined,
           true,
           undefined,

--- a/tests/integration/skills-mcp.test.ts
+++ b/tests/integration/skills-mcp.test.ts
@@ -30,7 +30,7 @@ describe('Skills MCP Integration', () => {
     await fs.writeFile(path.join(skillDir, SKILL_MD_FILENAME), '# Test Skill');
 
     const unsupportedAgent = allAgents.find(
-      (agent) => agent.getIdentifier() === 'zed',
+      (agent) => agent.getIdentifier() === 'jules',
     );
 
     expect(unsupportedAgent).toBeDefined();

--- a/tests/unit/agents/ZedAgent.test.ts
+++ b/tests/unit/agents/ZedAgent.test.ts
@@ -29,6 +29,11 @@ describe('ZedAgent', () => {
     expect(agent.getMcpServerKey()).toBe('context_servers');
   });
 
+  it('should support native skills', () => {
+    const agent = new ZedAgent();
+    expect(agent.supportsNativeSkills()).toBe(true);
+  });
+
   it('writes AGENTS.md via base class', async () => {
     const { projectRoot } = await setupTestProject({
       '.ruler/AGENTS.md': 'Rule A',


### PR DESCRIPTION
👋 This PR adds support for zed skills

[Zed also uses `.agents/skills/`](https://zed.dev/docs/ai/skills) so the changes piggyback on the existing Goose flow.

<img width="587" height="197" alt="image" src="https://github.com/user-attachments/assets/03d8b1dd-0ed2-49d4-990e-10047b6af3d6" />

Loving ruler btw!

