### PR TITLE
Deduplicate paths during revert

### DIFF
--- a/src/core/revert-engine.ts
+++ b/src/core/revert-engine.ts
@@ -594,13 +594,21 @@ export async function revertAgentConfiguration(
   };
 
   const outputPaths = getAgentOutputPaths(agent, projectRoot, agentConfig);
+  const processedPaths = new Set<string>();
 
   logVerbose(
     `Agent ${agent.getName()} output paths: ${outputPaths.join(', ')}`,
     verbose,
   );
 
-  for (const outputPath of outputPaths) {
+  const processPath = async (outputPath: string): Promise<void> => {
+    const resolvedPath = path.resolve(projectRoot, outputPath);
+    if (processedPaths.has(resolvedPath)) {
+      logVerbose(`Skipping already processed path: ${outputPath}`, verbose);
+      return;
+    }
+    processedPaths.add(resolvedPath);
+
     const restored = await restoreFromBackup(
       outputPath,
       verbose,
@@ -632,6 +640,10 @@ export async function revertAgentConfiguration(
         result.removed++;
       }
     }
+  };
+
+  for (const outputPath of outputPaths) {
+    await processPath(outputPath);
   }
 
   // Handle MCP files
@@ -650,37 +662,7 @@ export async function revertAgentConfiguration(
         verbose,
       );
     } else {
-      const mcpRestored = await restoreFromBackup(
-        mcpPath,
-        verbose,
-        dryRun,
-        projectRoot,
-      );
-      if (mcpRestored) {
-        result.restored++;
-
-        if (!keepBackups) {
-          const mcpBackupRemoved = await removeBackupFile(
-            mcpPath,
-            verbose,
-            dryRun,
-            projectRoot,
-          );
-          if (mcpBackupRemoved) {
-            result.backupsRemoved++;
-          }
-        }
-      } else {
-        const mcpRemoved = await removeGeneratedFile(
-          mcpPath,
-          verbose,
-          dryRun,
-          projectRoot,
-        );
-        if (mcpRemoved) {
-          result.removed++;
-        }
-      }
+      await processPath(mcpPath);
     }
   }
 

--- a/tests/unit/core/revert-engine.test.ts
+++ b/tests/unit/core/revert-engine.test.ts
@@ -50,7 +50,7 @@ class MockAgent implements IAgent {
     // Mock implementation
   }
 
-  getDefaultOutputPath(projectRoot: string): string {
+  getDefaultOutputPath(projectRoot: string): string | Record<string, string> {
     return `${projectRoot}/.${this.identifier}/config.json`;
   }
 
@@ -66,6 +66,19 @@ class MockOpenHandsAgent extends MockAgent {
 
   getDefaultOutputPath(projectRoot: string): string {
     return path.join(projectRoot, '.openhands', 'microagents', 'repo.md');
+  }
+}
+
+class MockCodexAgent extends MockAgent {
+  constructor() {
+    super('OpenAI Codex CLI', 'codex');
+  }
+
+  getDefaultOutputPath(projectRoot: string): Record<string, string> {
+    return {
+      instructions: path.join(projectRoot, 'AGENTS.md'),
+      config: path.join(projectRoot, '.codex', 'config.toml'),
+    };
   }
 }
 
@@ -331,6 +344,34 @@ describe('revert-engine', () => {
       expect(result.backupsRemoved).toBe(1);
       await expect(fs.readFile(configPath, 'utf8')).resolves.toBe(
         '[core]\nworkspace_base = "/tmp/project"\n',
+      );
+      await expect(fs.access(backupPath)).rejects.toThrow();
+    });
+
+    it('should process overlapping output and MCP paths only once', async () => {
+      const agent = new MockCodexAgent();
+      const configPath = path.join(tmpDir, '.codex', 'config.toml');
+      const backupPath = `${configPath}.bak`;
+
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.writeFile(configPath, '[mcp_servers.generated]\n');
+      await fs.writeFile(backupPath, '[model]\nname = "user-model"\n');
+      await writeRulerGitignore(tmpDir, ['.codex/config.toml']);
+
+      const result = await revertAgentConfiguration(
+        agent,
+        tmpDir,
+        undefined,
+        false,
+        false,
+        false,
+      );
+
+      expect(result.restored).toBe(1);
+      expect(result.removed).toBe(0);
+      expect(result.backupsRemoved).toBe(1);
+      await expect(fs.readFile(configPath, 'utf8')).resolves.toBe(
+        '[model]\nname = "user-model"\n',
       );
       await expect(fs.access(backupPath)).rejects.toThrow();
     });


### PR DESCRIPTION
Fixes #596.

## Summary
- process each resolved generated/native path at most once per agent revert
- share the existing restore/remove logic between normal output paths and MCP paths
- add a regression test for Codex-shaped overlapping output and MCP paths, where a restored backup was previously deleted in the same revert

## Verification
- `npx jest tests/unit/core/revert-engine.test.ts --runInBand` (failed before fix with `removed: 1` for the restored path)
- `npx jest tests/unit/core/revert-engine.test.ts --runInBand`
- `npm run format && npm run check:package-lock && npm run lint && npm test && npm run build && npm audit --omit=dev --audit-level=moderate && npm pack --dry-run`