### PR TITLE
ci: keep package lock version metadata in sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
       - run: npm ci
+      - run: npm run check:package-lock
       - run: npm run format:check
       - run: npm run lint
       - run: npm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org/'
       - run: npm ci
+      - run: npm run check:package-lock
       - name: Validate release target
         env:
           EVENT_NAME: ${{ github.event_name }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@intellectronica/ruler",
-  "version": "0.3.41",
+  "version": "0.3.42",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@intellectronica/ruler",
-      "version": "0.3.41",
+      "version": "0.3.42",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:coverage": "jest --coverage",
     "test:integration": "jest tests/e2e/ruler.integration.test.ts --verbose",
     "build": "tsc",
+    "check:package-lock": "node -e \"const pkg=require('./package.json'); const lock=require('./package-lock.json'); const root=lock.packages?.['']; if (lock.version !== pkg.version || root?.version !== pkg.version) { console.error('package-lock.json version metadata must match package.json version'); process.exit(1); }\"",
     "prepare": "npm run build"
   },
   "repository": {


### PR DESCRIPTION
Closes #535

## Summary
- sync package-lock.json root version metadata with package.json
- add a package-lock version check script
- run the check in CI and release before the heavier verification steps

## Verification
- npx prettier --write package.json package-lock.json .github/workflows/ci.yml .github/workflows/release.yml
- npm ci
- npm run check:package-lock
- npm run format:check
- npm run lint
- npm test
- npm run build