### PR TITLE
ci: publish manual releases from the resolved tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.release.tag_name || inputs.release_tag || github.ref }}
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -58,6 +59,12 @@ jobs:
           git fetch --force --tags origin
           git fetch origin main
           TAG_SHA="$(git rev-list -n 1 "${RELEASE_TAG}")"
+          HEAD_SHA="$(git rev-parse HEAD)"
+          if [ "${HEAD_SHA}" != "${TAG_SHA}" ]; then
+            echo "::error::Release workflow checked out ${HEAD_SHA}, but ${RELEASE_TAG} resolves to ${TAG_SHA}."
+            exit 1
+          fi
+
           MAIN_SHA="$(git rev-parse origin/main)"
           if [ "${TAG_SHA}" != "${MAIN_SHA}" ] && ! git diff --quiet "${TAG_SHA}" "${MAIN_SHA}" -- package.json package-lock.json tsconfig.json README.md LICENSE src; then
             echo "::error::Release tag ${RELEASE_TAG} (${TAG_SHA}) must point at origin/main (${MAIN_SHA}) or have identical package contents."


### PR DESCRIPTION
Closes #534

## Summary
- checkout the release event tag or manual release_tag before install/build
- verify HEAD exactly matches the resolved release tag SHA before publishing

## Verification
- npm ci
- npx prettier --write .github/workflows/release.yml
- npm run format:check
- npm run lint
- npm test
- npm run build