### PR TITLE
fix(config): reject unsafe output paths

### DIFF
--- a/src/core/ConfigLoader.ts
+++ b/src/core/ConfigLoader.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import * as os from 'os';
 import { parse as parseTOML } from '@iarna/toml';
 import { z } from 'zod';
+import { isPathInsideOrEqual } from './path-utils';
 import {
   McpConfig,
   GlobalMcpConfig,
@@ -245,18 +246,27 @@ export async function loadConfig(
         cfg.enabled = sectionObj.enabled;
       }
       if (typeof sectionObj.output_path === 'string') {
-        cfg.outputPath = path.resolve(projectRoot, sectionObj.output_path);
+        cfg.outputPath = resolveProjectOutputPath(
+          projectRoot,
+          sectionObj.output_path,
+          configFile,
+          `[agents.${name}].output_path`,
+        );
       }
       if (typeof sectionObj.output_path_instructions === 'string') {
-        cfg.outputPathInstructions = path.resolve(
+        cfg.outputPathInstructions = resolveProjectOutputPath(
           projectRoot,
           sectionObj.output_path_instructions,
+          configFile,
+          `[agents.${name}].output_path_instructions`,
         );
       }
       if (typeof sectionObj.output_path_config === 'string') {
-        cfg.outputPathConfig = path.resolve(
+        cfg.outputPathConfig = resolveProjectOutputPath(
           projectRoot,
           sectionObj.output_path_config,
+          configFile,
+          `[agents.${name}].output_path_config`,
         );
       }
       if (sectionObj.mcp && typeof sectionObj.mcp === 'object') {
@@ -384,6 +394,31 @@ export async function loadConfig(
     nested,
     nestedDefined,
   };
+}
+
+function resolveProjectOutputPath(
+  projectRoot: string,
+  configuredPath: string,
+  configFile: string | undefined,
+  fieldName: string,
+): string {
+  const resolvedPath = path.resolve(projectRoot, configuredPath);
+
+  if (!isPathInsideOrEqual(projectRoot, resolvedPath)) {
+    throw createRulerError(
+      'Configured output path is outside the project root',
+      [
+        configFile ? `File: ${configFile}` : undefined,
+        `Field: ${fieldName}`,
+        `Path: ${configuredPath}`,
+        `Project root: ${projectRoot}`,
+      ]
+        .filter(Boolean)
+        .join(', '),
+    );
+  }
+
+  return resolvedPath;
 }
 
 async function resolveImplicitConfigFile(

--- a/tests/integration/mcp-custom-config-path.test.ts
+++ b/tests/integration/mcp-custom-config-path.test.ts
@@ -105,7 +105,7 @@ args = ["server.js"]
     });
   });
 
-  it('skips custom MCP config paths outside the project root', async () => {
+  it('rejects custom MCP config paths outside the project root', async () => {
     const outsideDir = `${tmpDir}-outside`;
     const outsideConfig = path.join(outsideDir, 'opencode.json');
     const outsideRelative = path.relative(tmpDir, outsideConfig);
@@ -122,17 +122,19 @@ args = ["server.js"]
 `,
     );
 
-    await applyAllAgentConfigs(
-      tmpDir,
-      ['opencode'],
-      undefined,
-      true,
-      undefined,
-      false,
-      false,
-      false,
-      true,
-    );
+    await expect(
+      applyAllAgentConfigs(
+        tmpDir,
+        ['opencode'],
+        undefined,
+        true,
+        undefined,
+        false,
+        false,
+        false,
+        true,
+      ),
+    ).rejects.toThrow(/Configured output path is outside the project root/i);
 
     await expect(pathExists(outsideConfig)).resolves.toBe(false);
 

--- a/tests/unit/core/ConfigLoader.test.ts
+++ b/tests/unit/core/ConfigLoader.test.ts
@@ -195,6 +195,23 @@ describe('ConfigLoader', () => {
     );
   });
 
+  it.each([
+    ['output_path', '../outside.md'],
+    ['output_path_instructions', '../outside-instructions.md'],
+    ['output_path_config', '../outside-config.json'],
+    ['output_path', path.join(os.tmpdir(), 'ruler-outside-output.md')],
+  ])('rejects unsafe %s outside project root', async (key, configuredPath) => {
+    const content = `
+      [agents.A]
+      ${key} = ${JSON.stringify(configuredPath)}
+    `;
+    await fs.writeFile(path.join(rulerDir, 'ruler.toml'), content);
+
+    await expect(loadConfig({ projectRoot: tmpDir })).rejects.toThrow(
+      /Configured output path is outside the project root/i,
+    );
+  });
+
   it('loads config from custom path via configPath option', async () => {
     const altDir = path.join(tmpDir, 'alt');
     await fs.mkdir(altDir, { recursive: true });


### PR DESCRIPTION
Closes #525

## Summary
- Reject configured agent output paths that resolve outside the project root.
- Apply the guard to `output_path`, `output_path_instructions`, and `output_path_config`.
- Update the MCP custom config path integration test to expect explicit config failure rather than silent skipping.

## Rationale
MCP config writes already avoid outside-project destinations. Ordinary agent output overrides should have the same boundary so a repository config cannot write or back up arbitrary files outside the project.

## Verification
- `npm ci`
- `npx jest --runTestsByPath tests/unit/core/ConfigLoader.test.ts tests/integration/mcp-custom-config-path.test.ts --runInBand --coverage=false`
- `npm run lint`
- `npm run build`
- `npm run format:check`
- `npm test` (140 suites, 1024 tests)
