### PR TITLE
Use discovered project root when applying from subdirectories

### DIFF
--- a/src/core/FileSystemUtils.ts
+++ b/src/core/FileSystemUtils.ts
@@ -79,6 +79,15 @@ export async function findRulerDir(
   return null;
 }
 
+export function resolveProjectRootForRulerDir(
+  requestedProjectRoot: string,
+  rulerDir: string,
+): string {
+  return path.basename(rulerDir) === '.ruler'
+    ? path.dirname(rulerDir)
+    : requestedProjectRoot;
+}
+
 /**
  * Options for {@link readMarkdownFiles}.
  */

--- a/src/core/apply-engine.ts
+++ b/src/core/apply-engine.ts
@@ -34,6 +34,7 @@ export interface RulerConfiguration {
   config: LoadedConfig;
   concatenatedRules: string;
   rulerMcpJson: Record<string, unknown> | null;
+  projectRoot: string;
 }
 
 /**
@@ -139,6 +140,7 @@ async function createHierarchicalConfiguration(
     config,
     concatenatedRules,
     rulerMcpJson,
+    projectRoot: directoryRoot,
   };
 }
 
@@ -281,10 +283,14 @@ async function loadSingleConfiguration(
 
   // Warn about legacy mcp.json
   await warnAboutLegacyMcpJson(primaryDir);
+  const effectiveProjectRoot = FileSystemUtils.resolveProjectRootForRulerDir(
+    projectRoot,
+    primaryDir,
+  );
 
   // Load the ruler.toml configuration
   const config = await loadConfig({
-    projectRoot,
+    projectRoot: effectiveProjectRoot,
     configPath,
     checkGlobal: !localOnly,
   });
@@ -301,7 +307,7 @@ async function loadSingleConfiguration(
   // Load unified config to get merged MCP configuration
   const { loadUnifiedConfig } = await import('./UnifiedConfigLoader');
   const unifiedConfig = await loadUnifiedConfig({
-    projectRoot,
+    projectRoot: effectiveProjectRoot,
     configPath,
     checkGlobal: !localOnly,
   });
@@ -318,6 +324,7 @@ async function loadSingleConfiguration(
     config,
     concatenatedRules,
     rulerMcpJson,
+    projectRoot: effectiveProjectRoot,
   };
 }
 

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -112,6 +112,7 @@ export async function applyAllAgentConfigs(
   let selectedAgents: IAgent[];
   let generatedPaths: string[];
   let loadedConfig: LoadedConfig;
+  let outputProjectRoot = projectRoot;
 
   if (nested) {
     const hierarchicalConfigs = await loadNestedConfigurations(
@@ -228,6 +229,8 @@ export async function applyAllAgentConfigs(
       configPath,
       localOnly,
     );
+    const singleProjectRoot = singleConfig.projectRoot;
+    outputProjectRoot = singleProjectRoot;
 
     loadedConfig = singleConfig.config;
     singleConfig.config.cliAgents = includedAgents;
@@ -257,7 +260,7 @@ export async function applyAllAgentConfigs(
     if (skillsEnabledResolved) {
       const { propagateSkills } = await import('./core/SkillsProcessor');
       await propagateSkills(
-        projectRoot,
+        singleProjectRoot,
         selectedAgents,
         skillsEnabledResolved,
         verbose,
@@ -280,7 +283,7 @@ export async function applyAllAgentConfigs(
     {
       const { propagateSubagents } = await import('./core/SubagentsProcessor');
       await propagateSubagents(
-        projectRoot,
+        singleProjectRoot,
         selectedAgents,
         subagentsEnabledResolvedSingle,
         subagentsCleanupOrphanedSingle,
@@ -292,7 +295,7 @@ export async function applyAllAgentConfigs(
     generatedPaths = await processSingleConfiguration(
       selectedAgents,
       singleConfig,
-      projectRoot,
+      singleProjectRoot,
       verbose,
       dryRun,
       cliMcpEnabled,
@@ -311,7 +314,7 @@ export async function applyAllAgentConfigs(
     // Skills enabled by default or explicitly
     const { getSkillsGitignorePaths } = await import('./core/SkillsProcessor');
     const skillsPaths = await getSkillsGitignorePaths(
-      projectRoot,
+      outputProjectRoot,
       selectedAgents,
     );
     allGeneratedPaths = [...allGeneratedPaths, ...skillsPaths];
@@ -327,14 +330,14 @@ export async function applyAllAgentConfigs(
       './core/SubagentsProcessor'
     );
     const subagentPaths = await getSubagentsGitignorePaths(
-      projectRoot,
+      outputProjectRoot,
       selectedAgents,
     );
     allGeneratedPaths = [...allGeneratedPaths, ...subagentPaths];
   }
 
   await updateGitignore(
-    projectRoot,
+    outputProjectRoot,
     allGeneratedPaths,
     loadedConfig,
     cliGitignoreEnabled,

--- a/src/revert.ts
+++ b/src/revert.ts
@@ -35,18 +35,6 @@ export async function revertAllAgentConfigs(
   dryRun = false,
   localOnly = false,
 ): Promise<void> {
-  logVerbose(
-    `Loading configuration for revert from project root: ${projectRoot}`,
-    verbose,
-  );
-
-  const config = await loadConfig({
-    projectRoot,
-    cliAgents: includedAgents,
-    configPath,
-    checkGlobal: !localOnly,
-  });
-
   const rulerDir = await FileSystemUtils.findRulerDir(projectRoot, !localOnly);
   if (!rulerDir) {
     throw createRulerError(
@@ -54,6 +42,23 @@ export async function revertAllAgentConfigs(
       `Searched from: ${projectRoot}`,
     );
   }
+  const effectiveProjectRoot = FileSystemUtils.resolveProjectRootForRulerDir(
+    projectRoot,
+    rulerDir,
+  );
+
+  logVerbose(
+    `Loading configuration for revert from project root: ${effectiveProjectRoot}`,
+    verbose,
+  );
+
+  const config = await loadConfig({
+    projectRoot: effectiveProjectRoot,
+    cliAgents: includedAgents,
+    configPath,
+    checkGlobal: !localOnly,
+  });
+
   logVerbose(`Found .ruler directory at: ${rulerDir}`, verbose);
 
   // Normalize per-agent config keys to agent identifiers
@@ -132,7 +137,7 @@ export async function revertAllAgentConfigs(
     const agentConfig = config.agentConfigs[agent.getIdentifier()];
     const result = await revertAgentConfiguration(
       agent,
-      projectRoot,
+      effectiveProjectRoot,
       agentConfig,
       keepBackups,
       verbose,
@@ -147,7 +152,7 @@ export async function revertAllAgentConfigs(
     if (!isFullRevert) {
       totalDirectoriesRemoved += await cleanUpAgentDirectories(
         agent,
-        projectRoot,
+        effectiveProjectRoot,
         agentConfig,
         verbose,
         dryRun,
@@ -157,14 +162,14 @@ export async function revertAllAgentConfigs(
 
   // Clean up auxiliary files and directories only when reverting all agents.
   const cleanupResult = isFullRevert
-    ? await cleanUpAuxiliaryFiles(projectRoot, verbose, dryRun)
+    ? await cleanUpAuxiliaryFiles(effectiveProjectRoot, verbose, dryRun)
     : { additionalFilesRemoved: 0, directoriesRemoved: 0 };
   totalFilesRemoved += cleanupResult.additionalFilesRemoved;
   totalDirectoriesRemoved += cleanupResult.directoriesRemoved;
 
   // Clean managed ignore blocks if reverting all agents.
   const cleanedIgnoreFiles = isFullRevert
-    ? await cleanManagedIgnoreFiles(projectRoot, verbose, dryRun)
+    ? await cleanManagedIgnoreFiles(effectiveProjectRoot, verbose, dryRun)
     : [];
 
   // Display summary

--- a/tests/integration/root-agents-detection.test.ts
+++ b/tests/integration/root-agents-detection.test.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
+import { execFileSync } from 'child_process';
 import {
   setupTestProject,
   teardownTestProject,
@@ -27,7 +28,12 @@ describe('Root AGENTS.md detection', () => {
   afterEach(async () => {
     // Clean generated outputs between tests
     await fs.rm(path.join(projectRoot, 'AGENTS.md'), { force: true });
+    await fs.rm(path.join(projectRoot, 'AGENTS.md.bak'), { force: true });
     await fs.rm(path.join(projectRoot, '.github'), {
+      recursive: true,
+      force: true,
+    });
+    await fs.rm(path.join(projectRoot, 'subdir'), {
       recursive: true,
       force: true,
     });
@@ -70,5 +76,55 @@ describe('Root AGENTS.md detection', () => {
     expect(codexOutput).toContain('Extra inner file');
     // Should NOT include a Source section for root AGENTS.md
     expect(codexOutput).not.toMatch(/<!-- Source: AGENTS.md -->$/m);
+  });
+
+  it('writes generated files at the discovered project root when apply runs from a subdirectory', async () => {
+    const subdir = path.join(projectRoot, 'subdir');
+    await fs.mkdir(subdir);
+
+    execFileSync(
+      'node',
+      [
+        path.resolve('dist/cli/index.js'),
+        'apply',
+        '--agents',
+        'agentsmd',
+        '--no-backup',
+        '--no-gitignore',
+      ],
+      {
+        cwd: subdir,
+        stdio: 'pipe',
+      },
+    );
+
+    await expect(
+      fs.readFile(path.join(projectRoot, 'AGENTS.md'), 'utf8'),
+    ).resolves.toContain('Inner rules file');
+    await expect(fs.stat(path.join(subdir, 'AGENTS.md'))).rejects.toThrow();
+  });
+
+  it('reverts generated files at the discovered project root when revert runs from a subdirectory', async () => {
+    const subdir = path.join(projectRoot, 'subdir');
+    await fs.mkdir(subdir);
+
+    runRulerWithInheritedStdio(
+      'apply --agents agentsmd --no-backup --no-gitignore',
+      projectRoot,
+    );
+
+    execFileSync(
+      'node',
+      [path.resolve('dist/cli/index.js'), 'revert', '--agents', 'agentsmd'],
+      {
+        cwd: subdir,
+        stdio: 'pipe',
+      },
+    );
+
+    await expect(
+      fs.stat(path.join(projectRoot, 'AGENTS.md')),
+    ).rejects.toThrow();
+    await expect(fs.stat(path.join(subdir, 'AGENTS.md'))).rejects.toThrow();
   });
 });

--- a/tests/unit/core/apply-engine.test.ts
+++ b/tests/unit/core/apply-engine.test.ts
@@ -492,12 +492,14 @@ command = "sub-cmd"
       const configurations: HierarchicalRulerConfiguration[] = [
         {
           rulerDir: rootRulerDir,
+          projectRoot: tmpDir,
           config: { agentConfigs: { recording: {} } } as LoadedConfig,
           concatenatedRules: '# Root',
           rulerMcpJson: { mcpServers: { root: { command: 'root' } } },
         },
         {
           rulerDir: nestedRulerDir,
+          projectRoot: path.join(tmpDir, 'nested'),
           config: { agentConfigs: { recording: {} } } as LoadedConfig,
           concatenatedRules: '# Nested',
           rulerMcpJson: {

--- a/tests/unit/invalid-agent.test.ts
+++ b/tests/unit/invalid-agent.test.ts
@@ -45,15 +45,25 @@ jest.mock('fs', () => {
   };
 });
 
-jest.mock('../../src/core/FileSystemUtils', () => ({
-  findRulerDir: jest.fn().mockResolvedValue('/test/.ruler'),
-  readMarkdownFiles: jest.fn().mockResolvedValue([
-    {
-      path: '/test/.ruler/AGENTS.md',
-      content: '# Test Instructions',
-    },
-  ]),
-}));
+jest.mock('../../src/core/FileSystemUtils', () => {
+  const pathModule = jest.requireActual('path');
+  return {
+    findRulerDir: jest.fn().mockResolvedValue('/test/.ruler'),
+    resolveProjectRootForRulerDir: jest
+      .fn()
+      .mockImplementation((requestedProjectRoot, rulerDir) =>
+        pathModule.basename(rulerDir) === '.ruler'
+          ? pathModule.dirname(rulerDir)
+          : requestedProjectRoot,
+      ),
+    readMarkdownFiles: jest.fn().mockResolvedValue([
+      {
+        path: '/test/.ruler/AGENTS.md',
+        content: '# Test Instructions',
+      },
+    ]),
+  };
+});
 
 jest.mock('../../src/core/GitignoreUtils', () => ({
   updateGitignore: jest.fn().mockResolvedValue(undefined),


### PR DESCRIPTION
Fixes #558.

## Summary
- Resolve a local discovered `.ruler/` directory to its parent project root in single-directory apply
- Use the same effective root for skills, subagents, generated outputs, gitignore, MCP config, and revert
- Preserve XDG global config behaviour by only switching roots for directories actually named `.ruler`
- Add CLI regression coverage for running `apply` and `revert` from a subdirectory

## Verification
- `npm ci`
- `npx jest tests/integration/root-agents-detection.test.ts --runInBand --coverage=false`
- `npx jest tests/unit/invalid-agent.test.ts tests/integration/root-agents-detection.test.ts --runInBand --coverage=false`
- `npm run check:package-lock`
- `npm run format`
- `npm run format:check`
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit --omit=dev --audit-level=moderate`
- `npm pack --dry-run`
