### PR TITLE
fix(revert): avoid corrupting malformed gitignore blocks

### DIFF
--- a/src/revert.ts
+++ b/src/revert.ts
@@ -218,9 +218,17 @@ async function cleanIgnoreFile(
   const content = await fs.readFile(ignorePath, 'utf8');
 
   const startIndex = content.indexOf(RULER_IGNORE_START_MARKER);
-  const endIndex = content.indexOf(RULER_IGNORE_END_MARKER);
+  if (startIndex === -1) {
+    logVerbose(`No ruler-managed block found in ${ignoreFile}`, verbose);
+    return false;
+  }
 
-  if (startIndex === -1 || endIndex === -1) {
+  const endIndex = content.indexOf(
+    RULER_IGNORE_END_MARKER,
+    startIndex + RULER_IGNORE_START_MARKER.length,
+  );
+
+  if (endIndex === -1) {
     logVerbose(`No ruler-managed block found in ${ignoreFile}`, verbose);
     return false;
   }

--- a/tests/unit/core/revert.test.ts
+++ b/tests/unit/core/revert.test.ts
@@ -474,6 +474,40 @@ describe('Revert Core Functions', () => {
       }
     });
 
+    it('leaves .gitignore unchanged when the only end marker appears before the start marker', async () => {
+      const gitignoreContent = [
+        'node_modules/',
+        '# END Ruler Generated Files',
+        'important-user-pattern',
+        '# START Ruler Generated Files',
+        'another-user-pattern',
+        '',
+      ].join('\n');
+      await fs.writeFile(path.join(tmpDir, '.gitignore'), gitignoreContent);
+
+      const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+
+      try {
+        await revertAllAgentConfigs(
+          tmpDir,
+          undefined,
+          undefined,
+          false,
+          false,
+          false,
+        );
+
+        expect(consoleLogSpy).not.toHaveBeenCalledWith(
+          '  .gitignore cleaned: yes',
+        );
+        await expect(
+          fs.readFile(path.join(tmpDir, '.gitignore'), 'utf8'),
+        ).resolves.toBe(gitignoreContent);
+      } finally {
+        consoleLogSpy.mockRestore();
+      }
+    });
+
     it('recognises generated files listed in the real worktree exclude file', async () => {
       const actualGitDir = path.join(tmpDir, '.git-worktree');
       await fs.mkdir(path.join(actualGitDir, 'info'), { recursive: true });


### PR DESCRIPTION
Closes #529

## Summary
- treat Ruler ignore blocks as valid only when the end marker follows the start marker
- keep malformed ignore files unchanged instead of removing unrelated user content
- add a regression test for a stray end marker before the start marker

## Verification
- npm ci
- npx jest --runTestsByPath tests/unit/core/revert.test.ts --runInBand --coverage=false
- npx prettier --write src/revert.ts tests/unit/core/revert.test.ts
- npm run format:check
- npm run lint
- npm test
- npm run build