### PR TITLE
fix: load global TOML for local rules

### DIFF
--- a/src/core/UnifiedConfigLoader.ts
+++ b/src/core/UnifiedConfigLoader.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from 'fs';
 import * as path from 'path';
+import * as os from 'os';
 import { parse as parseTOML } from '@iarna/toml';
 import { sha256, stableJson } from './hash';
 import { concatenateRules } from './RuleProcessor';
@@ -42,6 +43,53 @@ function copyAdditionalMcpServerFields(
   );
 }
 
+async function resolveImplicitTomlFile(
+  projectRoot: string,
+  rulerDir: string,
+  checkGlobal: boolean,
+): Promise<string | undefined> {
+  const localTomlFile = path.join(rulerDir, 'ruler.toml');
+  if (await fileExists(localTomlFile)) {
+    return localTomlFile;
+  }
+
+  const projectTomlFile = path.join(projectRoot, '.ruler', 'ruler.toml');
+  if (
+    path.resolve(projectTomlFile) !== path.resolve(localTomlFile) &&
+    (await fileExists(projectTomlFile))
+  ) {
+    return projectTomlFile;
+  }
+
+  if (!checkGlobal) {
+    return undefined;
+  }
+
+  const xdgConfigDir =
+    process.env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config');
+  const globalTomlFile = path.join(xdgConfigDir, 'ruler', 'ruler.toml');
+  if (
+    path.resolve(globalTomlFile) !== path.resolve(localTomlFile) &&
+    (await fileExists(globalTomlFile))
+  ) {
+    return globalTomlFile;
+  }
+
+  return undefined;
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return false;
+    }
+    throw err;
+  }
+}
+
 export async function loadUnifiedConfig(
   options: UnifiedLoadOptions,
 ): Promise<RulerUnifiedConfig> {
@@ -65,16 +113,17 @@ export async function loadUnifiedConfig(
   let tomlRaw: unknown = {};
   const tomlFile = options.configPath
     ? path.resolve(options.configPath)
-    : path.join(meta.rulerDir, 'ruler.toml');
-  try {
-    const text = await fs.readFile(tomlFile, 'utf8');
-    tomlRaw = text.trim() ? parseTOML(text) : {};
-    meta.configFile = tomlFile;
-  } catch (err) {
-    if (
-      options.configPath ||
-      (err as NodeJS.ErrnoException).code !== 'ENOENT'
-    ) {
+    : await resolveImplicitTomlFile(
+        options.projectRoot,
+        meta.rulerDir,
+        options.checkGlobal ?? true,
+      );
+  if (tomlFile) {
+    try {
+      const text = await fs.readFile(tomlFile, 'utf8');
+      tomlRaw = text.trim() ? parseTOML(text) : {};
+      meta.configFile = tomlFile;
+    } catch (err) {
       diagnostics.push({
         severity: options.configPath ? 'error' : 'warning',
         code: 'TOML_READ_ERROR',

--- a/tests/apply-mcp.toml-stdio.test.ts
+++ b/tests/apply-mcp.toml-stdio.test.ts
@@ -1,5 +1,7 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
+import os from 'os';
+import { execFileSync } from 'child_process';
 import { setupTestProject, teardownTestProject, runRuler } from './harness';
 
 describe('apply-mcp.toml-stdio', () => {
@@ -53,5 +55,60 @@ args = ["-y", "@modelcontextprotocol/server-git", "--repository", "."]
       args: ['-y', '@modelcontextprotocol/server-git', '--repository', '.'],
       type: 'stdio',
     });
+  });
+
+  it('applies global TOML MCP servers when local rules have no ruler.toml', async () => {
+    const { projectRoot } = testProject;
+    const xdgConfigHome = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'ruler-global-config-'),
+    );
+
+    try {
+      await fs.rm(path.join(projectRoot, '.ruler', 'ruler.toml'), {
+        force: true,
+      });
+      await fs.writeFile(
+        path.join(projectRoot, '.ruler', 'AGENTS.md'),
+        '# Local rules',
+      );
+      const globalRulerDir = path.join(xdgConfigHome, 'ruler');
+      await fs.mkdir(globalRulerDir, { recursive: true });
+      await fs.writeFile(
+        path.join(globalRulerDir, 'ruler.toml'),
+        [
+          '[mcp_servers.global]',
+          'command = "node"',
+          'args = ["server.js"]',
+          '',
+        ].join('\n'),
+      );
+      execFileSync(
+        'node',
+        [
+          path.resolve('dist/cli/index.js'),
+          'apply',
+          '--project-root',
+          projectRoot,
+          '--agents',
+          'cursor',
+          '--no-backup',
+          '--no-gitignore',
+        ],
+        {
+          env: { ...process.env, XDG_CONFIG_HOME: xdgConfigHome },
+          stdio: 'pipe',
+        },
+      );
+
+      const nativePath = path.join(projectRoot, '.cursor', 'mcp.json');
+      const config = JSON.parse(await fs.readFile(nativePath, 'utf8'));
+      expect(config.mcpServers.global).toEqual({
+        command: 'node',
+        args: ['server.js'],
+        type: 'stdio',
+      });
+    } finally {
+      await fs.rm(xdgConfigHome, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary

- let `loadUnifiedConfig` resolve `ruler.toml` from global config when the local `.ruler` directory has rules but no local TOML file
- keep the local `.ruler` directory as the rule source while using global TOML for MCP server definitions
- add integration coverage for local rules plus global TOML MCP servers

Closes #626.

## Verification

Confirmed before the fix with a reproduction script on `main`: local `.ruler/AGENTS.md` plus global `[mcp_servers.global]` produced no `.cursor/mcp.json`.

After the fix:

- `npm run build && npx jest tests/apply-mcp.toml-stdio.test.ts --runInBand --coverage=false`
- `npm run format:check`
- `npm run lint`
- `npm run build`
- `npm run check:package-lock`
- `npm audit --omit=dev --audit-level=moderate`
- `npm test`
- `npm run build && npm pack --dry-run`
