### PR TITLE
Refuse symlinked generated output paths

### DIFF
--- a/src/core/FileSystemUtils.ts
+++ b/src/core/FileSystemUtils.ts
@@ -32,6 +32,23 @@ function shouldSkipNestedDiscoveryDir(dirName: string): boolean {
   );
 }
 
+async function isSymbolicLink(filePath: string): Promise<boolean> {
+  try {
+    return (await fs.lstat(filePath)).isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
+async function assertNotSymbolicLink(
+  filePath: string,
+  action: string,
+): Promise<void> {
+  if (await isSymbolicLink(filePath)) {
+    throw new Error(`${action}: ${filePath}`);
+  }
+}
+
 /**
  * Searches upwards from startPath to find a directory named .ruler.
  * If not found locally and checkGlobal is true, checks for global config at XDG_CONFIG_HOME/ruler.
@@ -223,7 +240,19 @@ export async function readMarkdownFiles(
     const repoRoot = path.dirname(rulerDir); // .ruler parent
     const rootAgentsPath = path.join(repoRoot, 'AGENTS.md');
     if (path.resolve(rootAgentsPath) !== path.resolve(topLevelAgents)) {
-      const stat = await fs.stat(rootAgentsPath);
+      const rootAgentsStat = await fs.lstat(rootAgentsPath);
+      if (rootAgentsStat.isSymbolicLink()) {
+        const [realRepoRoot, realRootAgentsPath] = await Promise.all([
+          fs.realpath(repoRoot),
+          fs.realpath(rootAgentsPath),
+        ]);
+        if (!isPathInsideOrEqual(realRepoRoot, realRootAgentsPath)) {
+          return ordered;
+        }
+      }
+      const stat = rootAgentsStat.isSymbolicLink()
+        ? await fs.stat(rootAgentsPath)
+        : rootAgentsStat;
       if (stat.isFile()) {
         const content = await fs.readFile(rootAgentsPath, 'utf8');
 
@@ -265,6 +294,10 @@ export async function writeGeneratedFile(
   content: string,
 ): Promise<void> {
   await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await assertNotSymbolicLink(
+    filePath,
+    'Refusing to write generated file through symlink',
+  );
   await fs.writeFile(filePath, content, 'utf8');
 }
 
@@ -274,6 +307,7 @@ export async function writeGeneratedFile(
  */
 export async function backupFile(filePath: string): Promise<void> {
   const backupPath = `${filePath}.bak`;
+  await assertNotSymbolicLink(filePath, 'Refusing to back up symlinked file');
 
   try {
     await fs.access(backupPath);

--- a/tests/integration/symlink-output-safety.test.ts
+++ b/tests/integration/symlink-output-safety.test.ts
@@ -1,0 +1,54 @@
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+import { setupTestProject, teardownTestProject } from '../harness';
+
+describe('Symlink output safety', () => {
+  let projectRoot: string;
+  let outsideFile: string;
+
+  beforeEach(async () => {
+    const project = await setupTestProject({
+      '.ruler/AGENTS.md': 'Ruler rules',
+    });
+    projectRoot = project.projectRoot;
+    outsideFile = path.join(
+      projectRoot,
+      '..',
+      `${path.basename(projectRoot)}-outside.md`,
+    );
+    await fs.writeFile(outsideFile, 'outside original');
+  });
+
+  afterEach(async () => {
+    await teardownTestProject(projectRoot);
+    await fs.rm(outsideFile, { force: true });
+  });
+
+  it('does not overwrite a root AGENTS.md symlink target outside the project', async () => {
+    await fs.symlink(outsideFile, path.join(projectRoot, 'AGENTS.md'));
+
+    expect(() =>
+      execFileSync(
+        'node',
+        [
+          path.resolve('dist/cli/index.js'),
+          'apply',
+          '--project-root',
+          projectRoot,
+          '--agents',
+          'agentsmd',
+          '--no-backup',
+          '--no-gitignore',
+        ],
+        {
+          stdio: 'pipe',
+        },
+      ),
+    ).toThrow();
+
+    await expect(fs.readFile(outsideFile, 'utf8')).resolves.toBe(
+      'outside original',
+    );
+  });
+});

--- a/tests/unit/core/FileSystemUtils.test.ts
+++ b/tests/unit/core/FileSystemUtils.test.ts
@@ -5,6 +5,7 @@ import {
   backupFile,
   findRulerDir,
   readMarkdownFiles,
+  writeGeneratedFile,
 } from '../../../src/core/FileSystemUtils';
 
 describe('FileSystemUtils', () => {
@@ -47,6 +48,32 @@ describe('FileSystemUtils', () => {
       await expect(fs.readFile(`${filePath}.bak`, 'utf8')).resolves.toBe(
         'original',
       );
+    });
+
+    it('refuses to back up a symlinked output file', async () => {
+      const outsidePath = path.join(tmpDir, 'backup-outside.txt');
+      const linkPath = path.join(tmpDir, 'backup-link.txt');
+      await fs.writeFile(outsidePath, 'outside');
+      await fs.symlink(outsidePath, linkPath);
+
+      await expect(backupFile(linkPath)).rejects.toThrow(
+        'Refusing to back up symlinked file',
+      );
+      await expect(fs.stat(`${linkPath}.bak`)).rejects.toThrow();
+    });
+  });
+
+  describe('writeGeneratedFile', () => {
+    it('refuses to write through a symlinked output file', async () => {
+      const outsidePath = path.join(tmpDir, 'write-outside.txt');
+      const linkPath = path.join(tmpDir, 'write-link.txt');
+      await fs.writeFile(outsidePath, 'outside');
+      await fs.symlink(outsidePath, linkPath);
+
+      await expect(writeGeneratedFile(linkPath, 'generated')).rejects.toThrow(
+        'Refusing to write generated file through symlink',
+      );
+      await expect(fs.readFile(outsidePath, 'utf8')).resolves.toBe('outside');
     });
   });
 
@@ -143,6 +170,25 @@ describe('FileSystemUtils', () => {
       await fs.symlink('/nonexistent/path/file.md', linkPath);
       const files = await readMarkdownFiles(rulerDir);
       expect(files.map((f) => f.path)).not.toContain(linkPath);
+    });
+
+    it('skips root AGENTS.md when it is a symlink outside the repository', async () => {
+      const projectDir = path.join(tmpDir, 'root-agents-outside-link');
+      const rulerDir = path.join(projectDir, '.ruler');
+      const outsidePath = path.join(tmpDir, 'external-root-agents.md');
+      const rootAgentsPath = path.join(projectDir, 'AGENTS.md');
+      await fs.mkdir(rulerDir, { recursive: true });
+      await fs.writeFile(path.join(rulerDir, 'AGENTS.md'), 'ruler content');
+      await fs.writeFile(outsidePath, 'external root content');
+      await fs.symlink(outsidePath, rootAgentsPath);
+
+      const files = await readMarkdownFiles(rulerDir);
+
+      expect(files.map((f) => f.path)).not.toContain(rootAgentsPath);
+      expect(files.map((f) => f.content)).not.toContain(
+        'external root content',
+      );
+      expect(files.map((f) => f.content)).toContain('ruler content');
     });
   });
 });


### PR DESCRIPTION
Fixes #559.

## Summary
- refuse to back up or write generated output files when the target path is a symlink
- skip root AGENTS.md fallback content when that file is a symlink outside the project
- add unit and integration coverage for symlinked output safety

## Verification
- npm ci
- npx jest tests/unit/core/FileSystemUtils.test.ts tests/integration/symlink-output-safety.test.ts --runInBand --coverage=false
- npm run check:package-lock
- npm run format
- npm run format:check
- npm run lint
- npm test
- npm run build
- npm audit --omit=dev --audit-level=moderate
- npm pack --dry-run