### PR TITLE
fix(agents): align context filenames with custom outputs

### DIFF
--- a/src/agents/GeminiCliAgent.ts
+++ b/src/agents/GeminiCliAgent.ts
@@ -12,6 +12,13 @@ export class GeminiCliAgent extends AgentsMdAgent {
     return 'Gemini CLI';
   }
 
+  private getContextFileName(projectRoot: string, agentConfig?: IAgentConfig) {
+    const outputPath = agentConfig?.outputPath ?? 'AGENTS.md';
+    return path
+      .relative(projectRoot, path.resolve(projectRoot, outputPath))
+      .replace(/\\/g, '/');
+  }
+
   async applyRulerConfig(
     concatenatedRules: string,
     projectRoot: string,
@@ -44,7 +51,7 @@ export class GeminiCliAgent extends AgentsMdAgent {
 
     const updated = {
       ...existingSettings,
-      contextFileName: 'AGENTS.md',
+      contextFileName: this.getContextFileName(projectRoot, agentConfig),
     } as Record<string, unknown>;
 
     // Handle MCP server configuration if provided

--- a/src/agents/QwenCodeAgent.ts
+++ b/src/agents/QwenCodeAgent.ts
@@ -12,6 +12,13 @@ export class QwenCodeAgent extends AgentsMdAgent {
     return 'Qwen Code';
   }
 
+  private getContextFileName(projectRoot: string, agentConfig?: IAgentConfig) {
+    const outputPath = agentConfig?.outputPath ?? 'AGENTS.md';
+    return path
+      .relative(projectRoot, path.resolve(projectRoot, outputPath))
+      .replace(/\\/g, '/');
+  }
+
   async applyRulerConfig(
     concatenatedRules: string,
     projectRoot: string,
@@ -44,7 +51,7 @@ export class QwenCodeAgent extends AgentsMdAgent {
 
     const updated = {
       ...existingSettings,
-      contextFileName: 'AGENTS.md',
+      contextFileName: this.getContextFileName(projectRoot, agentConfig),
     } as Record<string, unknown>;
 
     await fs.mkdir(path.dirname(settingsPath), { recursive: true });

--- a/tests/unit/agents/GeminiCliAgent.test.ts
+++ b/tests/unit/agents/GeminiCliAgent.test.ts
@@ -57,6 +57,29 @@ describe('GeminiCliAgent', () => {
     }
   });
 
+  it('sets contextFileName to a custom output path', async () => {
+    const { projectRoot } = await setupTestProject({
+      '.ruler/AGENTS.md': 'Rule A',
+    });
+    try {
+      const agent = new GeminiCliAgent();
+      const customOutputPath = path.join('docs', 'GEMINI.md');
+
+      await agent.applyRulerConfig('Rules', projectRoot, null, {
+        outputPath: customOutputPath,
+      });
+
+      await expect(
+        fs.readFile(path.join(projectRoot, customOutputPath), 'utf8'),
+      ).resolves.toContain('Rules');
+
+      const settings = await readGeminiSettings(projectRoot);
+      expect(settings.contextFileName).toBe('docs/GEMINI.md');
+    } finally {
+      await teardownTestProject(projectRoot);
+    }
+  });
+
   it('preserves existing settings and adds/updates contextFileName', async () => {
     const { projectRoot } = await setupTestProject({
       '.ruler/AGENTS.md': 'Rule X',

--- a/tests/unit/agents/QwenCodeAgent.test.ts
+++ b/tests/unit/agents/QwenCodeAgent.test.ts
@@ -5,6 +5,13 @@ import { AgentsMdAgent } from '../../../src/agents/AgentsMdAgent';
 import { setupTestProject, teardownTestProject } from '../../harness';
 
 describe('QwenCodeAgent', () => {
+  async function readQwenSettings(
+    projectRoot: string,
+  ): Promise<Record<string, unknown>> {
+    const settingsPath = path.join(projectRoot, '.qwen', 'settings.json');
+    return JSON.parse(await fs.readFile(settingsPath, 'utf8'));
+  }
+
   it('should be defined', () => {
     expect(new QwenCodeAgent()).toBeDefined();
   });
@@ -40,6 +47,29 @@ describe('QwenCodeAgent', () => {
       const settingsRaw = await fs.readFile(settingsPath, 'utf8');
       const settings = JSON.parse(settingsRaw);
       expect(settings.contextFileName).toBe('AGENTS.md');
+    } finally {
+      await teardownTestProject(projectRoot);
+    }
+  });
+
+  it('sets contextFileName to a custom output path', async () => {
+    const { projectRoot } = await setupTestProject({
+      '.ruler/AGENTS.md': 'Rule A',
+    });
+    try {
+      const agent = new QwenCodeAgent();
+      const customOutputPath = path.join('docs', 'QWEN.md');
+
+      await agent.applyRulerConfig('Rules', projectRoot, null, {
+        outputPath: customOutputPath,
+      });
+
+      await expect(
+        fs.readFile(path.join(projectRoot, customOutputPath), 'utf8'),
+      ).resolves.toContain('Rules');
+
+      const settings = await readQwenSettings(projectRoot);
+      expect(settings.contextFileName).toBe('docs/QWEN.md');
     } finally {
       await teardownTestProject(projectRoot);
     }


### PR DESCRIPTION
## Summary
- derive Gemini and Qwen contextFileName values from each agent's configured output path
- add regression coverage for custom Gemini and Qwen output paths

Closes #539

## Verification
- npx jest --runTestsByPath tests/unit/agents/GeminiCliAgent.test.ts tests/unit/agents/QwenCodeAgent.test.ts --runInBand --coverage=false
- npm run format:check && npm run lint && npm test && npm run build