### PR TITLE
fix: harden generated writes against symlinks

### DIFF
--- a/src/agents/CrushAgent.ts
+++ b/src/agents/CrushAgent.ts
@@ -1,7 +1,7 @@
 import { IAgent, IAgentConfig } from './IAgent';
 import * as fs from 'fs/promises';
 import * as path from 'path';
-import { backupFile } from '../core/FileSystemUtils';
+import { backupFile, writeGeneratedFile } from '../core/FileSystemUtils';
 
 export class CrushAgent implements IAgent {
   getIdentifier(): string {
@@ -81,7 +81,7 @@ export class CrushAgent implements IAgent {
     if (backup) {
       await backupFile(instructionsPath);
     }
-    await fs.writeFile(instructionsPath, concatenatedRules);
+    await writeGeneratedFile(instructionsPath, concatenatedRules);
 
     // Always transform from mcpServers ({ mcpServers: ... }) to { mcp: ... } for Crush
     let finalMcpConfig: { mcp: Record<string, unknown> } = { mcp: {} };
@@ -125,7 +125,10 @@ export class CrushAgent implements IAgent {
       if (backup) {
         await backupFile(mcpPath);
       }
-      await fs.writeFile(mcpPath, JSON.stringify(finalMcpConfig, null, 2));
+      await writeGeneratedFile(
+        mcpPath,
+        JSON.stringify(finalMcpConfig, null, 2),
+      );
     }
   }
 

--- a/src/agents/GeminiCliAgent.ts
+++ b/src/agents/GeminiCliAgent.ts
@@ -2,6 +2,7 @@ import { IAgentConfig } from './IAgent';
 import * as path from 'path';
 import { promises as fs } from 'fs';
 import { AgentsMdAgent } from './AgentsMdAgent';
+import { writeGeneratedFile } from '../core/FileSystemUtils';
 
 export class GeminiCliAgent extends AgentsMdAgent {
   getIdentifier(): string {
@@ -101,8 +102,7 @@ export class GeminiCliAgent extends AgentsMdAgent {
       }
     }
 
-    await fs.mkdir(path.dirname(settingsPath), { recursive: true });
-    await fs.writeFile(settingsPath, JSON.stringify(updated, null, 2));
+    await writeGeneratedFile(settingsPath, JSON.stringify(updated, null, 2));
   }
 
   // Ensure MCP merging uses the correct key for Gemini (.gemini/settings.json)

--- a/src/agents/OpenCodeAgent.ts
+++ b/src/agents/OpenCodeAgent.ts
@@ -1,7 +1,7 @@
 import { IAgent, IAgentConfig } from './IAgent';
 import * as fs from 'fs/promises';
 import * as path from 'path';
-import { backupFile } from '../core/FileSystemUtils';
+import { backupFile, writeGeneratedFile } from '../core/FileSystemUtils';
 
 export class OpenCodeAgent implements IAgent {
   getIdentifier(): string {
@@ -42,7 +42,7 @@ export class OpenCodeAgent implements IAgent {
     if (backup) {
       await backupFile(instructionsPath);
     }
-    await fs.writeFile(instructionsPath, concatenatedRules);
+    await writeGeneratedFile(instructionsPath, concatenatedRules);
 
     if (!rulerMcpJson) {
       return;
@@ -83,7 +83,7 @@ export class OpenCodeAgent implements IAgent {
     if (backup) {
       await backupFile(mcpPath);
     }
-    await fs.writeFile(mcpPath, JSON.stringify(finalMcpConfig, null, 2));
+    await writeGeneratedFile(mcpPath, JSON.stringify(finalMcpConfig, null, 2));
   }
 
   supportsMcpStdio(): boolean {

--- a/src/agents/QwenCodeAgent.ts
+++ b/src/agents/QwenCodeAgent.ts
@@ -2,6 +2,7 @@ import { IAgentConfig } from './IAgent';
 import * as path from 'path';
 import { promises as fs } from 'fs';
 import { AgentsMdAgent } from './AgentsMdAgent';
+import { writeGeneratedFile } from '../core/FileSystemUtils';
 
 export class QwenCodeAgent extends AgentsMdAgent {
   getIdentifier(): string {
@@ -54,8 +55,7 @@ export class QwenCodeAgent extends AgentsMdAgent {
       contextFileName: this.getContextFileName(projectRoot, agentConfig),
     } as Record<string, unknown>;
 
-    await fs.mkdir(path.dirname(settingsPath), { recursive: true });
-    await fs.writeFile(settingsPath, JSON.stringify(updated, null, 2));
+    await writeGeneratedFile(settingsPath, JSON.stringify(updated, null, 2));
   }
 
   // Ensure MCP merging uses the correct key for Qwen Code (.qwen/settings.json)

--- a/src/agents/ZedAgent.ts
+++ b/src/agents/ZedAgent.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 import { promises as fs } from 'fs';
 import { AgentsMdAgent } from './AgentsMdAgent';
 import { IAgentConfig } from './IAgent';
+import { writeGeneratedFile } from '../core/FileSystemUtils';
 
 /**
  * Zed editor agent adapter.
@@ -110,8 +111,7 @@ export class ZedAgent extends AgentsMdAgent {
       }
 
       // Write updated settings
-      await fs.mkdir(path.dirname(zedSettingsPath), { recursive: true });
-      await fs.writeFile(
+      await writeGeneratedFile(
         zedSettingsPath,
         JSON.stringify(mergedSettings, null, 2),
       );

--- a/src/core/FileSystemUtils.ts
+++ b/src/core/FileSystemUtils.ts
@@ -49,6 +49,35 @@ async function assertNotSymbolicLink(
   }
 }
 
+async function assertContainingDirectoryInsideRoot(
+  filePath: string,
+  rootPath: string,
+  action: string,
+): Promise<void> {
+  const realRoot = await fs.realpath(rootPath);
+  let current = path.dirname(path.resolve(filePath));
+
+  while (true) {
+    try {
+      const realCurrent = await fs.realpath(current);
+      if (!isPathInsideOrEqual(realRoot, realCurrent)) {
+        throw new Error(`${action}: ${filePath}`);
+      }
+      return;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw error;
+      }
+    }
+
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return;
+    }
+    current = parent;
+  }
+}
+
 /**
  * Searches upwards from startPath to find a directory named .ruler.
  * If not found locally and checkGlobal is true, checks for global config at XDG_CONFIG_HOME/ruler.
@@ -292,12 +321,27 @@ export async function readMarkdownFiles(
 export async function writeGeneratedFile(
   filePath: string,
   content: string,
+  containmentRoot?: string,
 ): Promise<void> {
+  if (containmentRoot) {
+    await assertContainingDirectoryInsideRoot(
+      filePath,
+      containmentRoot,
+      'Refusing to write generated file through symlinked directory',
+    );
+  }
   await fs.mkdir(path.dirname(filePath), { recursive: true });
   await assertNotSymbolicLink(
     filePath,
     'Refusing to write generated file through symlink',
   );
+  if (containmentRoot) {
+    await assertContainingDirectoryInsideRoot(
+      filePath,
+      containmentRoot,
+      'Refusing to write generated file through symlinked directory',
+    );
+  }
   await fs.writeFile(filePath, content, 'utf8');
 }
 

--- a/src/core/GitignoreUtils.ts
+++ b/src/core/GitignoreUtils.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from 'fs';
 import * as path from 'path';
+import { writeGeneratedFile } from './FileSystemUtils';
 
 const RULER_START_MARKER = '# START Ruler Generated Files';
 const RULER_END_MARKER = '# END Ruler Generated Files';
@@ -74,8 +75,7 @@ export async function updateGitignore(
   const newContent = updateGitignoreContent(existingContent, allRulerPaths);
 
   // Write the updated content
-  await fs.mkdir(path.dirname(gitignorePath), { recursive: true });
-  await fs.writeFile(gitignorePath, newContent);
+  await writeGeneratedFile(gitignorePath, newContent);
 }
 
 /**

--- a/src/core/apply-engine.ts
+++ b/src/core/apply-engine.ts
@@ -751,6 +751,7 @@ async function applyMcpConfiguration(
     dest,
     agentConfig,
     config,
+    projectRoot,
     cliMcpStrategy,
     dryRun,
     verbose,
@@ -926,6 +927,7 @@ async function applyStandardMcpConfiguration(
   dest: string,
   agentConfig: IAgentConfig | undefined,
   config: LoadedConfig,
+  projectRoot: string,
   cliMcpStrategy: McpStrategy | undefined,
   dryRun: boolean,
   verbose: boolean,
@@ -1053,9 +1055,10 @@ async function applyStandardMcpConfiguration(
         await FileSystemUtils.writeGeneratedFile(
           dest,
           stringify(toWrite as Record<string, unknown>),
+          projectRoot,
         );
       } else {
-        await writeNativeMcp(dest, toWrite);
+        await writeNativeMcp(dest, toWrite, projectRoot);
       }
     } else {
       logVerbose(

--- a/src/mcp/propagateOpenCodeMcp.ts
+++ b/src/mcp/propagateOpenCodeMcp.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs/promises';
-import { ensureDirExists } from '../core/FileSystemUtils';
+import { ensureDirExists, writeGeneratedFile } from '../core/FileSystemUtils';
 import * as path from 'path';
 import { McpStrategy } from '../types';
 
@@ -153,5 +153,5 @@ export async function propagateMcpToOpenCode(
     const { backupFile } = await import('../core/FileSystemUtils');
     await backupFile(openCodeConfigPath);
   }
-  await fs.writeFile(openCodeConfigPath, finalContent);
+  await writeGeneratedFile(openCodeConfigPath, finalContent);
 }

--- a/src/mcp/propagateOpenHandsMcp.ts
+++ b/src/mcp/propagateOpenHandsMcp.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs/promises';
 import { parse as parseTOML, stringify } from '@iarna/toml';
-import { ensureDirExists } from '../core/FileSystemUtils';
+import { ensureDirExists, writeGeneratedFile } from '../core/FileSystemUtils';
 import * as path from 'path';
 import { McpStrategy } from '../types';
 
@@ -234,5 +234,5 @@ export async function propagateMcpToOpenHands(
     const { backupFile } = await import('../core/FileSystemUtils');
     await backupFile(openHandsConfigPath);
   }
-  await fs.writeFile(openHandsConfigPath, finalContent);
+  await writeGeneratedFile(openHandsConfigPath, finalContent);
 }

--- a/src/paths/mcp.ts
+++ b/src/paths/mcp.ts
@@ -133,7 +133,8 @@ export async function readNativeMcpToml(
 export async function writeNativeMcp(
   filePath: string,
   data: unknown,
+  containmentRoot?: string,
 ): Promise<void> {
   const text = JSON.stringify(data, null, 2) + '\n';
-  await writeGeneratedFile(filePath, text);
+  await writeGeneratedFile(filePath, text, containmentRoot);
 }

--- a/src/paths/mcp.ts
+++ b/src/paths/mcp.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 import { promises as fs } from 'fs';
+import { writeGeneratedFile } from '../core/FileSystemUtils';
 
 /** Determine the native MCP config path for a given agent. */
 export async function getNativeMcpPath(
@@ -133,7 +134,6 @@ export async function writeNativeMcp(
   filePath: string,
   data: unknown,
 ): Promise<void> {
-  await fs.mkdir(path.dirname(filePath), { recursive: true });
   const text = JSON.stringify(data, null, 2) + '\n';
-  await fs.writeFile(filePath, text, 'utf8');
+  await writeGeneratedFile(filePath, text);
 }

--- a/src/vscode/settings.ts
+++ b/src/vscode/settings.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'fs';
 import * as path from 'path';
 import { McpStrategy } from '../types';
+import { writeGeneratedFile } from '../core/FileSystemUtils';
 
 /**
  * VSCode settings.json structure for Augment MCP configuration
@@ -47,8 +48,7 @@ export async function writeVSCodeSettings(
   settingsPath: string,
   settings: VSCodeSettings,
 ): Promise<void> {
-  await fs.mkdir(path.dirname(settingsPath), { recursive: true });
-  await fs.writeFile(settingsPath, JSON.stringify(settings, null, 4));
+  await writeGeneratedFile(settingsPath, JSON.stringify(settings, null, 4));
 }
 
 /**

--- a/tests/integration/symlink-output-safety.test.ts
+++ b/tests/integration/symlink-output-safety.test.ts
@@ -91,4 +91,50 @@ describe('Symlink output safety', () => {
       'outside original',
     );
   });
+
+  it('does not write through an MCP config directory symlink outside the project', async () => {
+    const outsideDir = path.join(
+      projectRoot,
+      '..',
+      `${path.basename(projectRoot)}-outside-dir`,
+    );
+    await fs.mkdir(outsideDir);
+    await fs.writeFile(
+      path.join(projectRoot, '.ruler', 'ruler.toml'),
+      [
+        '[mcp_servers.filesystem]',
+        'command = "node"',
+        'args = ["server.js"]',
+        '',
+      ].join('\n'),
+    );
+    await fs.symlink(outsideDir, path.join(projectRoot, '.cursor'));
+
+    try {
+      expect(() =>
+        execFileSync(
+          'node',
+          [
+            path.resolve('dist/cli/index.js'),
+            'apply',
+            '--project-root',
+            projectRoot,
+            '--agents',
+            'cursor',
+            '--no-backup',
+            '--no-gitignore',
+          ],
+          {
+            stdio: 'pipe',
+          },
+        ),
+      ).toThrow();
+
+      await expect(
+        fs.access(path.join(outsideDir, 'mcp.json')),
+      ).rejects.toThrow();
+    } finally {
+      await fs.rm(outsideDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/tests/integration/symlink-output-safety.test.ts
+++ b/tests/integration/symlink-output-safety.test.ts
@@ -51,4 +51,44 @@ describe('Symlink output safety', () => {
       'outside original',
     );
   });
+
+  it('does not overwrite an MCP config symlink target outside the project', async () => {
+    await fs.writeFile(
+      path.join(projectRoot, '.ruler', 'ruler.toml'),
+      [
+        '[mcp_servers.filesystem]',
+        'command = "node"',
+        'args = ["server.js"]',
+        '',
+      ].join('\n'),
+    );
+    await fs.mkdir(path.join(projectRoot, '.cursor'), { recursive: true });
+    await fs.symlink(
+      outsideFile,
+      path.join(projectRoot, '.cursor', 'mcp.json'),
+    );
+
+    expect(() =>
+      execFileSync(
+        'node',
+        [
+          path.resolve('dist/cli/index.js'),
+          'apply',
+          '--project-root',
+          projectRoot,
+          '--agents',
+          'cursor',
+          '--no-backup',
+          '--no-gitignore',
+        ],
+        {
+          stdio: 'pipe',
+        },
+      ),
+    ).toThrow();
+
+    await expect(fs.readFile(outsideFile, 'utf8')).resolves.toBe(
+      'outside original',
+    );
+  });
 });

--- a/tests/unit/agents/OpenCodeAgent.test.ts
+++ b/tests/unit/agents/OpenCodeAgent.test.ts
@@ -1,11 +1,16 @@
 import { OpenCodeAgent } from '../../../src/agents/OpenCodeAgent';
 import * as fs from 'fs/promises';
-import * as path from 'path';
+import { writeGeneratedFile } from '../../../src/core/FileSystemUtils';
 
 // Mock fs module
 jest.mock('fs/promises');
+jest.mock('../../../src/core/FileSystemUtils', () => ({
+  backupFile: jest.fn(),
+  writeGeneratedFile: jest.fn(),
+}));
 
 const mockedFs = jest.mocked(fs);
+const mockedWriteGeneratedFile = jest.mocked(writeGeneratedFile);
 
 describe('OpenCodeAgent', () => {
   let agent: OpenCodeAgent;
@@ -46,8 +51,11 @@ describe('OpenCodeAgent', () => {
 
     await agent.applyRulerConfig('rules', '/root', null);
 
-    expect(mockedFs.writeFile).toHaveBeenCalledWith('/root/AGENTS.md', 'rules');
-    expect(mockedFs.writeFile).toHaveBeenCalledTimes(1);
+    expect(mockedWriteGeneratedFile).toHaveBeenCalledWith(
+      '/root/AGENTS.md',
+      'rules',
+    );
+    expect(mockedWriteGeneratedFile).toHaveBeenCalledTimes(1);
   });
 
   it('should create opencode.json with MCP servers when MCP config provided', async () => {
@@ -64,8 +72,11 @@ describe('OpenCodeAgent', () => {
 
     await agent.applyRulerConfig('rules', '/root', mcpConfig);
 
-    expect(mockedFs.writeFile).toHaveBeenCalledWith('/root/AGENTS.md', 'rules');
-    expect(mockedFs.writeFile).toHaveBeenCalledWith(
+    expect(mockedWriteGeneratedFile).toHaveBeenCalledWith(
+      '/root/AGENTS.md',
+      'rules',
+    );
+    expect(mockedWriteGeneratedFile).toHaveBeenCalledWith(
       '/root/opencode.json',
       JSON.stringify(
         {
@@ -100,8 +111,11 @@ describe('OpenCodeAgent', () => {
       outputPathConfig: 'custom-opencode.json',
     });
 
-    expect(mockedFs.writeFile).toHaveBeenCalledWith('/root/CUSTOM.md', 'rules');
-    expect(mockedFs.writeFile).toHaveBeenCalledWith(
+    expect(mockedWriteGeneratedFile).toHaveBeenCalledWith(
+      '/root/CUSTOM.md',
+      'rules',
+    );
+    expect(mockedWriteGeneratedFile).toHaveBeenCalledWith(
       '/root/custom-opencode.json',
       JSON.stringify(
         {
@@ -127,6 +141,9 @@ describe('OpenCodeAgent', () => {
       outputPathInstructions: 'IGNORED.md',
     });
 
-    expect(mockedFs.writeFile).toHaveBeenCalledWith('/root/CUSTOM.md', 'rules');
+    expect(mockedWriteGeneratedFile).toHaveBeenCalledWith(
+      '/root/CUSTOM.md',
+      'rules',
+    );
   });
 });


### PR DESCRIPTION
Fixes #570

## Summary
- routes generated MCP/settings/gitignore writes through the symlink-safe generated-file writer
- updates OpenCode/Crush custom writers to use the same protected path
- adds MCP symlink regression coverage for `--no-backup`

## Verification
- `npm run check:package-lock`
- `npm run format:check`
- `npm run lint`
- `npx jest tests/integration/symlink-output-safety.test.ts --runInBand --coverage=false`
- `npm test`
- `npm run build`
- `npm audit --omit=dev --audit-level=moderate`
- `npm pack --dry-run`