### PR TITLE
Fix Aider MCP output

### DIFF
--- a/src/agents/AiderAgent.ts
+++ b/src/agents/AiderAgent.ts
@@ -83,11 +83,12 @@ export class AiderAgent implements IAgent {
     return {
       instructions: path.join(projectRoot, 'AGENTS.md'),
       config: path.join(projectRoot, '.aider.conf.yml'),
+      mcp: path.join(projectRoot, '.mcp.json'),
     };
   }
 
   getMcpServerKey(): string {
-    return this.agentsMdAgent.getMcpServerKey();
+    return 'mcpServers';
   }
 
   supportsMcpStdio(): boolean {

--- a/src/core/apply-engine.ts
+++ b/src/core/apply-engine.ts
@@ -975,7 +975,10 @@ async function applyStandardMcpConfiguration(
   } else {
     // Transform MCP config for agent-specific compatibility
     let mcpToMerge = filteredMcpJson;
-    if (agent.getIdentifier() === 'claude') {
+    if (
+      agent.getIdentifier() === 'claude' ||
+      agent.getIdentifier() === 'aider'
+    ) {
       mcpToMerge = transformMcpForClaude(filteredMcpJson);
     } else if (agent.getIdentifier() === 'kilocode') {
       mcpToMerge = transformMcpForKiloCode(filteredMcpJson);

--- a/tests/mcp-empty-server-key-fix.test.ts
+++ b/tests/mcp-empty-server-key-fix.test.ts
@@ -75,6 +75,25 @@ describe('mcp-empty-server-key-fix', () => {
     ]);
   });
 
+  it('writes Aider native MCP configuration with the mcpServers key', async () => {
+    const { projectRoot } = testProject;
+
+    runRulerWithInheritedStdio('apply --agents aider', projectRoot);
+
+    const aiderResultText = await fs.readFile(
+      path.join(projectRoot, '.mcp.json'),
+      'utf8',
+    );
+    const aiderResult = JSON.parse(aiderResultText);
+
+    expect(aiderResult.mcpServers).toBeDefined();
+    expect(aiderResult['']).toBeUndefined();
+    expect(aiderResult.mcpServers.ruler_server).toEqual({
+      type: 'http',
+      url: 'http://ruler.com',
+    });
+  });
+
   it('should not create empty string key when applying to multiple agents including ones with empty getMcpServerKey', async () => {
     const { projectRoot } = testProject;
 


### PR DESCRIPTION
Fixes #594.

## Summary
- add Aider's native `.mcp.json` output path so generated-path tracking includes it
- make Aider use the `mcpServers` native key instead of the empty AGENTS.md key
- apply the existing `.mcp.json` remote transport normalisation for Aider so it does not undo Claude-compatible shared-file output
- add a focused regression test for Aider-only MCP propagation

## Verification
- `npx jest tests/mcp-empty-server-key-fix.test.ts --runInBand` (failed before fix with missing `.mcp.json`)
- `npx jest tests/mcp-empty-server-key-fix.test.ts tests/claude-http-type.test.ts --runInBand`
- `npm run format && npm run check:package-lock && npm run lint && npm test && npm run build && npm audit --omit=dev --audit-level=moderate && npm pack --dry-run`