### PR TITLE
fix(agents): honour MCP custom config paths

### DIFF
--- a/src/agents/GeminiCliAgent.ts
+++ b/src/agents/GeminiCliAgent.ts
@@ -37,8 +37,11 @@ export class GeminiCliAgent extends AgentsMdAgent {
       backup,
     );
 
-    // Prepare .gemini/settings.json with contextFileName and MCP configuration
-    const settingsPath = path.join(projectRoot, '.gemini', 'settings.json');
+    // Prepare settings with contextFileName and MCP configuration
+    const settingsPath = path.resolve(
+      projectRoot,
+      agentConfig?.outputPathConfig ?? path.join('.gemini', 'settings.json'),
+    );
     let existingSettings: Record<string, unknown> = {};
     try {
       const raw = await fs.readFile(settingsPath, 'utf8');

--- a/src/agents/ZedAgent.ts
+++ b/src/agents/ZedAgent.ts
@@ -38,7 +38,10 @@ export class ZedAgent extends AgentsMdAgent {
     // Handle MCP server configuration if enabled and provided
     const mcpEnabled = agentConfig?.mcp?.enabled ?? true;
     if (mcpEnabled && rulerMcpJson) {
-      const zedSettingsPath = path.join(projectRoot, '.zed', 'settings.json');
+      const zedSettingsPath = path.resolve(
+        projectRoot,
+        agentConfig?.outputPathConfig ?? path.join('.zed', 'settings.json'),
+      );
 
       // Read existing settings
       let existingSettings: Record<string, unknown> = {};

--- a/tests/integration/mcp-custom-config-path.test.ts
+++ b/tests/integration/mcp-custom-config-path.test.ts
@@ -106,6 +106,83 @@ args = ["server.js"]
     });
   });
 
+  it('writes Gemini MCP config only to output_path_config', async () => {
+    await writeProject(
+      tmpDir,
+      `
+[agents.gemini-cli]
+output_path_config = "custom/gemini-settings.json"
+
+[mcp_servers.repo]
+command = "node"
+args = ["server.js"]
+`,
+    );
+
+    await applyAllAgentConfigs(
+      tmpDir,
+      ['gemini-cli'],
+      undefined,
+      true,
+      undefined,
+      false,
+      false,
+      false,
+      true,
+    );
+
+    const customPath = path.join(tmpDir, 'custom', 'gemini-settings.json');
+    const defaultPath = path.join(tmpDir, '.gemini', 'settings.json');
+
+    await expect(pathExists(customPath)).resolves.toBe(true);
+    await expect(pathExists(defaultPath)).resolves.toBe(false);
+
+    const config = JSON.parse(await fs.readFile(customPath, 'utf8'));
+    expect(config.mcpServers.repo).toEqual({
+      command: 'node',
+      args: ['server.js'],
+    });
+  });
+
+  it('writes Zed MCP config only to output_path_config', async () => {
+    await writeProject(
+      tmpDir,
+      `
+[agents.zed]
+output_path_config = "custom/zed-settings.json"
+
+[mcp_servers.repo]
+command = "node"
+args = ["server.js"]
+`,
+    );
+
+    await applyAllAgentConfigs(
+      tmpDir,
+      ['zed'],
+      undefined,
+      true,
+      undefined,
+      false,
+      false,
+      false,
+      true,
+    );
+
+    const customPath = path.join(tmpDir, 'custom', 'zed-settings.json');
+    const defaultPath = path.join(tmpDir, '.zed', 'settings.json');
+
+    await expect(pathExists(customPath)).resolves.toBe(true);
+    await expect(pathExists(defaultPath)).resolves.toBe(false);
+
+    const config = JSON.parse(await fs.readFile(customPath, 'utf8'));
+    expect(config.context_servers.repo).toEqual({
+      command: 'node',
+      args: ['server.js'],
+      source: 'custom',
+    });
+  });
+
   it('reverts MCP config written to output_path_config', async () => {
     await writeProject(
       tmpDir,


### PR DESCRIPTION
Closes #533

## Summary
- make Gemini CLI write settings to `output_path_config` when configured
- make Zed write settings to `output_path_config` when configured
- add integration coverage for Gemini and Zed custom MCP config paths

## Verification
- `npx jest --runTestsByPath tests/integration/mcp-custom-config-path.test.ts --runInBand --coverage=false`
- `npm run format:check`
- `npm run lint`
- `npm run build`