### PR TITLE
ci: validate release target before install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,6 @@ jobs:
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org/'
-      - run: npm ci
-      - run: npm run check:package-lock
       - name: Validate release target
         env:
           EVENT_NAME: ${{ github.event_name }}
@@ -75,6 +73,8 @@ jobs:
             echo "::error::${PACKAGE_NAME}@${VERSION} is already published to npm."
             exit 1
           fi
+      - run: npm ci
+      - run: npm run check:package-lock
       - run: npm run format:check
       - run: npm run lint
       - run: npm test

--- a/tests/unit/workflows/release-workflow.test.ts
+++ b/tests/unit/workflows/release-workflow.test.ts
@@ -1,0 +1,21 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('release workflow', () => {
+  it('validates the release target before running npm lifecycle scripts', () => {
+    const workflowPath = path.join(
+      process.cwd(),
+      '.github',
+      'workflows',
+      'release.yml',
+    );
+    const workflow = fs.readFileSync(workflowPath, 'utf8');
+
+    const validateIndex = workflow.indexOf('- name: Validate release target');
+    const npmCiIndex = workflow.indexOf('- run: npm ci');
+
+    expect(validateIndex).toBeGreaterThanOrEqual(0);
+    expect(npmCiIndex).toBeGreaterThanOrEqual(0);
+    expect(validateIndex).toBeLessThan(npmCiIndex);
+  });
+});


### PR DESCRIPTION
Fixes #568

## Summary
- move release target validation before `npm ci` and package-controlled lifecycle scripts
- add a regression test for the release workflow step order

## Verification
- npx jest tests/unit/workflows/release-workflow.test.ts --runInBand --coverage=false
- npm run check:package-lock
- npm run format:check
- npm run lint
- npm test
- npm run build
- npm audit --omit=dev --audit-level=moderate
- npm pack --dry-run