### PR TITLE
Restrict Copilot workflow tool access

### DIFF
--- a/.github/workflows/this-codebase-smells.yml
+++ b/.github/workflows/this-codebase-smells.yml
@@ -58,7 +58,6 @@ jobs:
           # Read the prompt and run Copilot CLI in programmatic mode
           copilot_args=(
             -p "$(cat .github/workflows/this-codebase-smells/prompt.md)"
-            --allow-tool 'shell(*)'
             --allow-tool 'read_file(*)'
             --allow-tool 'glob(*)'
           )

--- a/tests/unit/workflows/this-codebase-smells-workflow.test.ts
+++ b/tests/unit/workflows/this-codebase-smells-workflow.test.ts
@@ -1,0 +1,21 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('This Codebase Smells workflow', () => {
+  it('does not grant shell access to the Copilot analysis step', () => {
+    const workflowPath = path.join(
+      process.cwd(),
+      '.github',
+      'workflows',
+      'this-codebase-smells.yml',
+    );
+    const workflow = fs.readFileSync(workflowPath, 'utf8');
+
+    expect(workflow).not.toContain("--allow-tool 'shell(*)'");
+    expect(workflow).toContain("--allow-tool 'read_file(*)'");
+    expect(workflow).toContain("--allow-tool 'glob(*)'");
+    expect(workflow).toContain(
+      'GITHUB_TOKEN: ${{ secrets.COPILOT_CLI_TOKEN }}',
+    );
+  });
+});


### PR DESCRIPTION
Fixes #612.\n\n## Summary\n- remove `shell(*)` from the Copilot analysis workflow allowlist\n- keep repository text inspection tools enabled\n- add a workflow regression test for the restricted allowlist\n\n## Verification\n- npx jest tests/unit/workflows/this-codebase-smells-workflow.test.ts --runInBand (failed before the fix, passed after)\n- npm run format\n- npm run check:package-lock\n- npm run lint\n- npm test\n- npm run build\n- npm audit --omit=dev --audit-level=moderate\n- npm pack --dry-run