### PR TITLE
Preserve invalid Mistral Vibe config

### DIFF
--- a/src/agents/MistralVibeAgent.ts
+++ b/src/agents/MistralVibeAgent.ts
@@ -3,7 +3,7 @@ import { promises as fs } from 'fs';
 import { parse as parseTOML, stringify } from '@iarna/toml';
 import { IAgent, IAgentConfig } from './IAgent';
 import { AgentsMdAgent } from './AgentsMdAgent';
-import { writeGeneratedFile } from '../core/FileSystemUtils';
+import { backupFile, writeGeneratedFile } from '../core/FileSystemUtils';
 import { DEFAULT_RULES_FILENAME } from '../constants';
 
 /**
@@ -145,11 +145,20 @@ export class MistralVibeAgent implements IAgent {
 
       // Read existing TOML config if it exists
       let existingConfig: VibeConfig = {};
+      let configExists = false;
       try {
         const existingContent = await fs.readFile(configPath, 'utf8');
+        configExists = true;
         existingConfig = parseTOML(existingContent) as VibeConfig;
-      } catch {
-        // File doesn't exist or can't be parsed, use empty config
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+          // Missing config starts from an empty config.
+          existingConfig = {};
+        } else {
+          throw new Error(
+            `Invalid Mistral config at ${configPath}: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
       }
 
       // Create the updated config
@@ -176,6 +185,9 @@ export class MistralVibeAgent implements IAgent {
       // Convert to TOML and write
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const tomlContent = stringify(updatedConfig as any);
+      if (configExists && backup) {
+        await backupFile(configPath, projectRoot);
+      }
       await writeGeneratedFile(configPath, tomlContent, projectRoot);
     }
   }

--- a/tests/unit/agents/MistralVibeAgent.test.ts
+++ b/tests/unit/agents/MistralVibeAgent.test.ts
@@ -268,6 +268,64 @@ args = ["-y", "existing-mcp"]
       expect(parsed.mcp_servers).toHaveLength(2);
     });
 
+    it('throws without overwriting invalid existing TOML config', async () => {
+      const configPath = path.join(tmpDir, '.vibe', 'config.toml');
+      const invalidConfig = '[mcp_servers';
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.writeFile(configPath, invalidConfig);
+
+      const mcpJson = {
+        mcpServers: {
+          new_server: {
+            command: 'npx',
+            args: ['-y', 'new-mcp'],
+          },
+        },
+      };
+
+      await expect(
+        agent.applyRulerConfig('rules', tmpDir, mcpJson, {
+          mcp: { enabled: true, strategy: 'merge' },
+        }),
+      ).rejects.toThrow(`Invalid Mistral config at ${configPath}`);
+
+      await expect(fs.readFile(configPath, 'utf8')).resolves.toBe(
+        invalidConfig,
+      );
+      await expect(fs.access(`${configPath}.bak`)).rejects.toThrow();
+    });
+
+    it('backs up valid existing TOML config before writing changes', async () => {
+      const configPath = path.join(tmpDir, '.vibe', 'config.toml');
+      const existingConfig = `
+system_prompt_id = "custom_prompt"
+
+[[mcp_servers]]
+name = "existing_server"
+transport = "stdio"
+command = "npx"
+`;
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.writeFile(configPath, existingConfig);
+
+      const mcpJson = {
+        mcpServers: {
+          new_server: {
+            command: 'npx',
+            args: ['-y', 'new-mcp'],
+          },
+        },
+      };
+
+      await agent.applyRulerConfig('rules', tmpDir, mcpJson, {
+        mcp: { enabled: true, strategy: 'merge' },
+      });
+
+      await expect(fs.readFile(`${configPath}.bak`, 'utf8')).resolves.toBe(
+        existingConfig,
+      );
+    });
+
     it('uses custom config path when provided', async () => {
       const customPath = path.join(tmpDir, 'custom', 'vibe.toml');
       await fs.mkdir(path.dirname(customPath), { recursive: true });


### PR DESCRIPTION
Fixes #598.

## Summary
- treat only missing `.vibe/config.toml` as an empty Mistral config
- throw a clear error when an existing Mistral TOML config is invalid, leaving it unchanged
- back up valid existing Mistral config before writing merged MCP settings when backups are enabled
- add regression tests for invalid TOML preservation and backup creation

## Verification
- `npx jest tests/unit/agents/MistralVibeAgent.test.ts --runInBand` (failed before fix on invalid TOML preservation and backup creation)
- `npx jest tests/unit/agents/MistralVibeAgent.test.ts --runInBand`
- `npm run format && npm run check:package-lock && npm run lint && npm test && npm run build && npm audit --omit=dev --audit-level=moderate && npm pack --dry-run`