### PR TITLE
fix: reject blank agent selectors

### DIFF
--- a/src/core/ConfigLoader.ts
+++ b/src/core/ConfigLoader.ts
@@ -557,8 +557,44 @@ function validateConfig(
       `File: ${configFile}, Errors: ${validationResult.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join(', ')}`,
     );
   }
+  validateAgentSelectors(raw, configFile);
 }
 
 function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+function validateAgentSelectors(
+  raw: Record<string, unknown>,
+  configFile: string,
+): void {
+  if (Array.isArray(raw.default_agents)) {
+    const hasBlankDefaultAgent = raw.default_agents.some(
+      (agent) => typeof agent === 'string' && agent.trim().length === 0,
+    );
+    if (hasBlankDefaultAgent) {
+      throw createRulerError(
+        'Invalid configuration file format',
+        `File: ${configFile}, default_agents contains an empty agent selector`,
+      );
+    }
+  }
+
+  if (
+    !raw.agents ||
+    typeof raw.agents !== 'object' ||
+    Array.isArray(raw.agents)
+  ) {
+    return;
+  }
+
+  for (const key of Object.keys(raw.agents)) {
+    if (SUBAGENT_RESERVED_KEYS.has(key)) continue;
+    if (key.trim().length === 0) {
+      throw createRulerError(
+        'Invalid configuration file format',
+        `File: ${configFile}, agent configuration key must not be empty`,
+      );
+    }
+  }
 }

--- a/tests/unit/core/ConfigLoader.test.ts
+++ b/tests/unit/core/ConfigLoader.test.ts
@@ -116,6 +116,37 @@ describe('ConfigLoader', () => {
     expect(config.defaultAgents).toEqual(['A', 'B']);
   });
 
+  it.each(['""', '"   "'])(
+    'rejects blank default_agents selector %s',
+    async (selector) => {
+      await fs.writeFile(
+        path.join(rulerDir, 'ruler.toml'),
+        `default_agents = [${selector}]`,
+      );
+
+      await expect(loadConfig({ projectRoot: tmpDir })).rejects.toThrow(
+        /default_agents.*empty/i,
+      );
+    },
+  );
+
+  it.each(['""', '"   "'])(
+    'rejects blank agent configuration key %s',
+    async (selector) => {
+      await fs.writeFile(
+        path.join(rulerDir, 'ruler.toml'),
+        `
+        [agents.${selector}]
+        enabled = false
+        `,
+      );
+
+      await expect(loadConfig({ projectRoot: tmpDir })).rejects.toThrow(
+        /agent configuration key.*empty/i,
+      );
+    },
+  );
+
   it('loads implicit config from the nearest ancestor .ruler directory', async () => {
     const childDir = path.join(tmpDir, 'packages', 'app');
     await fs.mkdir(childDir, { recursive: true });


### PR DESCRIPTION
Fixes #581

## Summary

- Rejects empty and whitespace-only `default_agents` entries during TOML config loading.
- Rejects empty and whitespace-only `[agents.*]` table keys before agent config mapping.
- Adds regression tests for both selector paths.

## Verification

- `npx jest tests/unit/core/ConfigLoader.test.ts --runInBand --coverage=false`
- `npm run check:package-lock`
- `npm run format:check`
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit --omit=dev --audit-level=moderate`
- `npm pack --dry-run`