### PR TITLE
fix: clean dist before package builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "test:integration": "jest tests/e2e/ruler.integration.test.ts --verbose",
-    "build": "tsc",
+    "clean": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\"",
+    "build": "npm run clean && tsc",
     "check:package-lock": "node -e \"const pkg=require('./package.json'); const lock=require('./package-lock.json'); const root=lock.packages?.['']; if (lock.version !== pkg.version || root?.version !== pkg.version) { console.error('package-lock.json version metadata must match package.json version'); process.exit(1); }\"",
     "prepublishOnly": "npm run build"
   },

--- a/tests/unit/package-json.test.ts
+++ b/tests/unit/package-json.test.ts
@@ -13,4 +13,19 @@ describe('package manifest', () => {
     expect(packageJson.scripts?.prepare).toBeUndefined();
     expect(packageJson.scripts?.prepublishOnly).toBe('npm run build');
   });
+
+  it('cleans stale dist output before building publish artifacts', () => {
+    const packageJsonPath = path.join(process.cwd(), 'package.json');
+    const packageJson = JSON.parse(
+      fs.readFileSync(packageJsonPath, 'utf8'),
+    ) as {
+      scripts?: Record<string, string>;
+    };
+
+    expect(packageJson.scripts?.clean).toContain("rmSync('dist'");
+    expect(packageJson.scripts?.clean).toContain('recursive: true');
+    expect(packageJson.scripts?.clean).toContain('force: true');
+    expect(packageJson.scripts?.build).toBe('npm run clean && tsc');
+    expect(packageJson.scripts?.prepublishOnly).toBe('npm run build');
+  });
 });


### PR DESCRIPTION
## Summary

- add an explicit `clean` script that removes `dist` before TypeScript compilation
- make `build` run the clean step before `tsc`
- add a package manifest test for the publish-build invariant

Closes #620.

## Verification

- `npx jest tests/unit/package-json.test.ts --runInBand --coverage=false`
- stale-file reproduction: `mkdir -p dist && printf 'stale proof\n' > dist/__ruler-stale-publish-proof.txt && npm run build && npm pack --dry-run --json` no longer includes the proof file
- `npm run format:check`
- `npm run lint`
- `npm run check:package-lock`
- `npm audit --omit=dev --audit-level=moderate`
- `npm run build`
- `npm test`
- `npm run build && npm pack --dry-run`
