### PR TITLE
Prevent prerelease releases from publishing npm latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,10 +33,16 @@ jobs:
           REF_TYPE: ${{ github.ref_type }}
           RELEASE_TAG_FROM_EVENT: ${{ github.event.release.tag_name }}
           RELEASE_TAG_FROM_INPUT: ${{ inputs.release_tag }}
+          RELEASE_PRERELEASE: ${{ github.event.release.prerelease }}
         run: |
           PACKAGE_NAME="$(node -p "require('./package.json').name")"
           VERSION="$(node -p "require('./package.json').version")"
           EXPECTED_TAG="v${VERSION}"
+
+          if [ "${EVENT_NAME}" = "release" ] && [ "${RELEASE_PRERELEASE}" = "true" ]; then
+            echo "::error::GitHub prereleases must not be published to npm latest."
+            exit 1
+          fi
 
           if [ "${EVENT_NAME}" = "release" ]; then
             RELEASE_TAG="${RELEASE_TAG_FROM_EVENT}"

--- a/tests/unit/workflows/release-workflow.test.ts
+++ b/tests/unit/workflows/release-workflow.test.ts
@@ -18,4 +18,27 @@ describe('release workflow', () => {
     expect(npmCiIndex).toBeGreaterThanOrEqual(0);
     expect(validateIndex).toBeLessThan(npmCiIndex);
   });
+
+  it('fails GitHub prereleases before publishing to npm latest', () => {
+    const workflowPath = path.join(
+      process.cwd(),
+      '.github',
+      'workflows',
+      'release.yml',
+    );
+    const workflow = fs.readFileSync(workflowPath, 'utf8');
+
+    const validateIndex = workflow.indexOf('- name: Validate release target');
+    const publishIndex = workflow.indexOf('npm publish --access public');
+
+    expect(workflow).toContain(
+      'RELEASE_PRERELEASE: ${{ github.event.release.prerelease }}',
+    );
+    expect(workflow).toContain(
+      'GitHub prereleases must not be published to npm latest.',
+    );
+    expect(validateIndex).toBeGreaterThanOrEqual(0);
+    expect(publishIndex).toBeGreaterThanOrEqual(0);
+    expect(validateIndex).toBeLessThan(publishIndex);
+  });
 });


### PR DESCRIPTION
Closes #602

## Summary
- fail release-triggered publishes when the GitHub release is marked as a prerelease
- cover the release workflow guard with a regression test

## Verification
- npm run format && npm run check:package-lock && npm run lint && npm test && npm run build && npm audit --omit=dev --audit-level=moderate && npm pack --dry-run