### PR TITLE
Harden Ruler ignore block cleanup

### DIFF
--- a/src/core/GitignoreUtils.ts
+++ b/src/core/GitignoreUtils.ts
@@ -5,9 +5,14 @@ import { writeGeneratedFile } from './FileSystemUtils';
 const RULER_START_MARKER = '# START Ruler Generated Files';
 const RULER_END_MARKER = '# END Ruler Generated Files';
 
-interface RulerBlockRange {
+export interface RulerBlockRange {
   start: number;
   end: number;
+}
+
+export interface RemoveRulerBlocksResult {
+  content: string;
+  removed: boolean;
 }
 
 /**
@@ -142,7 +147,7 @@ function getExistingPathsExcludingRulerBlock(content: string): string[] {
   return paths;
 }
 
-function findCompleteRulerBlocks(lines: string[]): RulerBlockRange[] {
+export function findCompleteRulerBlocks(lines: string[]): RulerBlockRange[] {
   const ranges: RulerBlockRange[] = [];
 
   for (let index = 0; index < lines.length; index++) {
@@ -166,6 +171,34 @@ function findCompleteRulerBlocks(lines: string[]): RulerBlockRange[] {
   return ranges;
 }
 
+export function removeCompleteRulerBlocks(
+  content: string,
+): RemoveRulerBlocksResult {
+  const lines = content.split('\n');
+  const rulerBlocks = findCompleteRulerBlocks(lines);
+
+  if (rulerBlocks.length === 0) {
+    return { content, removed: false };
+  }
+
+  const retainedLines: string[] = [];
+
+  for (let index = 0; index < lines.length; index++) {
+    const block = rulerBlocks.find((range) => range.start === index);
+    if (block) {
+      index = block.end;
+      continue;
+    }
+
+    retainedLines.push(lines[index]);
+  }
+
+  return {
+    content: retainedLines.join('\n').replace(/\n{3,}/g, '\n\n'),
+    removed: true,
+  };
+}
+
 /**
  * Updates the .gitignore content by replacing or adding the Ruler block.
  */
@@ -174,15 +207,23 @@ function updateGitignoreContent(
   rulerPaths: string[],
 ): string {
   const lines = existingContent.split('\n');
-  const firstRulerBlock = findCompleteRulerBlocks(lines)[0];
+  const rulerBlocks = findCompleteRulerBlocks(lines);
   const newLines: string[] = [];
+  let replacedFirstBlock = false;
 
   for (let index = 0; index < lines.length; index++) {
-    if (firstRulerBlock && index === firstRulerBlock.start) {
-      newLines.push(lines[index]);
+    const block = rulerBlocks.find((range) => range.start === index);
+    if (block && !replacedFirstBlock) {
+      newLines.push(lines[block.start]);
       rulerPaths.forEach((p) => newLines.push(p));
-      newLines.push(lines[firstRulerBlock.end]);
-      index = firstRulerBlock.end;
+      newLines.push(lines[block.end]);
+      replacedFirstBlock = true;
+      index = block.end;
+      continue;
+    }
+
+    if (block) {
+      index = block.end;
       continue;
     }
 
@@ -190,7 +231,7 @@ function updateGitignoreContent(
   }
 
   // If no Ruler block exists, add one at the end
-  if (!firstRulerBlock) {
+  if (rulerBlocks.length === 0) {
     // Add blank line if content exists and doesn't end with blank line
     if (existingContent.trim() && !existingContent.endsWith('\n\n')) {
       newLines.push('');

--- a/src/revert.ts
+++ b/src/revert.ts
@@ -14,11 +14,12 @@ import {
   resolveSelectedAgents,
 } from './core/agent-selection';
 import { mapRawAgentConfigs } from './core/config-utils';
-import { resolveIgnoreFilePath } from './core/GitignoreUtils';
+import {
+  removeCompleteRulerBlocks,
+  resolveIgnoreFilePath,
+} from './core/GitignoreUtils';
 
 const agents: IAgent[] = allAgents;
-const RULER_IGNORE_START_MARKER = '# START Ruler Generated Files';
-const RULER_IGNORE_END_MARKER = '# END Ruler Generated Files';
 const MANAGED_IGNORE_FILES = ['.gitignore', '.git/info/exclude'];
 
 export { allAgents };
@@ -228,19 +229,8 @@ async function cleanIgnoreFile(
   }
 
   const content = await fs.readFile(ignorePath, 'utf8');
-
-  const startIndex = content.indexOf(RULER_IGNORE_START_MARKER);
-  if (startIndex === -1) {
-    logVerbose(`No ruler-managed block found in ${ignoreFile}`, verbose);
-    return false;
-  }
-
-  const endIndex = content.indexOf(
-    RULER_IGNORE_END_MARKER,
-    startIndex + RULER_IGNORE_START_MARKER.length,
-  );
-
-  if (endIndex === -1) {
+  const cleaned = removeCompleteRulerBlocks(content);
+  if (!cleaned.removed) {
     logVerbose(`No ruler-managed block found in ${ignoreFile}`, verbose);
     return false;
   }
@@ -253,19 +243,11 @@ async function cleanIgnoreFile(
       verbose,
     );
   } else {
-    const beforeBlock = content.substring(0, startIndex);
-    const afterBlock = content.substring(
-      endIndex + RULER_IGNORE_END_MARKER.length,
-    );
-
-    let newContent = beforeBlock + afterBlock;
-    newContent = newContent.replace(/\n{3,}/g, '\n\n'); // Replace 3+ newlines with 2
-
-    if (newContent.trim() === '') {
+    if (cleaned.content.trim() === '') {
       await fs.unlink(ignorePath);
       logVerbose(`${prefix} Removed empty ${ignoreFile} file`, verbose);
     } else {
-      await fs.writeFile(ignorePath, newContent);
+      await fs.writeFile(ignorePath, cleaned.content);
       logVerbose(`${prefix} Removed ruler block from ${ignoreFile}`, verbose);
     }
   }

--- a/tests/unit/core/GitignoreUtils.test.ts
+++ b/tests/unit/core/GitignoreUtils.test.ts
@@ -192,7 +192,7 @@ CLAUDE.md
       ).rejects.toThrow();
     });
 
-    it('handles multiple Ruler blocks by updating the first one', async () => {
+    it('removes duplicate complete Ruler blocks when updating', async () => {
       const paths = ['CLAUDE.md'];
       const gitignorePath = path.join(tmpDir, '.gitignore');
       const initialContent = `# START Ruler Generated Files
@@ -209,8 +209,8 @@ duplicate-block.md
       const content = await fs.readFile(gitignorePath, 'utf8');
       expect(content).toContain('/CLAUDE.md');
       expect(content).not.toContain('old-file.md');
-      // Should still contain the duplicate block
-      expect(content).toContain('duplicate-block.md');
+      expect(content).not.toContain('duplicate-block.md');
+      expect(content.match(/# START Ruler Generated Files/g)).toHaveLength(1);
     });
 
     it('preserves entries after an unterminated Ruler start marker', async () => {

--- a/tests/unit/core/revert.test.ts
+++ b/tests/unit/core/revert.test.ts
@@ -369,6 +369,76 @@ describe('Revert Core Functions', () => {
       expect(content).toBe('node_modules/\n\n*.log\n');
     });
 
+    it('removes every complete ruler-managed block from .gitignore', async () => {
+      await fs.writeFile(
+        path.join(tmpDir, '.gitignore'),
+        [
+          'node_modules/',
+          '',
+          '# START Ruler Generated Files',
+          '/AGENTS.md',
+          '# END Ruler Generated Files',
+          '',
+          '*.log',
+          '',
+          '# START Ruler Generated Files',
+          '/CLAUDE.md',
+          '# END Ruler Generated Files',
+          '',
+        ].join('\n'),
+      );
+
+      await revertAllAgentConfigs(
+        tmpDir,
+        undefined,
+        undefined,
+        false,
+        false,
+        false,
+      );
+
+      const content = await fs.readFile(
+        path.join(tmpDir, '.gitignore'),
+        'utf8',
+      );
+      expect(content).toBe('node_modules/\n\n*.log\n\n');
+      expect(content).not.toContain('# START Ruler Generated Files');
+    });
+
+    it('ignores ruler marker text that is not on a complete marker line', async () => {
+      const gitignoreContent = [
+        'node_modules/',
+        'literal-# START Ruler Generated Files',
+        'important-user-pattern',
+        '# END Ruler Generated Files-suffix',
+        '*.log',
+        '',
+      ].join('\n');
+      await fs.writeFile(path.join(tmpDir, '.gitignore'), gitignoreContent);
+
+      const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+
+      try {
+        await revertAllAgentConfigs(
+          tmpDir,
+          undefined,
+          undefined,
+          false,
+          false,
+          false,
+        );
+
+        expect(consoleLogSpy).not.toHaveBeenCalledWith(
+          '  .gitignore cleaned: yes',
+        );
+        await expect(
+          fs.readFile(path.join(tmpDir, '.gitignore'), 'utf8'),
+        ).resolves.toBe(gitignoreContent);
+      } finally {
+        consoleLogSpy.mockRestore();
+      }
+    });
+
     it('removes the ruler-managed block from .git/info/exclude', async () => {
       const excludePath = path.join(tmpDir, '.git', 'info', 'exclude');
       await fs.mkdir(path.dirname(excludePath), { recursive: true });


### PR DESCRIPTION
Closes #604

## Summary
- parse Ruler ignore markers as complete trimmed lines
- remove duplicate complete Ruler ignore blocks during updates
- remove all complete Ruler ignore blocks during full revert while preserving malformed marker text

## Verification
- npx jest tests/unit/core/GitignoreUtils.test.ts tests/unit/core/revert.test.ts --runInBand
- npm run format && npm run check:package-lock && npm run lint && npm test && npm run build && npm audit --omit=dev --audit-level=moderate && npm pack --dry-run