### PR TITLE
fix: skip symlinked skill entries

### DIFF
--- a/src/core/SkillsUtils.ts
+++ b/src/core/SkillsUtils.ts
@@ -111,7 +111,11 @@ export function formatValidationWarnings(warnings: string[]): string {
  * Recursively copies a directory and all its contents.
  */
 async function copyRecursive(src: string, dest: string): Promise<void> {
-  const stat = await fs.stat(src);
+  const stat = await fs.lstat(src);
+
+  if (stat.isSymbolicLink()) {
+    return;
+  }
 
   if (stat.isDirectory()) {
     await fs.mkdir(dest, { recursive: true });

--- a/tests/skills-propagation.test.ts
+++ b/tests/skills-propagation.test.ts
@@ -227,6 +227,47 @@ describe('Skills Discovery and Validation', () => {
       const copiedSkill1 = path.join(destDir, 'skill1', SKILL_MD_FILENAME);
       expect(await fs.readFile(copiedSkill1, 'utf8')).toBe('# Skill 1');
     });
+
+    it('does not follow symlinked files while copying skills', async () => {
+      const { copySkillsDirectory } = await import('../src/core/SkillsUtils');
+      const skillsDir = path.join(tmpDir, '.ruler', 'skills');
+      const skill1 = path.join(skillsDir, 'skill1');
+      const outsideDir = path.join(tmpDir, 'outside');
+      const outsideFile = path.join(outsideDir, 'secret.txt');
+
+      await fs.mkdir(skill1, { recursive: true });
+      await fs.mkdir(outsideDir, { recursive: true });
+      await fs.writeFile(path.join(skill1, SKILL_MD_FILENAME), '# Skill 1');
+      await fs.writeFile(outsideFile, 'secret');
+      await fs.symlink(outsideFile, path.join(skill1, 'leak.txt'));
+
+      const destDir = path.join(tmpDir, '.claude', 'skills');
+      await copySkillsDirectory(skillsDir, destDir);
+
+      await expect(
+        fs.access(path.join(destDir, 'skill1', 'leak.txt')),
+      ).rejects.toThrow();
+    });
+
+    it('does not follow symlinked directories while copying skills', async () => {
+      const { copySkillsDirectory } = await import('../src/core/SkillsUtils');
+      const skillsDir = path.join(tmpDir, '.ruler', 'skills');
+      const skill1 = path.join(skillsDir, 'skill1');
+      const outsideDir = path.join(tmpDir, 'outside');
+
+      await fs.mkdir(skill1, { recursive: true });
+      await fs.mkdir(outsideDir, { recursive: true });
+      await fs.writeFile(path.join(skill1, SKILL_MD_FILENAME), '# Skill 1');
+      await fs.writeFile(path.join(outsideDir, 'secret.txt'), 'secret');
+      await fs.symlink(outsideDir, path.join(skill1, 'linked-dir'));
+
+      const destDir = path.join(tmpDir, '.claude', 'skills');
+      await copySkillsDirectory(skillsDir, destDir);
+
+      await expect(
+        fs.access(path.join(destDir, 'skill1', 'linked-dir')),
+      ).rejects.toThrow();
+    });
   });
 
   describe('propagateSkillsForClaude', () => {


### PR DESCRIPTION
## Summary

- Skip symbolic links when recursively copying `.ruler/skills` into native skill directories
- Add regression coverage for symlinked file and directory entries under skills

Fixes #617.

## Verification

- `npm ci`
- `npm run format:check`
- `npm run lint`
- `npm run build`
- `npm test`
- `npm run check:package-lock`
- `npm audit --omit=dev --audit-level=moderate`
- `npm pack --dry-run`

Note: the focused `npm test -- tests/skills-propagation.test.ts --runInBand` functionally passed after the fix, but exits non-zero because global coverage thresholds are enforced against a single suite. The full `npm test` passes.
