### PR TITLE
Fix package lock version for 0.3.44 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@intellectronica/ruler",
-  "version": "0.3.43",
+  "version": "0.3.44",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@intellectronica/ruler",
-      "version": "0.3.43",
+      "version": "0.3.44",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^2.2.5",


### PR DESCRIPTION
## Summary
- update package-lock.json version metadata to match package.json 0.3.44
- unblock the release workflow's package-lock validation

## Verification
- npm ci
- npm run check:package-lock
- npm run format:check
- npm run lint
- npm test
- npm run build
- npm audit --omit=dev --audit-level=moderate
- npm pack --dry-run

## Release recovery
After this lands, v0.3.44 needs to be retagged to the fixed commit and the Release workflow can be run with release_tag=v0.3.44.