### PR TITLE
fix: validate agent-scoped MCP server types

### DIFF
--- a/src/core/ConfigLoader.ts
+++ b/src/core/ConfigLoader.ts
@@ -178,7 +178,10 @@ function parseAgentMcpServers(
     sectionObj.mcp_servers as Record<string, unknown>,
   )) {
     if (def && typeof def === 'object' && !Array.isArray(def)) {
-      servers[name] = normalizeAgentMcpServer(def as Record<string, unknown>);
+      const server = normalizeAgentMcpServer(def as Record<string, unknown>);
+      if (server.command || server.url) {
+        servers[name] = server;
+      }
     }
   }
 
@@ -191,6 +194,18 @@ function normalizeAgentMcpServer(
   const server = { ...def };
   const hasCommand = typeof server.command === 'string';
   const hasUrl = typeof server.url === 'string';
+
+  if (!hasCommand) {
+    delete server.command;
+    delete server.args;
+    delete server.env;
+  }
+  if (!hasUrl) {
+    delete server.url;
+    delete server.headers;
+    delete server.auth;
+    delete server.oauth;
+  }
 
   if (hasCommand && hasUrl) {
     delete server.command;

--- a/src/mcp/capabilities.ts
+++ b/src/mcp/capabilities.ts
@@ -50,8 +50,9 @@ export function filterMcpConfigForAgent(
     const config = serverConfig as Record<string, unknown>;
 
     // Determine server type
-    const hasCommand = 'command' in config;
-    const hasUrl = 'url' in config;
+    const hasCommand =
+      typeof config.command === 'string' || Array.isArray(config.command);
+    const hasUrl = typeof config.url === 'string';
 
     const isStdio = hasCommand && !hasUrl;
     const isRemote = hasUrl && !hasCommand;

--- a/tests/agent-mcp-servers.test.ts
+++ b/tests/agent-mcp-servers.test.ts
@@ -77,4 +77,27 @@ headers = { Authorization = "Bearer remote-token" }
       headers: { Authorization: 'Bearer remote-token' },
     });
   });
+
+  it('skips agent-specific server definitions with invalid command and url types', async () => {
+    const toml = `
+[agents.cursor.mcp_servers.bad_stdio]
+command = 123
+args = ["server.js"]
+
+[agents.cursor.mcp_servers.bad_remote]
+url = false
+`;
+
+    testProject = await setupTestProject({
+      '.ruler/AGENTS.md': '# Test instructions',
+      '.ruler/ruler.toml': toml,
+    });
+
+    const { projectRoot } = testProject;
+    runRuler('apply --agents cursor --no-backup --no-gitignore', projectRoot);
+
+    await expect(
+      fs.access(path.join(projectRoot, '.cursor', 'mcp.json')),
+    ).rejects.toThrow();
+  });
 });

--- a/tests/unit/mcp/capabilities.test.ts
+++ b/tests/unit/mcp/capabilities.test.ts
@@ -126,6 +126,26 @@ describe('MCP Capabilities', () => {
       expect(filtered).toBeNull();
     });
 
+    it('ignores servers whose command or url fields have invalid types', () => {
+      const agent = new OpenHandsAgent();
+      const filtered = filterMcpConfigForAgent(
+        {
+          mcpServers: {
+            invalid_stdio: {
+              command: 123,
+              args: ['server.js'],
+            },
+            invalid_remote: {
+              url: false,
+            },
+          },
+        },
+        agent,
+      );
+
+      expect(filtered).toBeNull();
+    });
+
     it('transforms remote servers to stdio servers for stdio-only agents', () => {
       const agent = new FirebaseAgent();
       const configWithRemoteServers = {


### PR DESCRIPTION
## Summary

- skip agent-scoped MCP servers that do not have a string `command` or string `url`
- drop invalid typed transport-specific fields during agent-scoped MCP normalisation
- classify MCP server compatibility by value type in the capability filter
- add unit and integration coverage for invalid typed agent-scoped MCP servers

Closes #624.

## Verification

Regression tests failed before the fix:

- `npx jest tests/unit/mcp/capabilities.test.ts tests/agent-mcp-servers.test.ts --runInBand --coverage=false`

After the fix:

- `npm run build && npx jest tests/unit/mcp/capabilities.test.ts tests/agent-mcp-servers.test.ts --runInBand --coverage=false`
- `npm run format:check`
- `npm run lint`
- `npm run build`
- `npm run check:package-lock`
- `npm audit --omit=dev --audit-level=moderate`
- `npm test`
- `npm run build && npm pack --dry-run`
