### PR TITLE
Avoid install-time prepare builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:integration": "jest tests/e2e/ruler.integration.test.ts --verbose",
     "build": "tsc",
     "check:package-lock": "node -e \"const pkg=require('./package.json'); const lock=require('./package-lock.json'); const root=lock.packages?.['']; if (lock.version !== pkg.version || root?.version !== pkg.version) { console.error('package-lock.json version metadata must match package.json version'); process.exit(1); }\"",
-    "prepare": "npm run build"
+    "prepublishOnly": "npm run build"
   },
   "repository": {
     "type": "git",

--- a/tests/unit/package-json.test.ts
+++ b/tests/unit/package-json.test.ts
@@ -1,0 +1,16 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('package manifest', () => {
+  it('does not run builds during install-time lifecycle hooks', () => {
+    const packageJsonPath = path.join(process.cwd(), 'package.json');
+    const packageJson = JSON.parse(
+      fs.readFileSync(packageJsonPath, 'utf8'),
+    ) as {
+      scripts?: Record<string, string>;
+    };
+
+    expect(packageJson.scripts?.prepare).toBeUndefined();
+    expect(packageJson.scripts?.prepublishOnly).toBe('npm run build');
+  });
+});


### PR DESCRIPTION
Fixes #610.\n\n## Summary\n- replace the install-time `prepare` lifecycle with `prepublishOnly`\n- add a package manifest regression test to prevent reintroducing install-time build hooks\n\n## Verification\n- npx jest tests/unit/package-json.test.ts --runInBand (failed before the fix, passed after)\n- npm run format\n- npm run check:package-lock\n- npm run lint\n- npm test\n- npm run build\n- npm audit --omit=dev --audit-level=moderate\n- npm pack --dry-run