### PR TITLE
Update GitHub Actions action majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ jobs:
       matrix:
         node-version: ['20.19.0', '22.12.0', '24.x']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,12 +18,12 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ github.event.release.tag_name || inputs.release_tag || github.ref }}
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org/'

--- a/.github/workflows/ruler.yml
+++ b/.github/workflows/ruler.yml
@@ -18,12 +18,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 'lts/*'
           check-latest: true

--- a/.github/workflows/this-codebase-smells.yml
+++ b/.github/workflows/this-codebase-smells.yml
@@ -32,10 +32,10 @@ jobs:
             echo "Not 16:00 Europe/Zurich; skipping subsequent steps."
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         if: ${{ steps.gate.outputs.run != 'false' }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         if: ${{ steps.gate.outputs.run != 'false' }}
         with:
           node-version: '22'

--- a/.github/workflows/writeme.yml
+++ b/.github/workflows/writeme.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Read prompt file
         id: prompt

--- a/tests/unit/workflows/action-pins.test.ts
+++ b/tests/unit/workflows/action-pins.test.ts
@@ -1,0 +1,20 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('GitHub Actions pins', () => {
+  it('uses current checkout and setup-node action majors', () => {
+    const workflowsDir = path.join(process.cwd(), '.github', 'workflows');
+    const workflowText = fs
+      .readdirSync(workflowsDir)
+      .filter((fileName) => fileName.endsWith('.yml'))
+      .map((fileName) =>
+        fs.readFileSync(path.join(workflowsDir, fileName), 'utf8'),
+      )
+      .join('\n');
+
+    expect(workflowText).not.toContain('actions/checkout@v4');
+    expect(workflowText).not.toContain('actions/setup-node@v4');
+    expect(workflowText).toContain('actions/checkout@v7');
+    expect(workflowText).toContain('actions/setup-node@v6');
+  });
+});


### PR DESCRIPTION
Fixes #614.\n\n## Summary\n- update workflow uses of `actions/checkout` to v7\n- update workflow uses of `actions/setup-node` to v6\n- add a workflow regression test for stale v4 pins\n\n## Verification\n- npx jest tests/unit/workflows/action-pins.test.ts --runInBand (failed before the fix, passed after)\n- npm run format\n- npm run check:package-lock\n- npm run lint\n- npm test\n- npm run build\n- npm audit --omit=dev --audit-level=moderate\n- npm pack --dry-run