### PR TITLE
ci: declare read-only contents permission

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches: [main]
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #538

## Summary
- add explicit read-only contents permission to the CI workflow token

## Verification
- npm ci
- npm run format:check
- npm run lint
- npm test
- npm run build