### PR TITLE
Skip external symlinks during .ruler discovery

### DIFF
--- a/src/core/FileSystemUtils.ts
+++ b/src/core/FileSystemUtils.ts
@@ -2,6 +2,7 @@ import { promises as fs } from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { SKILLS_DIR, RULER_SUBAGENTS_PATH } from '../constants';
+import { isPathInsideOrEqual } from './path-utils';
 
 const SUBAGENTS_DIR_NAME = path.basename(RULER_SUBAGENTS_PATH);
 
@@ -103,6 +104,8 @@ export async function readMarkdownFiles(
 ): Promise<{ path: string; content: string }[]> {
   const mdFiles: { path: string; content: string }[] = [];
   const includeAgents = options.includeAgents === true;
+  const realRulerDir = await fs.realpath(rulerDir);
+  const visitedDirectories = new Set<string>();
   // Tracks whether we skipped a `.ruler/agents` subtree so the root-AGENTS.md
   // fallback below still recognises ruler content as present and does not
   // resurrect a previously generated root AGENTS.md (which may itself contain
@@ -111,6 +114,18 @@ export async function readMarkdownFiles(
 
   // Gather all markdown files (recursive) first
   async function walk(dir: string) {
+    let realDir: string;
+    try {
+      realDir = await fs.realpath(dir);
+    } catch {
+      return;
+    }
+
+    if (visitedDirectories.has(realDir)) {
+      return;
+    }
+    visitedDirectories.add(realDir);
+
     const entries = await fs.readdir(dir, { withFileTypes: true });
     for (const entry of entries) {
       const fullPath = path.join(dir, entry.name);
@@ -119,6 +134,10 @@ export async function readMarkdownFiles(
       let isFile = entry.isFile();
       if (entry.isSymbolicLink()) {
         try {
+          const realTarget = await fs.realpath(fullPath);
+          if (!isPathInsideOrEqual(realRulerDir, realTarget)) {
+            continue;
+          }
           const stat = await fs.stat(fullPath);
           isDir = stat.isDirectory();
           isFile = stat.isFile();

--- a/tests/unit/core/FileSystemUtils.test.ts
+++ b/tests/unit/core/FileSystemUtils.test.ts
@@ -65,7 +65,7 @@ describe('FileSystemUtils', () => {
       expect(files[1].content).toBe('contentB');
     });
 
-    it('reads symlinked markdown files', async () => {
+    it('skips symlinked markdown files outside .ruler', async () => {
       const rulerDir = path.join(tmpDir, '.ruler-symlink-file');
       await fs.mkdir(rulerDir, { recursive: true });
       const realFile = path.join(tmpDir, 'external.md');
@@ -73,12 +73,25 @@ describe('FileSystemUtils', () => {
       const linkPath = path.join(rulerDir, 'linked.md');
       await fs.symlink(realFile, linkPath);
       const files = await readMarkdownFiles(rulerDir);
-      expect(files.map((f) => f.path)).toContain(linkPath);
-      const linked = files.find((f) => f.path === linkPath);
-      expect(linked?.content).toBe('symlinked content');
+      expect(files.map((f) => f.path)).not.toContain(linkPath);
     });
 
-    it('follows symlinked directories', async () => {
+    it('reads symlinked markdown files inside .ruler', async () => {
+      const rulerDir = path.join(tmpDir, '.ruler-internal-symlink-file');
+      await fs.mkdir(path.join(rulerDir, 'real'), { recursive: true });
+      const realFile = path.join(rulerDir, 'real', 'source.md');
+      await fs.writeFile(realFile, 'internal symlinked content');
+      const linkPath = path.join(rulerDir, 'linked.md');
+      await fs.symlink(realFile, linkPath);
+
+      const files = await readMarkdownFiles(rulerDir);
+
+      expect(files.map((f) => f.path)).toContain(linkPath);
+      const linked = files.find((f) => f.path === linkPath);
+      expect(linked?.content).toBe('internal symlinked content');
+    });
+
+    it('skips symlinked directories outside .ruler', async () => {
       const rulerDir = path.join(tmpDir, '.ruler-symlink-dir');
       await fs.mkdir(rulerDir, { recursive: true });
       const realDir = path.join(tmpDir, 'external-dir');
@@ -89,9 +102,38 @@ describe('FileSystemUtils', () => {
       await fs.symlink(realDir, linkPath);
       const files = await readMarkdownFiles(rulerDir);
       const deepFile = path.join(linkPath, 'deep.md');
+      expect(files.map((f) => f.path)).not.toContain(deepFile);
+    });
+
+    it('follows symlinked directories inside .ruler', async () => {
+      const rulerDir = path.join(tmpDir, '.ruler-internal-symlink-dir');
+      await fs.mkdir(rulerDir, { recursive: true });
+      const realDir = path.join(rulerDir, 'real-dir');
+      await fs.mkdir(realDir, { recursive: true });
+      const realFile = path.join(realDir, 'deep.md');
+      await fs.writeFile(realFile, 'deep content');
+      const linkPath = path.join(rulerDir, 'linked-dir');
+      await fs.symlink(realDir, linkPath);
+
+      const files = await readMarkdownFiles(rulerDir);
+      const deepFile = path.join(linkPath, 'deep.md');
+
       expect(files.map((f) => f.path)).toContain(deepFile);
       const deep = files.find((f) => f.path === deepFile);
       expect(deep?.content).toBe('deep content');
+    });
+
+    it('does not recurse through symlink cycles', async () => {
+      const rulerDir = path.join(tmpDir, '.ruler-symlink-cycle');
+      await fs.mkdir(rulerDir, { recursive: true });
+      await fs.writeFile(path.join(rulerDir, 'rules.md'), 'content');
+      await fs.symlink(rulerDir, path.join(rulerDir, 'self'));
+
+      const files = await readMarkdownFiles(rulerDir);
+
+      expect(files.map((f) => path.relative(rulerDir, f.path))).toEqual([
+        'rules.md',
+      ]);
     });
 
     it('skips broken symlinks gracefully', async () => {


### PR DESCRIPTION
Closes #526

## Summary
- resolve .ruler symlink targets before reading markdown files
- skip symlinked files and directories outside the .ruler tree
- avoid recursive traversal through symlink cycles

## Verification
- npm ci
- npx jest --runTestsByPath tests/unit/core/FileSystemUtils.test.ts --runInBand --coverage=false
- npm run lint
- npm run build
- npm run format:check
- npm test