### PR TITLE
fix(revert): honour custom MCP output paths

### DIFF
--- a/src/core/revert-engine.ts
+++ b/src/core/revert-engine.ts
@@ -34,6 +34,18 @@ export interface CleanUpResult {
   directoriesRemoved: number;
 }
 
+async function resolveMcpPathForRevert(
+  agent: IAgent,
+  projectRoot: string,
+  agentConfig: IAgentConfig | undefined,
+): Promise<string | null> {
+  if (agentConfig?.outputPathConfig) {
+    return path.resolve(projectRoot, agentConfig.outputPathConfig);
+  }
+
+  return await getNativeMcpPath(agent.getName(), projectRoot);
+}
+
 /**
  * Checks if a file exists.
  */
@@ -561,7 +573,11 @@ export async function revertAgentConfiguration(
   }
 
   // Handle MCP files
-  const mcpPath = await getNativeMcpPath(agent.getName(), projectRoot);
+  const mcpPath = await resolveMcpPathForRevert(
+    agent,
+    projectRoot,
+    agentConfig,
+  );
   if (mcpPath && isPathInsideOrEqual(projectRoot, mcpPath)) {
     if (
       agent.getName() === 'AugmentCode' &&

--- a/tests/integration/mcp-custom-config-path.test.ts
+++ b/tests/integration/mcp-custom-config-path.test.ts
@@ -2,6 +2,7 @@ import { promises as fs } from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { applyAllAgentConfigs } from '../../src/lib';
+import { revertAllAgentConfigs } from '../../src/revert';
 
 async function pathExists(filePath: string): Promise<boolean> {
   try {
@@ -103,6 +104,40 @@ args = ["server.js"]
       command: ['node', 'server.js'],
       enabled: true,
     });
+  });
+
+  it('reverts MCP config written to output_path_config', async () => {
+    await writeProject(
+      tmpDir,
+      `
+[agents.opencode]
+output_path_config = "custom/opencode.json"
+
+[mcp_servers.repo]
+command = "node"
+args = ["server.js"]
+`,
+    );
+
+    await applyAllAgentConfigs(tmpDir, ['opencode']);
+
+    const customPath = path.join(tmpDir, 'custom', 'opencode.json');
+    const defaultPath = path.join(tmpDir, 'opencode.json');
+
+    await expect(pathExists(customPath)).resolves.toBe(true);
+    await expect(pathExists(defaultPath)).resolves.toBe(false);
+
+    await revertAllAgentConfigs(
+      tmpDir,
+      ['opencode'],
+      undefined,
+      false,
+      false,
+      false,
+    );
+
+    await expect(pathExists(customPath)).resolves.toBe(false);
+    await expect(pathExists(defaultPath)).resolves.toBe(false);
   });
 
   it('rejects custom MCP config paths outside the project root', async () => {


### PR DESCRIPTION
Closes #528

## Summary
- resolve MCP revert targets from output_path_config before falling back to native paths
- remove generated custom MCP config files when they have Ruler provenance
- add an integration regression for OpenCode custom MCP config revert

## Verification
- npm ci
- npx jest --runTestsByPath tests/integration/mcp-custom-config-path.test.ts --runInBand --coverage=false
- npx prettier --write src/core/revert-engine.ts tests/integration/mcp-custom-config-path.test.ts
- npm run format:check
- npm run lint
- npm test
- npm run build