### PR TITLE
fix: update js-yaml dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^2.2.5",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^4.2.0",
         "yargs": "^18.0.0",
         "zod": "^4.1.12"
       },
@@ -5841,9 +5841,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   },
   "dependencies": {
     "@iarna/toml": "^2.2.5",
-    "js-yaml": "^4.1.1",
+    "js-yaml": "^4.2.0",
     "yargs": "^18.0.0",
     "zod": "^4.1.12"
   }


### PR DESCRIPTION
Fixes #578

## Summary

- Updates the direct production `js-yaml` dependency to `^4.2.0`.
- Refreshes `package-lock.json` so the CI production audit no longer resolves vulnerable `js-yaml@4.1.1`.

## Verification

- `npm run check:package-lock`
- `npm run format:check`
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit --omit=dev --audit-level=moderate`
- `npm pack --dry-run`