### PR TITLE
fix(revert): scope auxiliary cleanup to selected agents

### DIFF
--- a/src/core/revert-engine.ts
+++ b/src/core/revert-engine.ts
@@ -648,3 +648,43 @@ export async function cleanUpAuxiliaryFiles(
     directoriesRemoved,
   };
 }
+
+export async function cleanUpAgentDirectories(
+  agent: IAgent,
+  projectRoot: string,
+  agentConfig: IAgentConfig | undefined,
+  verbose: boolean,
+  dryRun: boolean,
+): Promise<number> {
+  const candidateFiles = getAgentOutputPaths(agent, projectRoot, agentConfig);
+  const mcpPath = await getNativeMcpPath(agent.getName(), projectRoot);
+  if (mcpPath && isPathInsideOrEqual(projectRoot, mcpPath)) {
+    candidateFiles.push(mcpPath);
+  }
+
+  const candidateDirs = [
+    ...new Set(candidateFiles.map((filePath) => path.dirname(filePath))),
+  ];
+
+  let directoriesRemoved = 0;
+  const resolvedProjectRoot = path.resolve(projectRoot);
+
+  for (const candidateDir of candidateDirs) {
+    let currentDir = path.resolve(candidateDir);
+
+    while (
+      currentDir !== resolvedProjectRoot &&
+      isPathInsideOrEqual(resolvedProjectRoot, currentDir)
+    ) {
+      const removed = await removeEmptyDirectory(currentDir, verbose, dryRun);
+      if (!removed) {
+        break;
+      }
+
+      directoriesRemoved++;
+      currentDir = path.dirname(currentDir);
+    }
+  }
+
+  return directoriesRemoved;
+}

--- a/src/revert.ts
+++ b/src/revert.ts
@@ -7,6 +7,7 @@ import { createRulerError, logVerbose, actionPrefix } from './constants';
 import {
   revertAgentConfiguration,
   cleanUpAuxiliaryFiles,
+  cleanUpAgentDirectories,
 } from './core/revert-engine';
 import {
   agentMatchesFilter,
@@ -115,12 +116,14 @@ export async function revertAllAgentConfigs(
     `Selected agents: ${selected.map((a) => a.getName()).join(', ')}`,
     verbose,
   );
+  const isFullRevert = !config.cliAgents || config.cliAgents.length === 0;
 
   // Revert configurations for each agent
   let totalFilesProcessed = 0;
   let totalFilesRestored = 0;
   let totalFilesRemoved = 0;
   let totalBackupsRemoved = 0;
+  let totalDirectoriesRemoved = 0;
 
   for (const agent of selected) {
     const prefix = actionPrefix(dryRun);
@@ -140,21 +143,29 @@ export async function revertAllAgentConfigs(
     totalFilesRestored += result.restored;
     totalFilesRemoved += result.removed;
     totalBackupsRemoved += result.backupsRemoved;
+
+    if (!isFullRevert) {
+      totalDirectoriesRemoved += await cleanUpAgentDirectories(
+        agent,
+        projectRoot,
+        agentConfig,
+        verbose,
+        dryRun,
+      );
+    }
   }
 
-  // Clean up auxiliary files and directories
-  const cleanupResult = await cleanUpAuxiliaryFiles(
-    projectRoot,
-    verbose,
-    dryRun,
-  );
+  // Clean up auxiliary files and directories only when reverting all agents.
+  const cleanupResult = isFullRevert
+    ? await cleanUpAuxiliaryFiles(projectRoot, verbose, dryRun)
+    : { additionalFilesRemoved: 0, directoriesRemoved: 0 };
   totalFilesRemoved += cleanupResult.additionalFilesRemoved;
+  totalDirectoriesRemoved += cleanupResult.directoriesRemoved;
 
   // Clean managed ignore blocks if reverting all agents.
-  const cleanedIgnoreFiles =
-    !config.cliAgents || config.cliAgents.length === 0
-      ? await cleanManagedIgnoreFiles(projectRoot, verbose, dryRun)
-      : [];
+  const cleanedIgnoreFiles = isFullRevert
+    ? await cleanManagedIgnoreFiles(projectRoot, verbose, dryRun)
+    : [];
 
   // Display summary
   const prefix = actionPrefix(dryRun);
@@ -171,10 +182,8 @@ export async function revertAllAgentConfigs(
   if (!keepBackups) {
     console.log(`  Backup files removed: ${totalBackupsRemoved}`);
   }
-  if (cleanupResult.directoriesRemoved > 0) {
-    console.log(
-      `  Empty directories removed: ${cleanupResult.directoriesRemoved}`,
-    );
+  if (totalDirectoriesRemoved > 0) {
+    console.log(`  Empty directories removed: ${totalDirectoriesRemoved}`);
   }
   for (const ignoreFile of cleanedIgnoreFiles) {
     console.log(`  ${ignoreFile} cleaned: yes`);

--- a/tests/integration/revert-agents.test.ts
+++ b/tests/integration/revert-agents.test.ts
@@ -43,6 +43,12 @@ describe('Revert Agent Integration', () => {
         path.join(tmpDir, 'CLAUDE.md'),
         `${GENERATED_MARKER}\nClaude content`,
       );
+      await fs.mkdir(path.join(tmpDir, '.gemini'), { recursive: true });
+      await fs.writeFile(
+        path.join(tmpDir, '.gemini', 'settings.json'),
+        '{"contextFileName":"AGENTS.md"}',
+      );
+      await writeRulerGitignore(tmpDir, ['.gemini/settings.json']);
       await fs.writeFile(path.join(tmpDir, 'AGENTS.md'), 'Agents content');
 
       await revertAllAgentConfigs(
@@ -57,6 +63,9 @@ describe('Revert Agent Integration', () => {
       await expect(fs.access(path.join(tmpDir, 'CLAUDE.md'))).rejects.toThrow();
       await expect(
         fs.access(path.join(tmpDir, 'AGENTS.md')),
+      ).resolves.toBeUndefined();
+      await expect(
+        fs.access(path.join(tmpDir, '.gemini', 'settings.json')),
       ).resolves.toBeUndefined();
     });
 


### PR DESCRIPTION
Closes #527

## Summary
- skip global auxiliary-file cleanup during scoped revert
- clean only empty directories reached from the selected agents
- add a regression showing scoped Claude revert preserves Gemini settings

## Verification
- npm ci
- npx jest --runTestsByPath tests/integration/revert-agents.test.ts --runInBand --coverage=false
- npx prettier --write src/revert.ts src/core/revert-engine.ts tests/integration/revert-agents.test.ts
- npm run format:check
- npm run lint
- npm test
- npm run build
- post-rebase: npm run format:check
- post-rebase: npm run lint
- post-rebase: npm test
- post-rebase: npm run build