### PR TITLE
fix: suppress missing global config noise

### DIFF
--- a/src/core/FileSystemUtils.ts
+++ b/src/core/FileSystemUtils.ts
@@ -125,6 +125,9 @@ export async function findRulerDir(
         return globalConfigDir;
       }
     } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        return null;
+      }
       console.error(
         `[ruler] Error checking global config directory ${globalConfigDir}:`,
         err,

--- a/tests/unit/core/FileSystemUtils.test.ts
+++ b/tests/unit/core/FileSystemUtils.test.ts
@@ -34,6 +34,32 @@ describe('FileSystemUtils', () => {
       const found = await findRulerDir(someDir, false); // Don't check global config
       expect(found).toBeNull();
     });
+
+    it('does not log an error when optional global config is absent', async () => {
+      const originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+      const xdgConfigHome = path.join(tmpDir, 'missing-global-config');
+      process.env.XDG_CONFIG_HOME = xdgConfigHome;
+      const consoleErrorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      try {
+        const projectDir = path.join(tmpDir, 'project-without-ruler');
+        await fs.mkdir(projectDir, { recursive: true });
+
+        const found = await findRulerDir(projectDir, true);
+
+        expect(found).toBeNull();
+        expect(consoleErrorSpy).not.toHaveBeenCalled();
+      } finally {
+        consoleErrorSpy.mockRestore();
+        if (originalXdgConfigHome === undefined) {
+          delete process.env.XDG_CONFIG_HOME;
+        } else {
+          process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
+        }
+      }
+    });
   });
 
   describe('backupFile', () => {


### PR DESCRIPTION
Fixes #580

## Summary

- Treats a missing optional `$XDG_CONFIG_HOME/ruler` directory as a quiet no-config result.
- Keeps unexpected global config lookup errors visible.
- Adds regression coverage for no local config and no global config.

## Verification

- `npx jest tests/unit/core/FileSystemUtils.test.ts --runInBand --coverage=false`
- `npm run check:package-lock`
- `npm run format:check`
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit --omit=dev --audit-level=moderate`
- `npm pack --dry-run`