### PR TITLE
Diagnose invalid legacy MCP servers

### DIFF
--- a/src/core/UnifiedConfigLoader.ts
+++ b/src/core/UnifiedConfigLoader.ts
@@ -396,6 +396,53 @@ export async function loadUnifiedConfig(
           if (typeof def.timeout === 'number') {
             server.timeout = def.timeout;
           }
+
+          const hasCommand = !!server.command;
+          const hasUrl = !!server.url;
+
+          if (!hasCommand && !hasUrl) {
+            diagnostics.push({
+              severity: 'warning',
+              code: 'MCP_JSON_INVALID_SERVER',
+              message: `MCP server '${name}' must have at least one of command or url`,
+              file: mcpFile,
+            });
+            continue;
+          }
+
+          if (hasCommand && hasUrl) {
+            diagnostics.push({
+              severity: 'warning',
+              code: 'MCP_JSON_FIELD_CONFLICT',
+              message: `MCP server '${name}' has both command and url - using url (remote)`,
+              file: mcpFile,
+            });
+          }
+
+          if (hasCommand && server.headers) {
+            diagnostics.push({
+              severity: 'warning',
+              code: 'MCP_JSON_FIELD_CONFLICT',
+              message: `MCP server '${name}' has headers with command (should be used with url only)`,
+              file: mcpFile,
+            });
+          }
+
+          if (hasUrl && server.env) {
+            diagnostics.push({
+              severity: 'warning',
+              code: 'MCP_JSON_FIELD_CONFLICT',
+              message: `MCP server '${name}' has env with url (should be used with command only)`,
+              file: mcpFile,
+            });
+          }
+
+          if (hasCommand && hasUrl) {
+            delete server.command;
+            delete server.args;
+            delete server.env;
+          }
+
           // Derive type
           if (server.url) server.type = 'remote';
           else if (server.command) server.type = 'stdio';

--- a/tests/mcp-invalid-fields.test.ts
+++ b/tests/mcp-invalid-fields.test.ts
@@ -111,4 +111,66 @@ args = ["some", "args"]
       'must have at least one of command or url',
     );
   });
+
+  it('diagnoses legacy JSON server with both command and url', async () => {
+    testProject = await setupTestProject({
+      '.ruler/mcp.json': JSON.stringify(
+        {
+          mcpServers: {
+            invalid: {
+              command: 'node',
+              url: 'https://example.com',
+            },
+          },
+        },
+        null,
+        2,
+      ),
+    });
+
+    const { projectRoot } = testProject;
+    const { loadUnifiedConfig } = require('../dist/core/UnifiedConfigLoader');
+    const config = await loadUnifiedConfig({ projectRoot });
+
+    const fieldConflictError = config.diagnostics.find(
+      (d: any) => d.code === 'MCP_JSON_FIELD_CONFLICT',
+    );
+    expect(fieldConflictError).toBeTruthy();
+    expect(fieldConflictError.severity).toBe('warning');
+    expect(fieldConflictError.message).toContain('both command and url');
+    expect(config.mcp.servers.invalid).toEqual({
+      url: 'https://example.com',
+      type: 'remote',
+    });
+  });
+
+  it('diagnoses and skips legacy JSON server with neither command nor url', async () => {
+    testProject = await setupTestProject({
+      '.ruler/mcp.json': JSON.stringify(
+        {
+          mcpServers: {
+            invalid: {
+              args: ['some', 'args'],
+            },
+          },
+        },
+        null,
+        2,
+      ),
+    });
+
+    const { projectRoot } = testProject;
+    const { loadUnifiedConfig } = require('../dist/core/UnifiedConfigLoader');
+    const config = await loadUnifiedConfig({ projectRoot });
+
+    const invalidServerError = config.diagnostics.find(
+      (d: any) => d.code === 'MCP_JSON_INVALID_SERVER',
+    );
+    expect(invalidServerError).toBeTruthy();
+    expect(invalidServerError.severity).toBe('warning');
+    expect(invalidServerError.message).toContain(
+      'must have at least one of command or url',
+    );
+    expect(config.mcp.servers).toEqual({});
+  });
 });


### PR DESCRIPTION
Closes #606

## Summary
- add legacy JSON diagnostics for MCP servers with missing or conflicting transport fields
- skip invalid legacy JSON servers with neither command nor url
- apply remote precedence for legacy JSON servers that specify both command and url

## Verification
- npx jest tests/mcp-invalid-fields.test.ts --runInBand
- npm run format && npm run check:package-lock && npm run lint && npm test && npm run build && npm audit --omit=dev --audit-level=moderate && npm pack --dry-run