### PR TITLE
fix: normalize agent-scoped MCP servers

### DIFF
--- a/src/core/ConfigLoader.ts
+++ b/src/core/ConfigLoader.ts
@@ -181,9 +181,7 @@ function normalizeAgentMcpServer(
     delete server.command;
     delete server.args;
     delete server.env;
-    if (typeof server.type !== 'string') {
-      server.type = 'remote';
-    }
+    server.type = 'remote';
   }
 
   return server;

--- a/src/core/ConfigLoader.ts
+++ b/src/core/ConfigLoader.ts
@@ -163,11 +163,30 @@ function parseAgentMcpServers(
     sectionObj.mcp_servers as Record<string, unknown>,
   )) {
     if (def && typeof def === 'object' && !Array.isArray(def)) {
-      servers[name] = { ...(def as Record<string, unknown>) };
+      servers[name] = normalizeAgentMcpServer(def as Record<string, unknown>);
     }
   }
 
   return Object.keys(servers).length > 0 ? servers : undefined;
+}
+
+function normalizeAgentMcpServer(
+  def: Record<string, unknown>,
+): Record<string, unknown> {
+  const server = { ...def };
+  const hasCommand = typeof server.command === 'string';
+  const hasUrl = typeof server.url === 'string';
+
+  if (hasCommand && hasUrl) {
+    delete server.command;
+    delete server.args;
+    delete server.env;
+    if (typeof server.type !== 'string') {
+      server.type = 'remote';
+    }
+  }
+
+  return server;
 }
 
 /**

--- a/tests/agent-mcp-servers.test.ts
+++ b/tests/agent-mcp-servers.test.ts
@@ -52,6 +52,7 @@ oauth = { clientId = "CLAUDE_ID", callbackPort = 3118 }
   it('normalizes mixed agent-specific server definitions as remote servers', async () => {
     const toml = `
 [agents.cursor.mcp_servers.search]
+type = "stdio"
 command = "node"
 args = ["local-server.js"]
 env = { LOCAL_ONLY = "1" }

--- a/tests/agent-mcp-servers.test.ts
+++ b/tests/agent-mcp-servers.test.ts
@@ -48,4 +48,32 @@ oauth = { clientId = "CLAUDE_ID", callbackPort = 3118 }
       oauth: { clientId: 'CLAUDE_ID', callbackPort: 3118 },
     });
   });
+
+  it('normalizes mixed agent-specific server definitions as remote servers', async () => {
+    const toml = `
+[agents.cursor.mcp_servers.search]
+command = "node"
+args = ["local-server.js"]
+env = { LOCAL_ONLY = "1" }
+url = "https://search.example.com/mcp"
+headers = { Authorization = "Bearer remote-token" }
+`;
+
+    testProject = await setupTestProject({
+      '.ruler/AGENTS.md': '# Test instructions',
+      '.ruler/ruler.toml': toml,
+    });
+
+    const { projectRoot } = testProject;
+    runRuler('apply --agents cursor', projectRoot);
+
+    const cursorMcp = JSON.parse(
+      await fs.readFile(path.join(projectRoot, '.cursor', 'mcp.json'), 'utf8'),
+    );
+    expect(cursorMcp.mcpServers.search).toEqual({
+      type: 'remote',
+      url: 'https://search.example.com/mcp',
+      headers: { Authorization: 'Bearer remote-token' },
+    });
+  });
 });


### PR DESCRIPTION
Fixes #565

## Summary
- normalise agent-scoped MCP entries that contain both `command` and `url` as remote servers
- remove stdio-only fields from conflicted agent-scoped entries before capability filtering
- add an integration regression for mixed agent-scoped Cursor MCP config

## Verification
- npx jest tests/agent-mcp-servers.test.ts --runInBand --coverage=false
- npm run check:package-lock
- npm run format:check
- npm run lint
- npm test
- npm run build
- npm audit --omit=dev --audit-level=moderate
- npm pack --dry-run