### PR TITLE
Reject non-object native MCP configs

### DIFF
--- a/src/paths/mcp.ts
+++ b/src/paths/mcp.ts
@@ -2,6 +2,10 @@ import * as path from 'path';
 import { promises as fs } from 'fs';
 import { writeGeneratedFile } from '../core/FileSystemUtils';
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 /** Determine the native MCP config path for a given agent. */
 export async function getNativeMcpPath(
   adapterName: string,
@@ -95,7 +99,11 @@ export async function readNativeMcp(
   }
 
   try {
-    return JSON.parse(text) as Record<string, unknown>;
+    const parsed = JSON.parse(text) as unknown;
+    if (!isRecord(parsed)) {
+      throw new Error('must be a JSON object');
+    }
+    return parsed;
   } catch (error) {
     throw new Error(
       `Invalid MCP config at ${filePath}: ${error instanceof Error ? error.message : String(error)}`,

--- a/tests/unit/paths/mcp-paths.test.ts
+++ b/tests/unit/paths/mcp-paths.test.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 import * as os from 'os';
-import { getNativeMcpPath } from '../../../src/paths/mcp';
+import { promises as fs } from 'fs';
+import { getNativeMcpPath, readNativeMcp } from '../../../src/paths/mcp';
 
 describe('MCP Path Resolution', () => {
   const projectRoot = '/test/project';
@@ -114,6 +115,37 @@ describe('MCP Path Resolution', () => {
           path.join(projectRoot, '.kiro', 'settings', 'mcp.json'),
         );
       });
+    });
+  });
+
+  describe('readNativeMcp', () => {
+    let tmpDir: string;
+
+    beforeEach(async () => {
+      tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ruler-native-mcp-'));
+    });
+
+    afterEach(async () => {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it('returns an empty object when the native config is missing', async () => {
+      await expect(
+        readNativeMcp(path.join(tmpDir, 'mcp.json')),
+      ).resolves.toEqual({});
+    });
+
+    it.each([
+      ['null', 'null'],
+      ['array', '[]'],
+    ])('rejects %s native MCP config content', async (_name, content) => {
+      const mcpPath = path.join(tmpDir, 'mcp.json');
+      await fs.writeFile(mcpPath, content);
+
+      await expect(readNativeMcp(mcpPath)).rejects.toThrow(
+        `Invalid MCP config at ${mcpPath}: must be a JSON object`,
+      );
+      await expect(fs.readFile(mcpPath, 'utf8')).resolves.toBe(content);
     });
   });
 });


### PR DESCRIPTION
Fixes #608.\n\n## Summary\n- validate native MCP JSON configs as top-level objects before merge\n- keep missing native MCP configs as an empty object\n- add regression coverage for null and array native MCP files\n\n## Verification\n- npm run format\n- npm run check:package-lock\n- npm run lint\n- npm test\n- npm run build\n- npm audit --omit=dev --audit-level=moderate\n- npm pack --dry-run