### PR TITLE
fix(mcp): reject unsupported OpenHands remote headers

### DIFF
--- a/src/mcp/propagateOpenHandsMcp.ts
+++ b/src/mcp/propagateOpenHandsMcp.ts
@@ -65,13 +65,23 @@ function extractApiKey(headers?: Record<string, string>): string | null {
 }
 
 function createRemoteServerEntry(
+  name: string,
   url: string,
   headers?: Record<string, string>,
 ): string | RemoteServerEntry {
+  const hasHeaders = headers && Object.keys(headers).length > 0;
   const apiKey = extractApiKey(headers);
-  if (apiKey) {
-    return { url, api_key: apiKey };
+
+  if (hasHeaders) {
+    if (apiKey) {
+      return { url, api_key: apiKey };
+    }
+
+    throw new Error(
+      `OpenHands MCP remote server "${name}" has unsupported headers. OpenHands config.toml can only represent a Bearer Authorization header as api_key.`,
+    );
   }
+
   return url;
 }
 
@@ -190,7 +200,11 @@ export async function propagateMcpToOpenHands(
       } else if (serverDef.url) {
         // Remote server
         const classification = classifyRemoteServer(serverDef.url);
-        const entry = createRemoteServerEntry(serverDef.url, serverDef.headers);
+        const entry = createRemoteServerEntry(
+          name,
+          serverDef.url,
+          serverDef.headers,
+        );
 
         if (classification === 'sse') {
           existingSseServers.set(serverDef.url, entry);

--- a/tests/e2e/ruler.integration.test.ts
+++ b/tests/e2e/ruler.integration.test.ts
@@ -69,7 +69,6 @@ url = "https://api.example.com/mcp"
 
 [mcp_servers.remote_api.headers]
 Authorization = "Bearer test-token-12345"
-"X-API-Version" = "v1"
 "Content-Type" = "application/json"
 
 # Agent-specific configuration - enable MCP for key agents

--- a/tests/unit/mcp/OpenHandsMcp.test.ts
+++ b/tests/unit/mcp/OpenHandsMcp.test.ts
@@ -284,7 +284,7 @@ stdio_servers = [
     });
   });
 
-  it('should fallback to simple URL when headers contain non-auth headers', async () => {
+  it('should reject remote headers that OpenHands cannot represent', async () => {
     const rulerMcp = {
       mcpServers: {
         complex_api: {
@@ -298,15 +298,13 @@ stdio_servers = [
       },
     };
 
-    await propagateMcpToOpenHands(rulerMcp, openHandsConfigPath);
+    await expect(
+      propagateMcpToOpenHands(rulerMcp, openHandsConfigPath),
+    ).rejects.toThrow(
+      /OpenHands MCP remote server "complex_api" has unsupported headers/,
+    );
 
-    const content = await fs.readFile(openHandsConfigPath, 'utf8');
-    const parsed = parseTOML(content);
-    const mcp: any = parsed.mcp;
-
-    expect(mcp.shttp_servers).toHaveLength(1);
-    // Should be simple URL string (no api_key extraction due to extra headers)
-    expect(mcp.shttp_servers[0]).toBe('https://complex.example.com/mcp');
+    await expect(fs.access(openHandsConfigPath)).rejects.toThrow();
   });
 
   it('should merge remote servers with existing OpenHands config', async () => {


### PR DESCRIPTION
Closes #532

## Summary
- reject OpenHands remote MCP servers whose headers cannot be represented in `config.toml`
- preserve the existing Bearer `Authorization` to `api_key` conversion
- update OpenHands MCP regression coverage so unsupported headers are not silently dropped

## Verification
- `npx jest --runTestsByPath tests/unit/mcp/OpenHandsMcp.test.ts --runInBand --coverage=false`
- `npm run format:check`
- `npm run lint`
- `npm run build`