### PR TITLE
fix: avoid unchanged MCP backup churn

### DIFF
--- a/src/mcp/propagateOpenCodeMcp.ts
+++ b/src/mcp/propagateOpenCodeMcp.ts
@@ -142,14 +142,16 @@ export async function propagateMcpToOpenCode(
             ...transformedConfig.mcp,
           },
   };
+  const finalContent = JSON.stringify(finalConfig, null, 2) + '\n';
+
+  if (existingContent === finalContent) {
+    return;
+  }
 
   await ensureDirExists(path.dirname(openCodeConfigPath));
   if (backup) {
     const { backupFile } = await import('../core/FileSystemUtils');
     await backupFile(openCodeConfigPath);
   }
-  await fs.writeFile(
-    openCodeConfigPath,
-    JSON.stringify(finalConfig, null, 2) + '\n',
-  );
+  await fs.writeFile(openCodeConfigPath, finalContent);
 }

--- a/src/mcp/propagateOpenHandsMcp.ts
+++ b/src/mcp/propagateOpenHandsMcp.ts
@@ -223,11 +223,16 @@ export async function propagateMcpToOpenHands(
   config.mcp.shttp_servers = normalizeRemoteServerArray(
     Array.from(existingShttpServers.values()),
   );
+  const finalContent = stringify(config);
+
+  if (tomlContent === finalContent) {
+    return;
+  }
 
   await ensureDirExists(path.dirname(openHandsConfigPath));
   if (backup) {
     const { backupFile } = await import('../core/FileSystemUtils');
     await backupFile(openHandsConfigPath);
   }
-  await fs.writeFile(openHandsConfigPath, stringify(config));
+  await fs.writeFile(openHandsConfigPath, finalContent);
 }

--- a/tests/unit/mcp/OpenCodeMcp.test.ts
+++ b/tests/unit/mcp/OpenCodeMcp.test.ts
@@ -246,5 +246,28 @@ describe('OpenCode MCP Integration', () => {
       expect(result.$schema).toBe('https://opencode.ai/config.json');
       expect(result.mcp).toEqual({});
     });
+
+    it('does not rewrite or back up unchanged generated config', async () => {
+      const openCodePath = path.join(tmpDir, 'opencode.json');
+      const rulerMcp = {
+        mcpServers: {
+          repo: {
+            command: 'node',
+            args: ['server.js'],
+          },
+        },
+      };
+
+      await propagateMcpToOpenCode(rulerMcp, openCodePath);
+      const statBefore = await fs.stat(openCodePath);
+      const contentBefore = await fs.readFile(openCodePath, 'utf8');
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      await propagateMcpToOpenCode(rulerMcp, openCodePath);
+
+      await expect(fs.access(`${openCodePath}.bak`)).rejects.toThrow();
+      expect(await fs.readFile(openCodePath, 'utf8')).toBe(contentBefore);
+      expect((await fs.stat(openCodePath)).mtimeMs).toBe(statBefore.mtimeMs);
+    });
   });
 });

--- a/tests/unit/mcp/OpenHandsMcp.test.ts
+++ b/tests/unit/mcp/OpenHandsMcp.test.ts
@@ -409,4 +409,26 @@ url = "https://api.example.com/mcp"
       api_key: 'new-token',
     });
   });
+
+  it('does not rewrite or back up unchanged generated config', async () => {
+    const rulerMcp = {
+      mcpServers: {
+        fs: { command: 'npx', args: ['mcp-fs'] },
+        api: { url: 'https://api.example.com/mcp' },
+      },
+    };
+
+    await propagateMcpToOpenHands(rulerMcp, openHandsConfigPath);
+    const statBefore = await fs.stat(openHandsConfigPath);
+    const contentBefore = await fs.readFile(openHandsConfigPath, 'utf8');
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    await propagateMcpToOpenHands(rulerMcp, openHandsConfigPath);
+
+    await expect(fs.access(`${openHandsConfigPath}.bak`)).rejects.toThrow();
+    expect(await fs.readFile(openHandsConfigPath, 'utf8')).toBe(contentBefore);
+    expect((await fs.stat(openHandsConfigPath)).mtimeMs).toBe(
+      statBefore.mtimeMs,
+    );
+  });
 });


### PR DESCRIPTION
Fixes #569

## Summary
- skip OpenCode MCP backup/write when the serialised config is unchanged
- skip OpenHands MCP backup/write when the serialised config is unchanged
- add idempotency regressions for both propagators

## Verification
- npx jest tests/unit/mcp/OpenCodeMcp.test.ts tests/unit/mcp/OpenHandsMcp.test.ts --runInBand --coverage=false
- npm run check:package-lock
- npm run format:check
- npm run lint
- npm test
- npm run build
- npm audit --omit=dev --audit-level=moderate
- npm pack --dry-run