### PR TITLE
Respect --keep-backups during revert

### DIFF
--- a/src/core/revert-engine.ts
+++ b/src/core/revert-engine.ts
@@ -518,7 +518,7 @@ async function removeAdditionalAgentFiles(
  * @param agent The agent to revert
  * @param projectRoot Root directory of the project
  * @param agentConfig Agent-specific configuration
- * @param _keepBackups Retained for API compatibility; restored backups are consumed
+ * @param keepBackups Whether restored backup files should be preserved
  * @param verbose Whether to enable verbose logging
  * @param dryRun Whether to perform a dry run
  * @returns Promise resolving to revert statistics
@@ -527,7 +527,7 @@ export async function revertAgentConfiguration(
   agent: IAgent,
   projectRoot: string,
   agentConfig: IAgentConfig | undefined,
-  _keepBackups: boolean,
+  keepBackups: boolean,
   verbose: boolean,
   dryRun: boolean,
 ): Promise<RevertAgentResult> {
@@ -549,9 +549,15 @@ export async function revertAgentConfiguration(
     if (restored) {
       result.restored++;
 
-      const backupRemoved = await removeBackupFile(outputPath, verbose, dryRun);
-      if (backupRemoved) {
-        result.backupsRemoved++;
+      if (!keepBackups) {
+        const backupRemoved = await removeBackupFile(
+          outputPath,
+          verbose,
+          dryRun,
+        );
+        if (backupRemoved) {
+          result.backupsRemoved++;
+        }
       }
     } else {
       const removed = await removeGeneratedFile(
@@ -586,13 +592,15 @@ export async function revertAgentConfiguration(
       if (mcpRestored) {
         result.restored++;
 
-        const mcpBackupRemoved = await removeBackupFile(
-          mcpPath,
-          verbose,
-          dryRun,
-        );
-        if (mcpBackupRemoved) {
-          result.backupsRemoved++;
+        if (!keepBackups) {
+          const mcpBackupRemoved = await removeBackupFile(
+            mcpPath,
+            verbose,
+            dryRun,
+          );
+          if (mcpBackupRemoved) {
+            result.backupsRemoved++;
+          }
         }
       } else {
         const mcpRemoved = await removeGeneratedFile(

--- a/tests/integration/revert-cli.test.ts
+++ b/tests/integration/revert-cli.test.ts
@@ -81,7 +81,7 @@ describe('Revert CLI Integration', () => {
       expect(output).not.toContain('Reverting OpenAI Codex CLI');
     });
 
-    it('should remove consumed backup after --keep-backups restore', async () => {
+    it('should keep consumed backup after --keep-backups restore', async () => {
       const filePath = path.join(tmpDir, 'CLAUDE.md');
       const backupPath = `${filePath}.bak`;
 
@@ -95,7 +95,7 @@ describe('Revert CLI Integration', () => {
         },
       );
 
-      await expect(fs.access(backupPath)).rejects.toThrow();
+      await expect(fs.access(backupPath)).resolves.toBeUndefined();
     });
 
     it('should handle --verbose option', () => {

--- a/tests/unit/core/revert-engine.test.ts
+++ b/tests/unit/core/revert-engine.test.ts
@@ -170,7 +170,7 @@ describe('revert-engine', () => {
       );
     });
 
-    it('should remove consumed backups when keepBackups is true', async () => {
+    it('should keep consumed backups when keepBackups is true', async () => {
       const agent = new MockAgent('Claude Code', 'claude');
       const configPath = path.join(tmpDir, '.claude', 'config.json');
       const backupPath = `${configPath}.bak`;
@@ -191,14 +191,14 @@ describe('revert-engine', () => {
 
       expect(result.restored).toBe(1);
       expect(result.removed).toBe(0);
-      expect(result.backupsRemoved).toBe(1);
+      expect(result.backupsRemoved).toBe(0);
 
-      // A consumed backup must not remain stale after restore.
+      // keepBackups preserves the restored backup for inspection.
       const backupExists = await fs
         .access(backupPath)
         .then(() => true)
         .catch(() => false);
-      expect(backupExists).toBe(false);
+      expect(backupExists).toBe(true);
     });
 
     it('should handle dry run mode', async () => {

--- a/tests/unit/core/revert.test.ts
+++ b/tests/unit/core/revert.test.ts
@@ -215,7 +215,7 @@ describe('Revert Core Functions', () => {
       consoleErrorSpy.mockRestore();
     });
 
-    it('should remove consumed backup when keep-backups is true', async () => {
+    it('should keep consumed backup when keep-backups is true', async () => {
       const filePath = path.join(tmpDir, 'CLAUDE.md');
       const backupPath = `${filePath}.bak`;
 
@@ -231,7 +231,7 @@ describe('Revert Core Functions', () => {
         false,
       );
 
-      await expect(fs.access(backupPath)).rejects.toThrow();
+      await expect(fs.access(backupPath)).resolves.toBeUndefined();
 
       const restoredContent = await fs.readFile(filePath, 'utf8');
       expect(restoredContent).toBe('Original content');


### PR DESCRIPTION
Fixes #560.

## Summary
- Preserve restored backup files when `revert --keep-backups` is set
- Continue removing consumed backups when backups are not being kept
- Correct unit and CLI integration tests that asserted the old behaviour

## Verification
- `npm ci`
- `npx jest tests/integration/revert-cli.test.ts tests/unit/core/revert-engine.test.ts tests/unit/core/revert.test.ts --runInBand --coverage=false`
- `npm run check:package-lock`
- `npm run format`
- `npm run format:check`
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit --omit=dev --audit-level=moderate`
- `npm pack --dry-run`
