### PR TITLE
fix(mcp): normalise server container aliases

### DIFF
--- a/src/mcp/merge.ts
+++ b/src/mcp/merge.ts
@@ -8,6 +8,40 @@ const MCP_SERVER_KEYS = [
   'context_servers',
 ];
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function collectMcpServers(
+  config: Record<string, unknown>,
+  serverKey: string,
+): Record<string, unknown> {
+  const servers: Record<string, unknown> = {};
+  const aliases = MCP_SERVER_KEYS.filter((key) => key !== serverKey);
+
+  for (const key of [...aliases, serverKey]) {
+    const value = config[key];
+    if (isRecord(value)) {
+      Object.assign(servers, value);
+    }
+  }
+
+  return servers;
+}
+
+function removeServerAliases(
+  config: Record<string, unknown>,
+  serverKey: string,
+): Record<string, unknown> {
+  const result = { ...config };
+  for (const key of MCP_SERVER_KEYS) {
+    if (key !== serverKey) {
+      delete result[key];
+    }
+  }
+  return result;
+}
+
 /**
  * Merge native and incoming MCP server configurations according to strategy.
  * @param base Existing native MCP config object.
@@ -23,44 +57,19 @@ export function mergeMcp(
   serverKey: string,
 ): Record<string, unknown> {
   if (strategy === 'overwrite') {
-    // Ensure the incoming object uses the correct server key.
-    // Transform from the standard (Crush) MCP config format
-    const incomingServers =
-      (incoming[serverKey] as Record<string, unknown>) ||
-      (incoming.mcpServers as Record<string, unknown>) ||
-      (incoming.mcp as Record<string, unknown>) ||
-      {};
-    const preservedBase = { ...base };
-    for (const key of MCP_SERVER_KEYS) {
-      if (key !== serverKey) {
-        delete preservedBase[key];
-      }
-    }
+    const incomingServers = collectMcpServers(incoming, serverKey);
+    const preservedBase = removeServerAliases(base, serverKey);
     return {
       ...preservedBase,
       [serverKey]: incomingServers,
     };
   }
 
-  const baseServers =
-    (base[serverKey] as Record<string, unknown>) ||
-    (base.mcpServers as Record<string, unknown>) ||
-    (base.mcp as Record<string, unknown>) ||
-    {};
-  const incomingServers =
-    (incoming[serverKey] as Record<string, unknown>) ||
-    (incoming.mcpServers as Record<string, unknown>) ||
-    (incoming.mcp as Record<string, unknown>) ||
-    {};
+  const baseServers = collectMcpServers(base, serverKey);
+  const incomingServers = collectMcpServers(incoming, serverKey);
 
   const mergedServers = { ...baseServers, ...incomingServers };
-
-  const newBase = { ...base };
-  for (const key of MCP_SERVER_KEYS) {
-    if (key !== serverKey) {
-      delete newBase[key];
-    }
-  }
+  const newBase = removeServerAliases(base, serverKey);
 
   return {
     ...newBase,

--- a/tests/unit/mcp/merge.test.ts
+++ b/tests/unit/mcp/merge.test.ts
@@ -1,17 +1,26 @@
 import { mergeMcp } from '../../../src/mcp/merge';
 
 describe('mergeMcp', () => {
-  it('removes alternate server aliases when writing the target key', () => {
+  it('normalises all recognised server containers into the requested key', () => {
     const result = mergeMcp(
       {
-        mcp: {
-          existing: { command: 'existing-command' },
-        },
         otherSetting: true,
+        servers: {
+          fromServers: { url: 'https://servers.example.com' },
+          duplicate: { url: 'https://servers-wins.example.com' },
+        },
+        mcpServers: {
+          fromMcpServers: { command: 'node' },
+          duplicate: { url: 'https://mcpservers.example.com' },
+        },
+        mcp: {
+          fromMcp: { url: 'https://mcp.example.com' },
+        },
       },
       {
         mcpServers: {
-          incoming: { command: 'incoming-command' },
+          incoming: { command: 'incoming' },
+          duplicate: { url: 'https://incoming.example.com' },
         },
       },
       'merge',
@@ -21,8 +30,40 @@ describe('mergeMcp', () => {
     expect(result).toEqual({
       otherSetting: true,
       servers: {
-        existing: { command: 'existing-command' },
-        incoming: { command: 'incoming-command' },
+        fromMcp: { url: 'https://mcp.example.com' },
+        fromMcpServers: { command: 'node' },
+        fromServers: { url: 'https://servers.example.com' },
+        duplicate: { url: 'https://incoming.example.com' },
+        incoming: { command: 'incoming' },
+      },
+    });
+  });
+
+  it('normalises incoming server containers when overwriting', () => {
+    const result = mergeMcp(
+      {
+        otherSetting: true,
+        servers: {
+          stale: { command: 'old' },
+        },
+      },
+      {
+        mcp: {
+          fromMcp: { command: 'mcp' },
+        },
+        mcpServers: {
+          fromMcpServers: { command: 'mcpServers' },
+        },
+      },
+      'overwrite',
+      'servers',
+    );
+
+    expect(result).toEqual({
+      otherSetting: true,
+      servers: {
+        fromMcp: { command: 'mcp' },
+        fromMcpServers: { command: 'mcpServers' },
       },
     });
   });


### PR DESCRIPTION
Closes #531

## Summary
- fold all recognised MCP server container aliases into the target output key
- preserve unrelated native config while removing stale alias keys
- add unit coverage for mixed `servers`/`mcpServers`/`mcp` inputs

## Verification
- `npx jest --runTestsByPath tests/unit/mcp/merge.test.ts --runInBand --coverage=false`
- `npm run format:check`
- `npm run lint`
- `npm run build`