### PR TITLE
Preserve malformed gitignore marker content

### DIFF
--- a/src/core/GitignoreUtils.ts
+++ b/src/core/GitignoreUtils.ts
@@ -5,6 +5,11 @@ import { writeGeneratedFile } from './FileSystemUtils';
 const RULER_START_MARKER = '# START Ruler Generated Files';
 const RULER_END_MARKER = '# END Ruler Generated Files';
 
+interface RulerBlockRange {
+  start: number;
+  end: number;
+}
+
 /**
  * Updates an ignore file in the project root with paths in a managed Ruler block.
  * Creates the file if it doesn't exist, and creates or updates the Ruler-managed block.
@@ -118,25 +123,47 @@ export async function resolveIgnoreFilePath(
  */
 function getExistingPathsExcludingRulerBlock(content: string): string[] {
   const lines = content.split('\n');
+  const rulerBlocks = findCompleteRulerBlocks(lines);
   const paths: string[] = [];
-  let inRulerBlock = false;
 
-  for (const line of lines) {
+  for (const [index, line] of lines.entries()) {
+    if (
+      rulerBlocks.some((block) => index >= block.start && index <= block.end)
+    ) {
+      continue;
+    }
+
     const trimmed = line.trim();
-    if (trimmed === RULER_START_MARKER) {
-      inRulerBlock = true;
-      continue;
-    }
-    if (trimmed === RULER_END_MARKER) {
-      inRulerBlock = false;
-      continue;
-    }
-    if (!inRulerBlock && trimmed && !trimmed.startsWith('#')) {
+    if (trimmed && !trimmed.startsWith('#')) {
       paths.push(trimmed);
     }
   }
 
   return paths;
+}
+
+function findCompleteRulerBlocks(lines: string[]): RulerBlockRange[] {
+  const ranges: RulerBlockRange[] = [];
+
+  for (let index = 0; index < lines.length; index++) {
+    if (lines[index].trim() !== RULER_START_MARKER) {
+      continue;
+    }
+
+    for (let endIndex = index + 1; endIndex < lines.length; endIndex++) {
+      const trimmed = lines[endIndex].trim();
+      if (trimmed === RULER_START_MARKER) {
+        break;
+      }
+      if (trimmed === RULER_END_MARKER) {
+        ranges.push({ start: index, end: endIndex });
+        index = endIndex;
+        break;
+      }
+    }
+  }
+
+  return ranges;
 }
 
 /**
@@ -147,35 +174,23 @@ function updateGitignoreContent(
   rulerPaths: string[],
 ): string {
   const lines = existingContent.split('\n');
+  const firstRulerBlock = findCompleteRulerBlocks(lines)[0];
   const newLines: string[] = [];
-  let inFirstRulerBlock = false;
-  let hasRulerBlock = false;
-  let processedFirstBlock = false;
 
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (trimmed === RULER_START_MARKER && !processedFirstBlock) {
-      inFirstRulerBlock = true;
-      hasRulerBlock = true;
-      newLines.push(line);
-      // Add the new Ruler paths
+  for (let index = 0; index < lines.length; index++) {
+    if (firstRulerBlock && index === firstRulerBlock.start) {
+      newLines.push(lines[index]);
       rulerPaths.forEach((p) => newLines.push(p));
+      newLines.push(lines[firstRulerBlock.end]);
+      index = firstRulerBlock.end;
       continue;
     }
-    if (trimmed === RULER_END_MARKER && inFirstRulerBlock) {
-      inFirstRulerBlock = false;
-      processedFirstBlock = true;
-      newLines.push(line);
-      continue;
-    }
-    if (!inFirstRulerBlock) {
-      newLines.push(line);
-    }
-    // Skip lines that are in the first Ruler block (they get replaced)
+
+    newLines.push(lines[index]);
   }
 
   // If no Ruler block exists, add one at the end
-  if (!hasRulerBlock) {
+  if (!firstRulerBlock) {
     // Add blank line if content exists and doesn't end with blank line
     if (existingContent.trim() && !existingContent.endsWith('\n\n')) {
       newLines.push('');

--- a/tests/unit/core/GitignoreUtils.test.ts
+++ b/tests/unit/core/GitignoreUtils.test.ts
@@ -212,5 +212,24 @@ duplicate-block.md
       // Should still contain the duplicate block
       expect(content).toContain('duplicate-block.md');
     });
+
+    it('preserves entries after an unterminated Ruler start marker', async () => {
+      const paths = ['CLAUDE.md'];
+      const gitignorePath = path.join(tmpDir, '.gitignore');
+      const initialContent = `node_modules/
+# START Ruler Generated Files
+*.log
+dist/
+`;
+      await fs.writeFile(gitignorePath, initialContent);
+
+      await updateGitignore(tmpDir, paths);
+
+      const content = await fs.readFile(gitignorePath, 'utf8');
+      expect(content).toContain('# START Ruler Generated Files\n*.log\ndist/');
+      expect(content).toContain('/CLAUDE.md');
+      expect(content).toContain('# END Ruler Generated Files');
+      expect(content.match(/# START Ruler Generated Files/g)).toHaveLength(2);
+    });
   });
 });


### PR DESCRIPTION
Fixes #600.

## Summary
- detect only complete Ruler start/end marker pairs as managed `.gitignore` blocks
- preserve unterminated marker content instead of treating the rest of the file as generated
- append a new well-formed Ruler block when no complete managed block exists
- add a regression test for preserving user patterns after an unterminated start marker

## Verification
- `npx jest tests/unit/core/GitignoreUtils.test.ts --runInBand` (failed before fix by dropping user patterns after the marker)
- `npx jest tests/unit/core/GitignoreUtils.test.ts --runInBand`
- `npm run format && npm run check:package-lock && npm run lint && npm test && npm run build && npm audit --omit=dev --audit-level=moderate && npm pack --dry-run`