### PR TITLE
fix(agents): respect backups for OpenCode and Crush

### DIFF
--- a/src/agents/CrushAgent.ts
+++ b/src/agents/CrushAgent.ts
@@ -1,6 +1,7 @@
 import { IAgent, IAgentConfig } from './IAgent';
 import * as fs from 'fs/promises';
 import * as path from 'path';
+import { backupFile } from '../core/FileSystemUtils';
 
 export class CrushAgent implements IAgent {
   getIdentifier(): string {
@@ -62,14 +63,24 @@ export class CrushAgent implements IAgent {
     projectRoot: string,
     rulerMcpJson: Record<string, unknown> | null,
     agentConfig?: IAgentConfig,
+    backup = true,
   ): Promise<void> {
     const outputPaths = this.getDefaultOutputPath(projectRoot);
-    const instructionsPath =
+    const instructionsPath = path.resolve(
+      projectRoot,
       agentConfig?.outputPath ??
-      agentConfig?.outputPathInstructions ??
-      outputPaths['instructions'];
-    const mcpPath = agentConfig?.outputPathConfig ?? outputPaths['mcp'];
+        agentConfig?.outputPathInstructions ??
+        outputPaths['instructions'],
+    );
+    const mcpPath = path.resolve(
+      projectRoot,
+      agentConfig?.outputPathConfig ?? outputPaths['mcp'],
+    );
 
+    await fs.mkdir(path.dirname(instructionsPath), { recursive: true });
+    if (backup) {
+      await backupFile(instructionsPath);
+    }
     await fs.writeFile(instructionsPath, concatenatedRules);
 
     // Always transform from mcpServers ({ mcpServers: ... }) to { mcp: ... } for Crush
@@ -110,6 +121,10 @@ export class CrushAgent implements IAgent {
     }
 
     if (Object.keys(finalMcpConfig.mcp).length > 0) {
+      await fs.mkdir(path.dirname(mcpPath), { recursive: true });
+      if (backup) {
+        await backupFile(mcpPath);
+      }
       await fs.writeFile(mcpPath, JSON.stringify(finalMcpConfig, null, 2));
     }
   }

--- a/src/agents/OpenCodeAgent.ts
+++ b/src/agents/OpenCodeAgent.ts
@@ -1,6 +1,7 @@
 import { IAgent, IAgentConfig } from './IAgent';
 import * as fs from 'fs/promises';
 import * as path from 'path';
+import { backupFile } from '../core/FileSystemUtils';
 
 export class OpenCodeAgent implements IAgent {
   getIdentifier(): string {
@@ -23,6 +24,7 @@ export class OpenCodeAgent implements IAgent {
     projectRoot: string,
     rulerMcpJson: Record<string, unknown> | null,
     agentConfig?: IAgentConfig,
+    backup = true,
   ): Promise<void> {
     const outputPaths = this.getDefaultOutputPath(projectRoot);
     const instructionsPath = path.resolve(
@@ -37,6 +39,9 @@ export class OpenCodeAgent implements IAgent {
     );
 
     await fs.mkdir(path.dirname(instructionsPath), { recursive: true });
+    if (backup) {
+      await backupFile(instructionsPath);
+    }
     await fs.writeFile(instructionsPath, concatenatedRules);
 
     if (!rulerMcpJson) {
@@ -75,6 +80,9 @@ export class OpenCodeAgent implements IAgent {
 
     // Always write the config file, even if MCP is empty
     await fs.mkdir(path.dirname(mcpPath), { recursive: true });
+    if (backup) {
+      await backupFile(mcpPath);
+    }
     await fs.writeFile(mcpPath, JSON.stringify(finalMcpConfig, null, 2));
   }
 

--- a/tests/integration/opencode-agent.test.ts
+++ b/tests/integration/opencode-agent.test.ts
@@ -94,4 +94,60 @@ timeout = 45
       timeout: 45,
     });
   });
+
+  it('should back up existing OpenCode instructions before overwriting', async () => {
+    const rulerDir = path.join(tmpDir, '.ruler');
+    await fs.mkdir(rulerDir, { recursive: true });
+    await fs.writeFile(path.join(rulerDir, 'AGENTS.md'), '# New Rules');
+
+    const instructionsPath = path.join(tmpDir, 'AGENTS.md');
+    await fs.writeFile(instructionsPath, 'Original OpenCode instructions');
+
+    await applyAllAgentConfigs(
+      tmpDir,
+      ['opencode'],
+      undefined,
+      true,
+      undefined,
+      false,
+      false,
+      false,
+      true,
+    );
+
+    await expect(fs.readFile(`${instructionsPath}.bak`, 'utf8')).resolves.toBe(
+      'Original OpenCode instructions',
+    );
+    await expect(fs.readFile(instructionsPath, 'utf8')).resolves.toContain(
+      '# New Rules',
+    );
+  });
+
+  it('should not back up existing OpenCode instructions when backup is disabled', async () => {
+    const rulerDir = path.join(tmpDir, '.ruler');
+    await fs.mkdir(rulerDir, { recursive: true });
+    await fs.writeFile(path.join(rulerDir, 'AGENTS.md'), '# New Rules');
+
+    const instructionsPath = path.join(tmpDir, 'AGENTS.md');
+    await fs.writeFile(instructionsPath, 'Original OpenCode instructions');
+
+    await applyAllAgentConfigs(
+      tmpDir,
+      ['opencode'],
+      undefined,
+      true,
+      undefined,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+    );
+
+    await expect(fs.access(`${instructionsPath}.bak`)).rejects.toThrow();
+    await expect(fs.readFile(instructionsPath, 'utf8')).resolves.toContain(
+      '# New Rules',
+    );
+  });
 });

--- a/tests/unit/agents/CrushAgent.test.ts
+++ b/tests/unit/agents/CrushAgent.test.ts
@@ -220,6 +220,50 @@ describe('CrushAgent', () => {
     });
   });
 
+  it('should back up existing generated files before overwriting', async () => {
+    const instructionsPath = path.join(projectRoot, 'CRUSH.md');
+    const mcpPath = path.join(projectRoot, '.crush.json');
+    await fs.writeFile(instructionsPath, 'Original Crush instructions');
+    await fs.writeFile(
+      mcpPath,
+      JSON.stringify({ mcp: { existing: { command: 'ls' } } }, null, 2),
+    );
+
+    await agent.applyRulerConfig('new rules', projectRoot, {
+      mcpServers: { next: { command: 'pwd' } },
+    });
+
+    await expect(fs.readFile(`${instructionsPath}.bak`, 'utf8')).resolves.toBe(
+      'Original Crush instructions',
+    );
+    await expect(
+      fs
+        .readFile(`${mcpPath}.bak`, 'utf8')
+        .then((content) => JSON.parse(content)),
+    ).resolves.toEqual({ mcp: { existing: { command: 'ls' } } });
+  });
+
+  it('should not create backups when backup is disabled', async () => {
+    const instructionsPath = path.join(projectRoot, 'CRUSH.md');
+    const mcpPath = path.join(projectRoot, '.crush.json');
+    await fs.writeFile(instructionsPath, 'Original Crush instructions');
+    await fs.writeFile(
+      mcpPath,
+      JSON.stringify({ mcp: { existing: { command: 'ls' } } }, null, 2),
+    );
+
+    await agent.applyRulerConfig(
+      'new rules',
+      projectRoot,
+      { mcpServers: { next: { command: 'pwd' } } },
+      undefined,
+      false,
+    );
+
+    await expect(fs.access(`${instructionsPath}.bak`)).rejects.toThrow();
+    await expect(fs.access(`${mcpPath}.bak`)).rejects.toThrow();
+  });
+
   describe('backup and revert functionality', () => {
     let tmpDir: string;
     let testAgent: CrushAgent;


### PR DESCRIPTION
Closes #540

## Summary
- add backup handling to OpenCode generated instruction and config writes
- add backup handling and directory creation to Crush generated instruction and config writes
- add regression coverage for backup creation and disabled backups

## Verification
- `npx jest --runTestsByPath tests/integration/opencode-agent.test.ts tests/unit/agents/CrushAgent.test.ts --runInBand --coverage=false`
- `npm run format:check`
- `npm run lint`
- `npm run build`