### PR TITLE
fix: guard revert against symlinked paths

### DIFF
--- a/src/core/FileSystemUtils.ts
+++ b/src/core/FileSystemUtils.ts
@@ -41,7 +41,7 @@ async function isSymbolicLink(filePath: string): Promise<boolean> {
   }
 }
 
-async function assertNotSymbolicLink(
+export async function assertNotSymbolicLink(
   filePath: string,
   action: string,
 ): Promise<void> {

--- a/src/core/revert-engine.ts
+++ b/src/core/revert-engine.ts
@@ -12,7 +12,10 @@ import {
   getVSCodeSettingsPath,
 } from '../vscode/settings';
 import { isPathInsideOrEqual } from './path-utils';
-import { assertManagedPathInsideRoot } from './FileSystemUtils';
+import {
+  assertManagedPathInsideRoot,
+  assertNotSymbolicLink,
+} from './FileSystemUtils';
 
 const RULER_START_MARKER = '# START Ruler Generated Files';
 const RULER_END_MARKER = '# END Ruler Generated Files';
@@ -166,6 +169,14 @@ async function restoreFromBackup(
         'Refusing to restore from backup through symlinked backup path',
       );
     }
+    await assertNotSymbolicLink(
+      filePath,
+      'Refusing to restore backup through symlinked output path',
+    );
+    await assertNotSymbolicLink(
+      backupPath,
+      'Refusing to restore from symlinked backup path',
+    );
     await fs.copyFile(backupPath, filePath);
     logVerbose(`${prefix} Restored: ${filePath} from backup`, verbose);
   }
@@ -218,6 +229,10 @@ async function removeGeneratedFile(
         'Refusing to remove generated file through symlinked path',
       );
     }
+    await assertNotSymbolicLink(
+      filePath,
+      'Refusing to remove symlinked generated file',
+    );
     await fs.unlink(filePath);
     logVerbose(`${prefix} Removed generated file: ${filePath}`, verbose);
   }
@@ -253,6 +268,10 @@ async function removeBackupFile(
         'Refusing to remove backup file through symlinked path',
       );
     }
+    await assertNotSymbolicLink(
+      backupPath,
+      'Refusing to remove symlinked backup file',
+    );
     await fs.unlink(backupPath);
     logVerbose(`${prefix} Removed backup file: ${backupPath}`, verbose);
   }
@@ -485,6 +504,15 @@ async function removeAdditionalAgentFiles(
             verbose,
           );
         } else {
+          await assertManagedPathInsideRoot(
+            fullPath,
+            projectRoot,
+            'Refusing to remove additional file through symlinked path',
+          );
+          await assertNotSymbolicLink(
+            fullPath,
+            'Refusing to remove symlinked additional file',
+          );
           await fs.unlink(fullPath);
           logVerbose(`${prefix} Removed additional file: ${fullPath}`, verbose);
         }

--- a/src/revert.ts
+++ b/src/revert.ts
@@ -228,6 +228,16 @@ async function cleanIgnoreFile(
     return false;
   }
 
+  await FileSystemUtils.assertManagedPathInsideRoot(
+    ignorePath,
+    projectRoot,
+    `Refusing to clean ${ignoreFile} through symlinked path`,
+  );
+  await FileSystemUtils.assertNotSymbolicLink(
+    ignorePath,
+    `Refusing to clean symlinked ${ignoreFile}`,
+  );
+
   const content = await fs.readFile(ignorePath, 'utf8');
   const cleaned = removeCompleteRulerBlocks(content);
   if (!cleaned.removed) {

--- a/tests/integration/symlink-output-safety.test.ts
+++ b/tests/integration/symlink-output-safety.test.ts
@@ -257,4 +257,75 @@ describe('Symlink output safety', () => {
       'backup content',
     );
   });
+
+  it('does not restore a backup through a symlinked output file inside the project', async () => {
+    const outputPath = path.join(projectRoot, 'CLAUDE.md');
+    const victimPath = path.join(projectRoot, 'victim.md');
+    await fs.writeFile(victimPath, 'victim original');
+    await fs.symlink(victimPath, outputPath);
+    await fs.writeFile(`${outputPath}.bak`, 'backup content');
+
+    expect(() =>
+      execFileSync(
+        'node',
+        [
+          path.resolve('dist/cli/index.js'),
+          'revert',
+          '--project-root',
+          projectRoot,
+          '--agents',
+          'claude',
+        ],
+        {
+          stdio: 'pipe',
+        },
+      ),
+    ).toThrow();
+
+    await expect(fs.readFile(victimPath, 'utf8')).resolves.toBe(
+      'victim original',
+    );
+    await expect(fs.readFile(`${outputPath}.bak`, 'utf8')).resolves.toBe(
+      'backup content',
+    );
+  });
+
+  it('does not clean a managed ignore file through a symlink', async () => {
+    await fs.writeFile(
+      outsideFile,
+      [
+        'outside original',
+        '# START Ruler Generated Files',
+        '/CLAUDE.md',
+        '# END Ruler Generated Files',
+        '',
+      ].join('\n'),
+    );
+    await fs.symlink(outsideFile, path.join(projectRoot, '.gitignore'));
+
+    expect(() =>
+      execFileSync(
+        'node',
+        [
+          path.resolve('dist/cli/index.js'),
+          'revert',
+          '--project-root',
+          projectRoot,
+        ],
+        {
+          stdio: 'pipe',
+        },
+      ),
+    ).toThrow();
+
+    await expect(fs.readFile(outsideFile, 'utf8')).resolves.toBe(
+      [
+        'outside original',
+        '# START Ruler Generated Files',
+        '/CLAUDE.md',
+        '# END Ruler Generated Files',
+        '',
+      ].join('\n'),
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- reject symlinked output and backup paths before revert restores or removes files
- reject symlinked additional generated files before full-revert cleanup removes them
- reject symlinked managed ignore files before full revert cleans `.gitignore` or `.git/info/exclude`
- add integration coverage for in-project output symlinks and symlinked managed ignore files

Closes #622.

## Verification

Regression tests failed before the fix:

- `npx jest tests/integration/symlink-output-safety.test.ts --runInBand --coverage=false` failed for the new in-project restore symlink and symlinked `.gitignore` cases

After the fix:

- `npm run build && npx jest tests/integration/symlink-output-safety.test.ts --runInBand --coverage=false`
- `npm run format:check`
- `npm run lint`
- `npm run build`
- `npm run check:package-lock`
- `npm test`
- `npm audit --omit=dev --audit-level=moderate`
- `npm run build && npm pack --dry-run`
