### PR TITLE
fix(revert): consume backups after restore

### DIFF
--- a/src/core/revert-engine.ts
+++ b/src/core/revert-engine.ts
@@ -518,7 +518,7 @@ async function removeAdditionalAgentFiles(
  * @param agent The agent to revert
  * @param projectRoot Root directory of the project
  * @param agentConfig Agent-specific configuration
- * @param keepBackups Whether to keep backup files
+ * @param _keepBackups Retained for API compatibility; restored backups are consumed
  * @param verbose Whether to enable verbose logging
  * @param dryRun Whether to perform a dry run
  * @returns Promise resolving to revert statistics
@@ -527,7 +527,7 @@ export async function revertAgentConfiguration(
   agent: IAgent,
   projectRoot: string,
   agentConfig: IAgentConfig | undefined,
-  keepBackups: boolean,
+  _keepBackups: boolean,
   verbose: boolean,
   dryRun: boolean,
 ): Promise<RevertAgentResult> {
@@ -549,15 +549,9 @@ export async function revertAgentConfiguration(
     if (restored) {
       result.restored++;
 
-      if (!keepBackups) {
-        const backupRemoved = await removeBackupFile(
-          outputPath,
-          verbose,
-          dryRun,
-        );
-        if (backupRemoved) {
-          result.backupsRemoved++;
-        }
+      const backupRemoved = await removeBackupFile(outputPath, verbose, dryRun);
+      if (backupRemoved) {
+        result.backupsRemoved++;
       }
     } else {
       const removed = await removeGeneratedFile(
@@ -592,15 +586,13 @@ export async function revertAgentConfiguration(
       if (mcpRestored) {
         result.restored++;
 
-        if (!keepBackups) {
-          const mcpBackupRemoved = await removeBackupFile(
-            mcpPath,
-            verbose,
-            dryRun,
-          );
-          if (mcpBackupRemoved) {
-            result.backupsRemoved++;
-          }
+        const mcpBackupRemoved = await removeBackupFile(
+          mcpPath,
+          verbose,
+          dryRun,
+        );
+        if (mcpBackupRemoved) {
+          result.backupsRemoved++;
         }
       } else {
         const mcpRemoved = await removeGeneratedFile(

--- a/src/revert.ts
+++ b/src/revert.ts
@@ -179,9 +179,7 @@ export async function revertAllAgentConfigs(
   console.log(`  Files processed: ${totalFilesProcessed}`);
   console.log(`  Files restored from backup: ${totalFilesRestored}`);
   console.log(`  Generated files removed: ${totalFilesRemoved}`);
-  if (!keepBackups) {
-    console.log(`  Backup files removed: ${totalBackupsRemoved}`);
-  }
+  console.log(`  Backup files removed: ${totalBackupsRemoved}`);
   if (totalDirectoriesRemoved > 0) {
     console.log(`  Empty directories removed: ${totalDirectoriesRemoved}`);
   }

--- a/tests/integration/revert-cli.test.ts
+++ b/tests/integration/revert-cli.test.ts
@@ -81,7 +81,7 @@ describe('Revert CLI Integration', () => {
       expect(output).not.toContain('Reverting OpenAI Codex CLI');
     });
 
-    it('should handle --keep-backups option', async () => {
+    it('should remove consumed backup after --keep-backups restore', async () => {
       const filePath = path.join(tmpDir, 'CLAUDE.md');
       const backupPath = `${filePath}.bak`;
 
@@ -95,7 +95,7 @@ describe('Revert CLI Integration', () => {
         },
       );
 
-      await expect(fs.access(backupPath)).resolves.toBeUndefined();
+      await expect(fs.access(backupPath)).rejects.toThrow();
     });
 
     it('should handle --verbose option', () => {

--- a/tests/unit/core/revert-engine.test.ts
+++ b/tests/unit/core/revert-engine.test.ts
@@ -170,7 +170,7 @@ describe('revert-engine', () => {
       );
     });
 
-    it('should keep backups when keepBackups is true', async () => {
+    it('should remove consumed backups when keepBackups is true', async () => {
       const agent = new MockAgent('Claude Code', 'claude');
       const configPath = path.join(tmpDir, '.claude', 'config.json');
       const backupPath = `${configPath}.bak`;
@@ -191,14 +191,14 @@ describe('revert-engine', () => {
 
       expect(result.restored).toBe(1);
       expect(result.removed).toBe(0);
-      expect(result.backupsRemoved).toBe(0);
+      expect(result.backupsRemoved).toBe(1);
 
-      // Check that backup still exists
+      // A consumed backup must not remain stale after restore.
       const backupExists = await fs
         .access(backupPath)
         .then(() => true)
         .catch(() => false);
-      expect(backupExists).toBe(true);
+      expect(backupExists).toBe(false);
     });
 
     it('should handle dry run mode', async () => {

--- a/tests/unit/core/revert.test.ts
+++ b/tests/unit/core/revert.test.ts
@@ -215,7 +215,7 @@ describe('Revert Core Functions', () => {
       consoleErrorSpy.mockRestore();
     });
 
-    it('should handle keep-backups flag', async () => {
+    it('should remove consumed backup when keep-backups is true', async () => {
       const filePath = path.join(tmpDir, 'CLAUDE.md');
       const backupPath = `${filePath}.bak`;
 
@@ -231,7 +231,7 @@ describe('Revert Core Functions', () => {
         false,
       );
 
-      await expect(fs.access(backupPath)).resolves.toBeUndefined();
+      await expect(fs.access(backupPath)).rejects.toThrow();
 
       const restoredContent = await fs.readFile(filePath, 'utf8');
       expect(restoredContent).toBe('Original content');


### PR DESCRIPTION
Closes #530

## Summary
- remove restored `.bak` files after a successful restore, including when `--keep-backups` is set
- always report the removed backup count in revert summaries
- add unit and integration regression coverage for consumed backups

## Verification
- `npx jest --runTestsByPath tests/unit/core/revert-engine.test.ts tests/unit/core/revert.test.ts tests/integration/revert-cli.test.ts --runInBand --coverage=false`
- `npm run format:check`
- `npm run lint`
- `npm run build`