### PR TITLE
feat: Propagate .ruler sub-directories to per-agent target folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -894,6 +894,99 @@ ruler apply
 - **Atomic replace, not merge.** Ruler regenerates each agent's subagent directory from the source on every apply. Manual edits to generated files will be overwritten.
 - **No support yet for agents without a native subagent primitive.** Windsurf, RooCode, Aider, Gemini CLI, and others are skipped with a warning. Propagation will be added when those agents ship a comparable file format.
 
+## Folder Propagation (Experimental)
+
+> **⚠️ Experimental:** Folder propagation is experimental and behavior may change in future releases.
+
+Ruler can propagate entire subdirectories from `.ruler/` to agent-specific target directories, instead of concatenating their contents into the agent's main rules file. This is useful for keeping separate supporting files (prompts, examples, reference docs) organised and accessible to specific agents.
+
+### How It Works
+
+When folder propagation is enabled:
+
+1. **Root-level `.md` files** in `.ruler/` (like `AGENTS.md`, `rules.md`, etc.) are **always concatenated** into the rules file — unchanged from normal behaviour.
+2. **Listed subdirectories** (e.g., `prompts`, `examples`) are **propagated** to each agent's configured target directory and **excluded** from rule concatenation.
+3. **`skip_unmapped`** controls what happens to **unlisted** subdirectories:
+   - `false` (default): unlisted subdirectories are concatenated into rules as usual.
+   - `true`: unlisted subdirectories are skipped entirely (neither concatenated nor propagated).
+
+### Configuration
+
+Configure folder propagation in `ruler.toml`:
+
+```toml
+[folders]
+# Enable folder propagation (default: false)
+enabled = true
+# When true, unlisted subdirectories are skipped entirely (default: false)
+skip_unmapped = false
+
+# Per-agent source→target folder mappings.
+# Key = source folder name under .ruler/
+# Value = target path relative to the project root.
+[folders.agents.claude]
+prompts = ".claude/prompts"
+examples = ".claude/examples"
+
+[folders.agents.cursor]
+prompts = ".cursor/prompts"
+
+[folders.agents.copilot]
+prompts = ".github/prompts"
+```
+
+In this example, files under `.ruler/prompts/` are copied to `.claude/prompts/`, `.cursor/prompts/`, and `.github/prompts/` instead of being concatenated into `CLAUDE.md`/`AGENTS.md`.
+
+### Example
+
+Given this `.ruler/` layout:
+
+```
+.ruler/
+├── AGENTS.md            # Always concatenated
+├── coding-style.md      # Always concatenated
+├── prompts/             # Listed → propagated, NOT concatenated
+│   ├── intro.md
+│   └── review.md
+└── tools/               # Unlisted → depends on skip_unmapped
+    └── linter.md
+```
+
+With `skip_unmapped = false` (default):
+- Concatenated into rules: `AGENTS.md`, `coding-style.md`, and `tools/linter.md`
+- Propagated to agent targets: `.claude/prompts/` (with `intro.md` and `review.md`)
+
+With `skip_unmapped = true`:
+- Concatenated into rules: `AGENTS.md`, `coding-style.md`
+- Propagated: `.claude/prompts/`
+- `tools/linter.md` is skipped entirely
+
+### CLI
+
+```bash
+# Enable folder propagation (overrides TOML config)
+ruler apply --folders
+
+# Disable folder propagation
+ruler apply --no-folders
+```
+
+### Dry-Run Mode
+
+```bash
+ruler apply --dry-run --folders
+```
+
+Shows which folders would be copied without writing any files.
+
+### Cleanup
+
+When folder propagation is disabled (either via `enabled = false` in config or `--no-folders` CLI flag), all previously propagated target directories are removed on the next `ruler apply`.
+
+### `.gitignore` Integration
+
+When folder propagation is enabled and gitignore integration is active, Ruler automatically adds the configured target directories to your `.gitignore` file within the managed Ruler block.
+
 ## `.gitignore` Integration
 
 Ruler automatically manages your `.gitignore` file to keep generated agent configuration files out of version control.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@intellectronica/ruler",
-  "version": "0.3.44",
+  "version": "0.3.45",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@intellectronica/ruler",
-      "version": "0.3.44",
+      "version": "0.3.45",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intellectronica/ruler",
-  "version": "0.3.44",
+  "version": "0.3.45",
   "description": "Ruler — apply the same rules to all coding agents",
   "main": "dist/lib.js",
   "types": "dist/lib.d.ts",

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -86,6 +86,11 @@ export function run(): void {
             type: 'boolean',
             description:
               'Enable/disable subagents support (experimental, default: disabled)',
+          })
+          .option('folders', {
+            type: 'boolean',
+            description:
+              'Enable/disable folder propagation (experimental, default: from config or disabled)',
           });
       },
       applyHandler,

--- a/src/cli/handlers.ts
+++ b/src/cli/handlers.ts
@@ -22,6 +22,7 @@ export interface ApplyArgs {
   backup?: boolean;
   skills?: boolean;
   subagents?: boolean;
+  folders?: boolean;
 }
 
 export interface InitArgs {
@@ -139,6 +140,14 @@ export async function applyHandler(argv: ApplyArgs): Promise<void> {
     subagentsEnabled = undefined; // Let config/default decide
   }
 
+  // Determine folders preference: CLI > TOML > Default (disabled)
+  let foldersEnabled: boolean | undefined;
+  if (argv.folders !== undefined) {
+    foldersEnabled = argv.folders;
+  } else {
+    foldersEnabled = undefined; // Let config/default decide
+  }
+
   try {
     const agents = parseCliAgents(argv.agents);
 
@@ -165,6 +174,7 @@ export async function applyHandler(argv: ApplyArgs): Promise<void> {
       skillsEnabled,
       gitignoreLocalPreference,
       subagentsEnabled,
+      foldersEnabled,
     );
     console.log('Ruler apply completed successfully.');
   } catch (err: unknown) {

--- a/src/core/ConfigLoader.ts
+++ b/src/core/ConfigLoader.ts
@@ -11,6 +11,7 @@ import {
   BackupConfig,
   SkillsConfig,
   SubagentsConfig,
+  FoldersConfig,
 } from '../types';
 import { createRulerError, logWarn } from '../constants';
 
@@ -123,6 +124,14 @@ const rulerConfigSchema = z
       .strict()
       .optional(),
     nested: z.boolean().optional(),
+    folders: z
+      .object({
+        enabled: z.boolean().optional(),
+        skip_unmapped: z.boolean().optional(),
+        agents: z.record(z.string(), z.record(z.string(), z.string())).optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict();
 
@@ -241,6 +250,8 @@ export interface LoadedConfig {
   nested?: boolean;
   /** Whether the nested option was explicitly provided in the config. */
   nestedDefined?: boolean;
+  /** Folders configuration for propagating sub-directories. */
+  folders?: FoldersConfig;
 }
 
 /**
@@ -429,6 +440,43 @@ export async function loadConfig(
   const nestedDefined = typeof raw.nested === 'boolean';
   const nested = nestedDefined ? (raw.nested as boolean) : false;
 
+  const rawFoldersSection =
+    raw.folders && typeof raw.folders === 'object' && !Array.isArray(raw.folders)
+      ? (raw.folders as Record<string, unknown>)
+      : {};
+  const foldersConfig: FoldersConfig = {};
+  if (typeof rawFoldersSection.enabled === 'boolean') {
+    foldersConfig.enabled = rawFoldersSection.enabled;
+  }
+  if (typeof rawFoldersSection.skip_unmapped === 'boolean') {
+    foldersConfig.skip_unmapped = rawFoldersSection.skip_unmapped;
+  }
+  if (
+    rawFoldersSection.agents &&
+    typeof rawFoldersSection.agents === 'object' &&
+    !Array.isArray(rawFoldersSection.agents)
+  ) {
+    const agentsRaw = rawFoldersSection.agents as Record<string, unknown>;
+    const agents: Record<string, Record<string, string>> = {};
+    for (const [agentId, mappings] of Object.entries(agentsRaw)) {
+      if (mappings && typeof mappings === 'object' && !Array.isArray(mappings)) {
+        const mappingObj = mappings as Record<string, unknown>;
+        const parsed: Record<string, string> = {};
+        for (const [source, target] of Object.entries(mappingObj)) {
+          if (typeof target === 'string') {
+            parsed[source] = target;
+          }
+        }
+        if (Object.keys(parsed).length > 0) {
+          agents[agentId] = parsed;
+        }
+      }
+    }
+    if (Object.keys(agents).length > 0) {
+      foldersConfig.agents = agents;
+    }
+  }
+
   return {
     defaultAgents,
     agentConfigs,
@@ -440,6 +488,7 @@ export async function loadConfig(
     subagents: subagentsConfig,
     nested,
     nestedDefined,
+    folders: foldersConfig,
   };
 }
 

--- a/src/core/FileSystemUtils.ts
+++ b/src/core/FileSystemUtils.ts
@@ -177,6 +177,18 @@ export interface ReadMarkdownFilesOptions {
    * omitted, `.ruler/agents/` is skipped, mirroring `.ruler/skills/`.
    */
   includeAgents?: boolean;
+  /**
+   * Subdirectory names (basenames) to skip during markdown file collection.
+   * Used by the folders feature to exclude propagated subdirectories
+   * from concatenation.
+   */
+  skipDirectories?: string[];
+  /**
+   * When true, ALL subdirectories that are not explicitly listed in
+   * `skipDirectories` are also skipped. Root-level `.md` files are
+   * always included regardless.
+   */
+  skipUnmapped?: boolean;
 }
 
 /**
@@ -250,6 +262,22 @@ export async function readMarkdownFiles(
           relativeFromRoot.startsWith(`${SUBAGENTS_DIR_NAME}${path.sep}`);
         if (isAgentsDir && !includeAgents) {
           sawExcludedAgents = true;
+          continue;
+        }
+        // Skip directories listed in skipDirectories (used by folders feature)
+        const isFirstLevel =
+          relativeFromRoot.indexOf(path.sep) === -1 &&
+          relativeFromRoot !== '';
+        if (isFirstLevel && options.skipDirectories?.includes(entry.name)) {
+          continue;
+        }
+        // When skipUnmapped is true, skip any first-level subdirectory
+        // that is not explicitly listed in skipDirectories.
+        if (
+          isFirstLevel &&
+          options.skipUnmapped &&
+          !options.skipDirectories?.includes(entry.name)
+        ) {
           continue;
         }
         await walk(fullPath);

--- a/src/core/FoldersProcessor.ts
+++ b/src/core/FoldersProcessor.ts
@@ -1,0 +1,259 @@
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import type { FoldersConfig } from '../types';
+import type { IAgent } from '../agents/IAgent';
+import { assertManagedPathInsideRoot } from './FileSystemUtils';
+import { logWarn, logVerboseInfo } from '../constants';
+
+async function dirExists(dirPath: string): Promise<boolean> {
+  try {
+    await fs.access(dirPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function copyRecursive(src: string, dest: string): Promise<void> {
+  const stat = await fs.lstat(src);
+
+  if (stat.isSymbolicLink()) {
+    return;
+  }
+
+  if (stat.isDirectory()) {
+    await fs.mkdir(dest, { recursive: true });
+    const entries = await fs.readdir(src, { withFileTypes: true });
+    for (const entry of entries) {
+      const srcPath = path.join(src, entry.name);
+      const destPath = path.join(dest, entry.name);
+      await copyRecursive(srcPath, destPath);
+    }
+  } else {
+    await fs.copyFile(src, dest);
+  }
+}
+
+async function removeDirectory(
+  targetPath: string,
+  projectRoot: string,
+): Promise<void> {
+  await assertManagedPathInsideRoot(
+    targetPath,
+    projectRoot,
+    'Refusing to remove folder through symlinked path',
+  );
+  await fs.rm(targetPath, { recursive: true, force: true });
+}
+
+/**
+ * Collects all source folder names that are configured for propagation
+ * across all agents in the folders config. Used to determine which
+ * subdirectories to skip during rule concatenation.
+ */
+export function getFolderSkipDirectories(folders?: FoldersConfig): string[] {
+  if (!folders?.enabled || !folders.agents) {
+    return [];
+  }
+  const seen = new Set<string>();
+  for (const mappings of Object.values(folders.agents)) {
+    for (const source of Object.keys(mappings)) {
+      seen.add(source);
+    }
+  }
+  return Array.from(seen);
+}
+
+/**
+ * Returns whether `skip_unmapped` is enabled in the folders config.
+ */
+export function getFolderSkipUnmapped(folders?: FoldersConfig): boolean {
+  return folders?.enabled === true && folders?.skip_unmapped === true;
+}
+
+/**
+ * Propagates configured folders from `.ruler/<source>/` to each agent's
+ * target path.
+ *
+ * When folders are disabled, previously propagated folders are cleaned up
+ * (removed) based on the agent mappings in the config.
+ */
+export async function propagateFolders(
+  projectRoot: string,
+  agents: IAgent[],
+  folders: FoldersConfig | undefined,
+  verbose: boolean,
+  dryRun: boolean,
+): Promise<{ generatedPaths: string[] }> {
+  const generatedPaths: string[] = [];
+
+  if (!folders?.enabled || !folders.agents) {
+    // Clean up previously propagated folders when disabled
+    if (folders && Object.keys(folders.agents ?? {}).length > 0) {
+      logVerboseInfo(
+        'Folders support disabled, cleaning up propagated directories',
+        verbose,
+        dryRun,
+      );
+      await cleanupFolderTargets(projectRoot, folders, verbose, dryRun);
+    } else {
+      logVerboseInfo(
+        'Folders support disabled or no folder mappings configured',
+        verbose,
+        dryRun,
+      );
+    }
+    return { generatedPaths };
+  }
+
+  const rulerDir = path.join(projectRoot, '.ruler');
+  const rulerDirExists = await dirExists(rulerDir);
+  if (!rulerDirExists) {
+    logVerboseInfo(
+      'No .ruler directory found, skipping folder propagation',
+      verbose,
+      dryRun,
+    );
+    return { generatedPaths };
+  }
+
+  // Collect target paths from all agents for gitignore
+  for (const [agentId, mappings] of Object.entries(folders.agents)) {
+    // Check if this agent is in the selected agents list
+    const isAgentSelected = agents.some(
+      (a) => a.getIdentifier() === agentId,
+    );
+    if (!isAgentSelected) {
+      continue;
+    }
+
+    for (const [source, target] of Object.entries(mappings)) {
+      const sourcePath = path.join(rulerDir, source);
+      const targetPath = path.resolve(projectRoot, target);
+
+      if (!(await dirExists(sourcePath))) {
+        logVerboseInfo(
+          `Source folder .ruler/${source} not found for agent ${agentId}, skipping`,
+          verbose,
+          dryRun,
+        );
+        continue;
+      }
+
+      // Track for gitignore (use relative path from project root)
+      const relativeTarget = path.relative(projectRoot, targetPath);
+      const normalizedTarget = relativeTarget.replace(/\\/g, '/');
+      if (!generatedPaths.includes(normalizedTarget)) {
+        generatedPaths.push(normalizedTarget);
+      }
+
+      if (dryRun) {
+        logVerboseInfo(
+          `DRY RUN: Would copy .ruler/${source}/ → ${normalizedTarget}/ for ${agentId}`,
+          verbose,
+          dryRun,
+        );
+      } else {
+        await assertManagedPathInsideRoot(
+          targetPath,
+          projectRoot,
+          `Refusing to write folder for ${agentId} outside project`,
+        );
+
+        // Remove existing target if it exists
+        try {
+          await removeDirectory(targetPath, projectRoot);
+        } catch {
+          // Target didn't exist, that's fine
+        }
+
+        // Ensure parent directory exists
+        await fs.mkdir(path.dirname(targetPath), { recursive: true });
+
+        // Recursively copy source → target
+        await copyRecursive(sourcePath, targetPath);
+
+        logVerboseInfo(
+          `Copied .ruler/${source}/ → ${normalizedTarget}/ for ${agentId}`,
+          verbose,
+          dryRun,
+        );
+      }
+    }
+  }
+
+  return { generatedPaths };
+}
+
+async function cleanupFolderTargets(
+  projectRoot: string,
+  folders: FoldersConfig,
+  verbose: boolean,
+  dryRun: boolean,
+): Promise<void> {
+  if (!folders.agents) return;
+
+  for (const mappings of Object.values(folders.agents)) {
+    for (const target of Object.values(mappings)) {
+      const targetPath = path.resolve(projectRoot, target);
+      const relativeTarget = path.relative(projectRoot, targetPath);
+
+      if (await dirExists(targetPath)) {
+        if (dryRun) {
+          logVerboseInfo(
+            `DRY RUN: Would remove ${relativeTarget}/`,
+            verbose,
+            dryRun,
+          );
+        } else {
+          try {
+            await removeDirectory(targetPath, projectRoot);
+            logVerboseInfo(
+              `Removed ${relativeTarget}/ (folders disabled)`,
+              verbose,
+              dryRun,
+            );
+          } catch (err) {
+            logWarn(
+              `Failed to remove ${relativeTarget}/: ${(err as Error).message}`,
+              dryRun,
+            );
+          }
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Returns absolute paths that folder propagation may generate, for gitignore
+ * integration.
+ */
+export async function getFoldersGitignorePaths(
+  projectRoot: string,
+  agents: IAgent[],
+  folders: FoldersConfig | undefined,
+): Promise<string[]> {
+  if (!folders?.enabled || !folders.agents) {
+    return [];
+  }
+
+  const paths: string[] = [];
+
+  for (const [agentId, mappings] of Object.entries(folders.agents)) {
+    const isAgentSelected = agents.some(
+      (a) => a.getIdentifier() === agentId,
+    );
+    if (!isAgentSelected) {
+      continue;
+    }
+
+    for (const target of Object.values(mappings)) {
+      const resolved = path.resolve(projectRoot, target);
+      const relative = path.relative(projectRoot, resolved);
+      paths.push(relative.replace(/\\/g, '/'));
+    }
+  }
+
+  return paths;
+}

--- a/src/core/apply-engine.ts
+++ b/src/core/apply-engine.ts
@@ -26,6 +26,10 @@ import {
   logWarn,
 } from '../constants';
 import { McpStrategy } from '../types';
+import {
+  getFolderSkipDirectories,
+  getFolderSkipUnmapped,
+} from './FoldersProcessor';
 
 /**
  * Configuration data loaded from the ruler setup
@@ -77,6 +81,8 @@ async function loadNestedConfigurations(
     );
     const files = await FileSystemUtils.readMarkdownFiles(rulerDir, {
       includeAgents: shouldIncludeAgentsInRules(config),
+      skipDirectories: getFolderSkipDirectories(config.folders),
+      skipUnmapped: getFolderSkipUnmapped(config.folders),
     });
     results.push(
       await createHierarchicalConfiguration(
@@ -208,6 +214,19 @@ function cloneLoadedConfig(config: LoadedConfig): LoadedConfig {
     backup: config.backup ? { ...config.backup } : undefined,
     skills: config.skills ? { ...config.skills } : undefined,
     subagents: config.subagents ? { ...config.subagents } : undefined,
+    folders: config.folders
+      ? {
+          ...config.folders,
+          agents: config.folders.agents
+            ? Object.fromEntries(
+                Object.entries(config.folders.agents).map(([k, v]) => [
+                  k,
+                  { ...v },
+                ]),
+              )
+            : undefined,
+        }
+      : undefined,
     nested: config.nested,
     nestedDefined: config.nestedDefined,
   };
@@ -299,6 +318,8 @@ async function loadSingleConfiguration(
   // `[agents] include_in_rules = true`.
   const files = await FileSystemUtils.readMarkdownFiles(rulerDirs[0], {
     includeAgents: shouldIncludeAgentsInRules(config),
+    skipDirectories: getFolderSkipDirectories(config.folders),
+    skipUnmapped: getFolderSkipUnmapped(config.folders),
   });
 
   // Concatenate rules

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -34,6 +34,21 @@ function resolveSkillsEnabled(
 }
 
 /**
+ * Resolves folders enabled state based on precedence:
+ * CLI flag > ruler.toml > default (disabled).
+ */
+function resolveFoldersEnabled(
+  cliFlag: boolean | undefined,
+  configSetting: boolean | undefined,
+): boolean {
+  return cliFlag !== undefined
+    ? cliFlag
+    : configSetting !== undefined
+      ? configSetting
+      : false; // default to disabled
+}
+
+/**
  * Resolves backup enabled state based on precedence:
  * CLI flag > ruler.toml > default (enabled).
  */
@@ -99,6 +114,7 @@ export async function applyAllAgentConfigs(
   skillsEnabled?: boolean,
   cliGitignoreLocal?: boolean,
   subagentsEnabled?: boolean,
+  foldersEnabled?: boolean,
 ): Promise<void> {
   // Load configuration and rules
   logVerbose(
@@ -113,6 +129,7 @@ export async function applyAllAgentConfigs(
   let generatedPaths: string[];
   let loadedConfig: LoadedConfig;
   let outputProjectRoot = projectRoot;
+  const accumulatorFolderPaths: string[] = [];
 
   if (nested) {
     const hierarchicalConfigs = await loadNestedConfigurations(
@@ -214,6 +231,34 @@ export async function applyAllAgentConfigs(
       }
     }
 
+    // Propagate folders for each nested .ruler directory.
+    {
+      const { propagateFolders } = await import('./core/FoldersProcessor');
+      for (const configEntry of hierarchicalConfigs) {
+        const nestedRoot = path.dirname(configEntry.rulerDir);
+        const resolvedNestedFoldersEnabled = resolveFoldersEnabled(
+          foldersEnabled,
+          configEntry.config.folders?.enabled,
+        );
+        const effectiveNestedFolders = {
+          ...configEntry.config.folders,
+          enabled: resolvedNestedFoldersEnabled,
+        };
+        logVerbose(
+          `Propagating folders for nested directory: ${nestedRoot}`,
+          verbose,
+        );
+        const { generatedPaths: folderPaths } = await propagateFolders(
+          nestedRoot,
+          selectedAgents,
+          effectiveNestedFolders,
+          verbose,
+          dryRun,
+        );
+        accumulatorFolderPaths.push(...folderPaths);
+      }
+    }
+
     generatedPaths = await processHierarchicalConfigurations(
       selectedAgents,
       hierarchicalConfigs,
@@ -292,6 +337,27 @@ export async function applyAllAgentConfigs(
       );
     }
 
+    // Propagate folders if enabled
+    {
+      const { propagateFolders } = await import('./core/FoldersProcessor');
+      const resolvedSingleFoldersEnabled = resolveFoldersEnabled(
+        foldersEnabled,
+        singleConfig.config.folders?.enabled,
+      );
+      const effectiveSingleFolders = {
+        ...singleConfig.config.folders,
+        enabled: resolvedSingleFoldersEnabled,
+      };
+      const { generatedPaths: folderPaths } = await propagateFolders(
+        singleProjectRoot,
+        selectedAgents,
+        effectiveSingleFolders,
+        verbose,
+        dryRun,
+      );
+      accumulatorFolderPaths.push(...folderPaths);
+    }
+
     generatedPaths = await processSingleConfiguration(
       selectedAgents,
       singleConfig,
@@ -304,8 +370,8 @@ export async function applyAllAgentConfigs(
     );
   }
 
-  // Add skills-generated paths to gitignore if skills are enabled
-  let allGeneratedPaths = generatedPaths;
+  // Merge folder propagation paths into generated paths for gitignore
+  let allGeneratedPaths = [...generatedPaths, ...accumulatorFolderPaths];
   const skillsEnabledForGitignore = resolveSkillsEnabled(
     skillsEnabled,
     loadedConfig.skills?.enabled,
@@ -334,6 +400,27 @@ export async function applyAllAgentConfigs(
       selectedAgents,
     );
     allGeneratedPaths = [...allGeneratedPaths, ...subagentPaths];
+  }
+
+  // Add folder propagation paths to gitignore if folders are enabled.
+  const resolvedFoldersEnabled = resolveFoldersEnabled(
+    foldersEnabled,
+    loadedConfig.folders?.enabled,
+  );
+  if (resolvedFoldersEnabled) {
+    const { getFoldersGitignorePaths } = await import(
+      './core/FoldersProcessor'
+    );
+    const effectiveFoldersForGitignore = {
+      ...loadedConfig.folders,
+      enabled: resolvedFoldersEnabled,
+    };
+    const folderPaths = await getFoldersGitignorePaths(
+      outputProjectRoot,
+      selectedAgents,
+      effectiveFoldersForGitignore,
+    );
+    allGeneratedPaths = [...allGeneratedPaths, ...folderPaths];
   }
 
   await updateGitignore(

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,6 +67,24 @@ export interface SubagentsConfig {
   include_in_rules?: boolean;
 }
 
+/** Folders configuration for propagating sub-directories to agent config directories. */
+export interface FoldersConfig {
+  /** Enable or disable folder propagation. Default: false. */
+  enabled?: boolean;
+  /**
+   * When true, unlisted subdirectories under .ruler/ are skipped entirely
+   * (neither concatenated nor propagated). When false (default), unlisted
+   * subdirectories are concatenated into rules as usual.
+   */
+  skip_unmapped?: boolean;
+  /**
+   * Per-agent mappings: agent_id -> { source_folder_name -> target_path }.
+   * Source keys are subdirectory names under .ruler/.
+   * Target values are paths relative to the project root.
+   */
+  agents?: Record<string, Record<string, string>>;
+}
+
 /** Frontmatter fields recognised on a source subagent definition. */
 export interface SubagentFrontmatter {
   name: string;

--- a/tests/integration/folder-propagation.test.ts
+++ b/tests/integration/folder-propagation.test.ts
@@ -1,0 +1,411 @@
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import { applyAllAgentConfigs } from '../../src/lib';
+
+describe('Folder Propagation', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'ruler-folder-test-'),
+    );
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('propagates listed folders and concatenates root files when enabled', async () => {
+    // Setup .ruler directory
+    const rulerDir = path.join(tmpDir, '.ruler');
+    const promptsDir = path.join(rulerDir, 'prompts');
+
+    await fs.mkdir(promptsDir, { recursive: true });
+    await fs.writeFile(path.join(rulerDir, 'AGENTS.md'), '# Root Rules');
+    await fs.writeFile(path.join(rulerDir, 'style.md'), '## Style Guide');
+    await fs.writeFile(path.join(promptsDir, 'intro.md'), '# Prompt Intro');
+    await fs.writeFile(path.join(promptsDir, 'review.md'), '# Code Review');
+
+    // Create ruler.toml with folders enabled
+    await fs.writeFile(
+      path.join(rulerDir, 'ruler.toml'),
+      `
+[folders]
+enabled = true
+skip_unmapped = false
+
+[folders.agents.claude]
+prompts = ".claude/prompts"
+`,
+    );
+
+    await applyAllAgentConfigs(
+      tmpDir,
+      ['claude'],
+      undefined,
+      true,
+      undefined,
+      undefined,
+      false,
+      false,
+      false,
+      false,
+      true,
+      undefined,
+      undefined,
+      undefined, // foldersEnabled → undefined, rely on config
+    );
+
+    // Root files should still be concatenated into CLAUDE.md
+    const claudeMd = await fs.readFile(path.join(tmpDir, 'CLAUDE.md'), 'utf8');
+    expect(claudeMd).toContain('# Root Rules');
+    expect(claudeMd).toContain('## Style Guide');
+    // Propagated folder files should NOT be in CLAUDE.md
+    expect(claudeMd).not.toContain('# Prompt Intro');
+    expect(claudeMd).not.toContain('# Code Review');
+
+    // Propagated folder should exist at target
+    const promptsTarget = path.join(tmpDir, '.claude', 'prompts');
+    const introContent = await fs.readFile(
+      path.join(promptsTarget, 'intro.md'),
+      'utf8',
+    );
+    expect(introContent).toBe('# Prompt Intro');
+    const reviewContent = await fs.readFile(
+      path.join(promptsTarget, 'review.md'),
+      'utf8',
+    );
+    expect(reviewContent).toBe('# Code Review');
+  });
+
+  it('skips unlisted subdirs when skip_unmapped is true', async () => {
+    const rulerDir = path.join(tmpDir, '.ruler');
+
+    await fs.mkdir(path.join(rulerDir, 'prompts'), { recursive: true });
+    await fs.mkdir(path.join(rulerDir, 'tools'), { recursive: true });
+    await fs.writeFile(path.join(rulerDir, 'AGENTS.md'), '# Root');
+    await fs.writeFile(path.join(rulerDir, 'prompts', 'intro.md'), '# Intro');
+    await fs.writeFile(path.join(rulerDir, 'tools', 'linter.md'), '# Linter');
+
+    await fs.writeFile(
+      path.join(rulerDir, 'ruler.toml'),
+      `
+[folders]
+enabled = true
+skip_unmapped = true
+
+[folders.agents.claude]
+prompts = ".claude/prompts"
+`,
+    );
+
+    await applyAllAgentConfigs(
+      tmpDir,
+      ['claude'],
+      undefined,
+      true,
+      undefined,
+      undefined,
+      false,
+      false,
+      false,
+      false,
+      true,
+      undefined,
+      undefined,
+      undefined,
+    );
+
+    const claudeMd = await fs.readFile(path.join(tmpDir, 'CLAUDE.md'), 'utf8');
+    // Root file is still concatenated
+    expect(claudeMd).toContain('# Root');
+    // Propagated folder is not in CLAUDE.md
+    expect(claudeMd).not.toContain('# Intro');
+    // Unlisted tools dir is also NOT in CLAUDE.md (skip_unmapped = true)
+    expect(claudeMd).not.toContain('# Linter');
+
+    // Propagated folder exists
+    const promptsTarget = path.join(tmpDir, '.claude', 'prompts');
+    expect(
+      await fs.readFile(path.join(promptsTarget, 'intro.md'), 'utf8'),
+    ).toBe('# Intro');
+
+    // Unlisted tools dir was NOT propagated
+    const toolsTarget = path.join(tmpDir, '.claude', 'tools');
+    await expect(fs.access(toolsTarget)).rejects.toThrow();
+  });
+
+  it('concatenates unlisted subdirs by default when skip_unmapped is false', async () => {
+    const rulerDir = path.join(tmpDir, '.ruler');
+
+    await fs.mkdir(path.join(rulerDir, 'prompts'), { recursive: true });
+    await fs.mkdir(path.join(rulerDir, 'tools'), { recursive: true });
+    await fs.writeFile(path.join(rulerDir, 'AGENTS.md'), '# Root');
+    await fs.writeFile(path.join(rulerDir, 'prompts', 'intro.md'), '# Intro');
+    await fs.writeFile(path.join(rulerDir, 'tools', 'linter.md'), '# Linter');
+
+    await fs.writeFile(
+      path.join(rulerDir, 'ruler.toml'),
+      `
+[folders]
+enabled = true
+skip_unmapped = false
+
+[folders.agents.claude]
+prompts = ".claude/prompts"
+`,
+    );
+
+    await applyAllAgentConfigs(
+      tmpDir,
+      ['claude'],
+      undefined,
+      true,
+      undefined,
+      undefined,
+      false,
+      false,
+      false,
+      false,
+      true,
+      undefined,
+      undefined,
+      undefined,
+    );
+
+    const claudeMd = await fs.readFile(path.join(tmpDir, 'CLAUDE.md'), 'utf8');
+    // Root file is still concatenated
+    expect(claudeMd).toContain('# Root');
+    // Propagated folder is NOT in CLAUDE.md
+    expect(claudeMd).not.toContain('# Intro');
+    // Unlisted tools dir IS concatenated (skip_unmapped = false)
+    expect(claudeMd).toContain('# Linter');
+
+    // Propagated folder exists
+    const promptsTarget = path.join(tmpDir, '.claude', 'prompts');
+    expect(
+      await fs.readFile(path.join(promptsTarget, 'intro.md'), 'utf8'),
+    ).toBe('# Intro');
+  });
+
+  it('does not propagate when folders is disabled', async () => {
+    const rulerDir = path.join(tmpDir, '.ruler');
+
+    await fs.mkdir(path.join(rulerDir, 'prompts'), { recursive: true });
+    await fs.writeFile(path.join(rulerDir, 'AGENTS.md'), '# Root');
+    await fs.writeFile(path.join(rulerDir, 'prompts', 'intro.md'), '# Intro');
+
+    await fs.writeFile(
+      path.join(rulerDir, 'ruler.toml'),
+      `
+[folders]
+enabled = false
+
+[folders.agents.claude]
+prompts = ".claude/prompts"
+`,
+    );
+
+    await applyAllAgentConfigs(
+      tmpDir,
+      ['claude'],
+      undefined,
+      true,
+      undefined,
+      undefined,
+      false,
+      false,
+      false,
+      false,
+      true,
+      undefined,
+      undefined,
+      undefined,
+    );
+
+    // Everything is concatenated as normal
+    const claudeMd = await fs.readFile(path.join(tmpDir, 'CLAUDE.md'), 'utf8');
+    expect(claudeMd).toContain('# Root');
+    expect(claudeMd).toContain('# Intro');
+
+    // No propagated folder
+    const promptsTarget = path.join(tmpDir, '.claude', 'prompts');
+    await expect(fs.access(promptsTarget)).rejects.toThrow();
+  });
+
+  it('only propagates to selected agents', async () => {
+    const rulerDir = path.join(tmpDir, '.ruler');
+
+    await fs.mkdir(path.join(rulerDir, 'prompts'), { recursive: true });
+    await fs.writeFile(path.join(rulerDir, 'AGENTS.md'), '# Root');
+    await fs.writeFile(path.join(rulerDir, 'prompts', 'intro.md'), '# Intro');
+
+    await fs.writeFile(
+      path.join(rulerDir, 'ruler.toml'),
+      `
+[folders]
+enabled = true
+
+[folders.agents.claude]
+prompts = ".claude/prompts"
+
+[folders.agents.cursor]
+prompts = ".cursor/prompts"
+`,
+    );
+
+    // Only apply for claude, not cursor
+    await applyAllAgentConfigs(
+      tmpDir,
+      ['claude'],
+      undefined,
+      true,
+      undefined,
+      undefined,
+      false,
+      false,
+      false,
+      false,
+      true,
+      undefined,
+      undefined,
+      undefined,
+    );
+
+    // Claude should have the propagated folder
+    const claudeTarget = path.join(tmpDir, '.claude', 'prompts');
+    expect(await fs.readFile(path.join(claudeTarget, 'intro.md'), 'utf8')).toBe(
+      '# Intro',
+    );
+
+    // Cursor should NOT have the propagated folder (not selected)
+    const cursorTarget = path.join(tmpDir, '.cursor', 'prompts');
+    await expect(fs.access(cursorTarget)).rejects.toThrow();
+  });
+
+  it('cleans up propagated folders when disabled after being enabled', async () => {
+    const rulerDir = path.join(tmpDir, '.ruler');
+
+    await fs.mkdir(path.join(rulerDir, 'prompts'), { recursive: true });
+    await fs.writeFile(path.join(rulerDir, 'AGENTS.md'), '# Root');
+    await fs.writeFile(path.join(rulerDir, 'prompts', 'intro.md'), '# Intro');
+
+    // First apply with folders enabled
+    await fs.writeFile(
+      path.join(rulerDir, 'ruler.toml'),
+      `
+[folders]
+enabled = true
+
+[folders.agents.claude]
+prompts = ".claude/prompts"
+`,
+    );
+
+    await applyAllAgentConfigs(
+      tmpDir,
+      ['claude'],
+      undefined,
+      true,
+      undefined,
+      undefined,
+      false,
+      false,
+      false,
+      false,
+      true,
+      undefined,
+      undefined,
+      undefined,
+    );
+
+    // Verify folder was propagated
+    const promptsTarget = path.join(tmpDir, '.claude', 'prompts');
+    expect(
+      await fs.readFile(path.join(promptsTarget, 'intro.md'), 'utf8'),
+    ).toBe('# Intro');
+
+    // Now disable folders
+    await fs.writeFile(
+      path.join(rulerDir, 'ruler.toml'),
+      `
+[folders]
+enabled = false
+
+[folders.agents.claude]
+prompts = ".claude/prompts"
+`,
+    );
+
+    await applyAllAgentConfigs(
+      tmpDir,
+      ['claude'],
+      undefined,
+      true,
+      undefined,
+      undefined,
+      false,
+      false,
+      false,
+      false,
+      true,
+      undefined,
+      undefined,
+      undefined,
+    );
+
+    // Propagated folder should be cleaned up
+    await expect(fs.access(promptsTarget)).rejects.toThrow();
+
+    // Files should be concatenated again
+    const claudeMd = await fs.readFile(path.join(tmpDir, 'CLAUDE.md'), 'utf8');
+    expect(claudeMd).toContain('# Intro');
+  });
+
+  it('CLI --folders flag overrides TOML config', async () => {
+    const rulerDir = path.join(tmpDir, '.ruler');
+
+    await fs.mkdir(path.join(rulerDir, 'prompts'), { recursive: true });
+    await fs.writeFile(path.join(rulerDir, 'AGENTS.md'), '# Root');
+
+    await fs.writeFile(path.join(rulerDir, 'prompts', 'intro.md'), '# Intro');
+
+    // TOML says disabled
+    await fs.writeFile(
+      path.join(rulerDir, 'ruler.toml'),
+      `
+[folders]
+enabled = false
+
+[folders.agents.claude]
+prompts = ".claude/prompts"
+`,
+    );
+
+    // CLI flag says enabled (overrides TOML)
+    await applyAllAgentConfigs(
+      tmpDir,
+      ['claude'],
+      undefined,
+      true,
+      undefined,
+      undefined,
+      false,
+      false,
+      false,
+      false,
+      true,
+      undefined,
+      undefined,
+      undefined,
+      true, // foldersEnabled = true
+    );
+
+    // Folder should be propagated because CLI overrides TOML
+    const promptsTarget = path.join(tmpDir, '.claude', 'prompts');
+    expect(
+      await fs.readFile(path.join(promptsTarget, 'intro.md'), 'utf8'),
+    ).toBe('# Intro');
+  });
+});

--- a/tests/integration/nested-folder-propagation.test.ts
+++ b/tests/integration/nested-folder-propagation.test.ts
@@ -1,0 +1,207 @@
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import { applyAllAgentConfigs } from '../../src/lib';
+import { setupTestProject, teardownTestProject } from '../harness';
+
+describe('Nested folder propagation', () => {
+  let projectRoot: string;
+
+  beforeEach(async () => {
+    ({ projectRoot } = await setupTestProject());
+  });
+
+  afterEach(async () => {
+    await teardownTestProject(projectRoot);
+  });
+
+  it('propagates root-level folders in nested mode', async () => {
+    const rulerDir = path.join(projectRoot, '.ruler');
+    const promptsDir = path.join(rulerDir, 'prompts');
+    await fs.mkdir(promptsDir, { recursive: true });
+    await fs.writeFile(path.join(rulerDir, 'AGENTS.md'), '# Root Rules');
+    await fs.writeFile(path.join(promptsDir, 'intro.md'), '# Root Prompt');
+
+    await fs.writeFile(
+      path.join(rulerDir, 'ruler.toml'),
+      `
+default_agents = ["claude"]
+nested = true
+
+[folders]
+enabled = true
+
+[folders.agents.claude]
+prompts = ".claude/prompts"
+`,
+    );
+
+    await applyAllAgentConfigs(
+      projectRoot,
+      ['claude'],
+      undefined,
+      true,
+      undefined,
+      undefined,
+      false,
+      false,
+      false,
+      true,
+      true,
+    );
+
+    const claudeMd = await fs.readFile(
+      path.join(projectRoot, 'CLAUDE.md'),
+      'utf8',
+    );
+    expect(claudeMd).toContain('# Root Rules');
+    expect(claudeMd).not.toContain('# Root Prompt');
+
+    const promptContent = await fs.readFile(
+      path.join(projectRoot, '.claude', 'prompts', 'intro.md'),
+      'utf8',
+    );
+    expect(promptContent).toBe('# Root Prompt');
+  });
+
+  it('propagates module-level folders in nested mode', async () => {
+    const moduleDir = path.join(projectRoot, 'packages', 'core');
+    const moduleRulerDir = path.join(moduleDir, '.ruler');
+    const modulePromptsDir = path.join(moduleRulerDir, 'prompts');
+    await fs.mkdir(modulePromptsDir, { recursive: true });
+    await fs.writeFile(path.join(moduleRulerDir, 'AGENTS.md'), '# Module Rules');
+    await fs.writeFile(path.join(modulePromptsDir, 'intro.md'), '# Module Prompt');
+
+    await fs.writeFile(
+      path.join(moduleRulerDir, 'ruler.toml'),
+      `
+default_agents = ["claude"]
+nested = true
+
+[folders]
+enabled = true
+
+[folders.agents.claude]
+prompts = ".claude/prompts"
+`,
+    );
+
+    await applyAllAgentConfigs(
+      projectRoot,
+      ['claude'],
+      undefined,
+      true,
+      undefined,
+      undefined,
+      false,
+      false,
+      false,
+      true,
+      true,
+    );
+
+    const moduleClaudeMd = await fs.readFile(
+      path.join(moduleDir, 'CLAUDE.md'),
+      'utf8',
+    );
+    expect(moduleClaudeMd).toContain('# Module Rules');
+    expect(moduleClaudeMd).not.toContain('# Module Prompt');
+
+    const promptContent = await fs.readFile(
+      path.join(moduleDir, '.claude', 'prompts', 'intro.md'),
+      'utf8',
+    );
+    expect(promptContent).toBe('# Module Prompt');
+
+    await expect(
+      fs.access(path.join(projectRoot, '.claude', 'prompts')),
+    ).rejects.toThrow();
+  });
+
+  it('isolates root and module folder propagation', async () => {
+    const rulerDir = path.join(projectRoot, '.ruler');
+    const rootPromptsDir = path.join(rulerDir, 'prompts');
+    await fs.mkdir(rootPromptsDir, { recursive: true });
+    await fs.writeFile(path.join(rulerDir, 'AGENTS.md'), '# Root Rules');
+    await fs.writeFile(path.join(rootPromptsDir, 'intro.md'), '# Root Prompt');
+
+    const moduleDir = path.join(projectRoot, 'packages', 'core');
+    const moduleRulerDir = path.join(moduleDir, '.ruler');
+    const moduleTemplatesDir = path.join(moduleRulerDir, 'templates');
+    await fs.mkdir(moduleTemplatesDir, { recursive: true });
+    await fs.writeFile(path.join(moduleRulerDir, 'AGENTS.md'), '# Module Rules');
+    await fs.writeFile(
+      path.join(moduleTemplatesDir, 'readme.md'),
+      '# Module Template',
+    );
+
+    const rootToml = `
+default_agents = ["claude"]
+nested = true
+
+[folders]
+enabled = true
+
+[folders.agents.claude]
+prompts = ".claude/prompts"
+`;
+
+    const moduleToml = `
+default_agents = ["claude"]
+nested = true
+
+[folders]
+enabled = true
+
+[folders.agents.claude]
+templates = ".claude/templates"
+`;
+
+    await Promise.all([
+      fs.writeFile(path.join(rulerDir, 'ruler.toml'), rootToml),
+      fs.writeFile(path.join(moduleRulerDir, 'ruler.toml'), moduleToml),
+    ]);
+
+    await applyAllAgentConfigs(
+      projectRoot,
+      ['claude'],
+      undefined,
+      true,
+      undefined,
+      undefined,
+      false,
+      false,
+      false,
+      true,
+      true,
+    );
+
+    const rootClaudeMd = await fs.readFile(
+      path.join(projectRoot, 'CLAUDE.md'),
+      'utf8',
+    );
+    expect(rootClaudeMd).toContain('# Root Rules');
+    expect(rootClaudeMd).not.toContain('# Root Prompt');
+    expect(rootClaudeMd).not.toContain('# Module Rules');
+    expect(rootClaudeMd).not.toContain('# Module Template');
+
+    const rootPrompt = await fs.readFile(
+      path.join(projectRoot, '.claude', 'prompts', 'intro.md'),
+      'utf8',
+    );
+    expect(rootPrompt).toBe('# Root Prompt');
+
+    const moduleTemplate = await fs.readFile(
+      path.join(moduleDir, '.claude', 'templates', 'readme.md'),
+      'utf8',
+    );
+    expect(moduleTemplate).toBe('# Module Template');
+
+    await expect(
+      fs.access(path.join(projectRoot, '.claude', 'templates')),
+    ).rejects.toThrow();
+
+    await expect(
+      fs.access(path.join(moduleDir, '.claude', 'prompts')),
+    ).rejects.toThrow();
+  });
+});

--- a/tests/unit/cli/handlers.test.ts
+++ b/tests/unit/cli/handlers.test.ts
@@ -68,6 +68,7 @@ describe('CLI Handlers', () => {
         undefined,
         undefined,
         undefined,
+        undefined,
       );
     });
 
@@ -164,6 +165,7 @@ describe('CLI Handlers', () => {
         undefined,
         undefined,
         undefined,
+        undefined,
       );
     });
 
@@ -197,6 +199,7 @@ describe('CLI Handlers', () => {
         undefined,
         undefined,
         undefined,
+        undefined,
       );
     });
 
@@ -226,6 +229,7 @@ describe('CLI Handlers', () => {
         false,
         false,
         true,
+        undefined,
         undefined,
         undefined,
         undefined,
@@ -262,6 +266,7 @@ describe('CLI Handlers', () => {
         undefined,
         true,
         undefined,
+        undefined,
       );
     });
 
@@ -291,6 +296,7 @@ describe('CLI Handlers', () => {
         false,
         true, // nested should be true from CLI
         true,
+        undefined,
         undefined,
         undefined,
         undefined,
@@ -342,6 +348,7 @@ describe('CLI Handlers', () => {
         undefined,
         undefined,
         undefined,
+        undefined,
       );
     });
 
@@ -383,6 +390,7 @@ describe('CLI Handlers', () => {
         undefined,
         undefined,
         undefined,
+        undefined,
       );
     });
 
@@ -416,6 +424,7 @@ describe('CLI Handlers', () => {
         true,
         false,
         true,
+        undefined,
         undefined,
         undefined,
         undefined,
@@ -493,6 +502,7 @@ describe('CLI Handlers', () => {
         false,
         true, // nested should be true from CLI, ignoring TOML
         true,
+        undefined,
         undefined,
         undefined,
         undefined,

--- a/tests/unit/core/FoldersProcessor.test.ts
+++ b/tests/unit/core/FoldersProcessor.test.ts
@@ -1,0 +1,485 @@
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import {
+  getFolderSkipDirectories,
+  getFolderSkipUnmapped,
+  getFoldersGitignorePaths,
+  propagateFolders,
+} from '../../../src/core/FoldersProcessor';
+import { ClaudeAgent } from '../../../src/agents/ClaudeAgent';
+import { CursorAgent } from '../../../src/agents/CursorAgent';
+import type { FoldersConfig } from '../../../src/types';
+
+describe('getFolderSkipDirectories', () => {
+  it('returns empty array when folders is undefined', () => {
+    expect(getFolderSkipDirectories(undefined)).toEqual([]);
+  });
+
+  it('returns empty array when folders.enabled is false', () => {
+    expect(getFolderSkipDirectories({ enabled: false })).toEqual([]);
+  });
+
+  it('returns empty array when folders.agents is empty', () => {
+    expect(
+      getFolderSkipDirectories({ enabled: true, agents: {} }),
+    ).toEqual([]);
+  });
+
+  it('returns collected source directory names from agent mappings', () => {
+    const config: FoldersConfig = {
+      enabled: true,
+      agents: {
+        claude: { prompts: '.claude/prompts', templates: '.claude/templates' },
+        cursor: { prompts: '.cursor/prompts' },
+      },
+    };
+    const result = getFolderSkipDirectories(config);
+    expect(result.sort()).toEqual(['prompts', 'templates']);
+  });
+
+  it('deduplicates when same source is mapped for multiple agents', () => {
+    const config: FoldersConfig = {
+      enabled: true,
+      agents: {
+        claude: { prompts: '.claude/prompts' },
+        cursor: { prompts: '.cursor/prompts' },
+      },
+    };
+    const result = getFolderSkipDirectories(config);
+    expect(result).toEqual(['prompts']);
+  });
+});
+
+describe('getFolderSkipUnmapped', () => {
+  it('returns false when folders is undefined', () => {
+    expect(getFolderSkipUnmapped(undefined)).toBe(false);
+  });
+
+  it('returns false when folders.enabled is false', () => {
+    expect(getFolderSkipUnmapped({ enabled: false })).toBe(false);
+  });
+
+  it('returns true only when both enabled and skip_unmapped are true', () => {
+    expect(
+      getFolderSkipUnmapped({ enabled: true, skip_unmapped: true }),
+    ).toBe(true);
+  });
+
+  it('returns false when enabled is true but skip_unmapped is missing', () => {
+    expect(getFolderSkipUnmapped({ enabled: true })).toBe(false);
+  });
+
+  it('returns false when enabled is true but skip_unmapped is false', () => {
+    expect(
+      getFolderSkipUnmapped({ enabled: true, skip_unmapped: false }),
+    ).toBe(false);
+  });
+});
+
+describe('getFoldersGitignorePaths', () => {
+  it('returns empty array when folders is undefined', async () => {
+    const result = await getFoldersGitignorePaths(
+      '/root',
+      [new ClaudeAgent()],
+      undefined,
+    );
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array when folders.enabled is false', async () => {
+    const result = await getFoldersGitignorePaths(
+      '/root',
+      [new ClaudeAgent()],
+      { enabled: false },
+    );
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array when folders.agents is empty', async () => {
+    const result = await getFoldersGitignorePaths(
+      '/root',
+      [new ClaudeAgent()],
+      { enabled: true, agents: {} },
+    );
+    expect(result).toEqual([]);
+  });
+
+  it('only includes paths for selected agents', async () => {
+    const config: FoldersConfig = {
+      enabled: true,
+      agents: {
+        claude: { prompts: '.claude/prompts' },
+        cursor: { prompts: '.cursor/prompts' },
+      },
+    };
+    const result = await getFoldersGitignorePaths(
+      '/root',
+      [new ClaudeAgent()],
+      config,
+    );
+    expect(result).toEqual(['.claude/prompts']);
+  });
+
+  it('returns normalized relative paths with forward slashes', async () => {
+    const config: FoldersConfig = {
+      enabled: true,
+      agents: {
+        claude: { prompts: '.claude/prompts' },
+      },
+    };
+    const result = await getFoldersGitignorePaths(
+      '/root',
+      [new ClaudeAgent()],
+      config,
+    );
+    expect(result).toEqual(['.claude/prompts']);
+  });
+
+  it('includes paths for all selected agents', async () => {
+    const config: FoldersConfig = {
+      enabled: true,
+      agents: {
+        claude: { prompts: '.claude/prompts' },
+        cursor: { prompts: '.cursor/prompts' },
+      },
+    };
+    const result = await getFoldersGitignorePaths(
+      '/root',
+      [new ClaudeAgent(), new CursorAgent()],
+      config,
+    );
+    expect(result.sort()).toEqual(['.claude/prompts', '.cursor/prompts']);
+  });
+});
+
+describe('propagateFolders — dry-run', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ruler-folder-dry-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('does not create target directories in dry-run mode', async () => {
+    const rulerDir = path.join(tmpDir, '.ruler');
+    const promptsDir = path.join(rulerDir, 'prompts');
+    await fs.mkdir(promptsDir, { recursive: true });
+    await fs.writeFile(path.join(promptsDir, 'intro.md'), '# Intro');
+
+    const config: FoldersConfig = {
+      enabled: true,
+      agents: {
+        claude: { prompts: '.claude/prompts' },
+      },
+    };
+
+    const { generatedPaths } = await propagateFolders(
+      tmpDir,
+      [new ClaudeAgent()],
+      config,
+      false,
+      true,
+    );
+
+    const targetDir = path.join(tmpDir, '.claude', 'prompts');
+    await expect(fs.access(targetDir)).rejects.toThrow();
+    expect(generatedPaths).toEqual(['.claude/prompts']);
+  });
+
+  it('does not remove existing target directories during dry-run cleanup', async () => {
+    const rulerDir = path.join(tmpDir, '.ruler');
+    const promptsDir = path.join(rulerDir, 'prompts');
+    await fs.mkdir(promptsDir, { recursive: true });
+    await fs.writeFile(path.join(promptsDir, 'intro.md'), '# Intro');
+
+    const enabledConfig: FoldersConfig = {
+      enabled: true,
+      agents: {
+        claude: { prompts: '.claude/prompts' },
+      },
+    };
+
+    await propagateFolders(
+      tmpDir,
+      [new ClaudeAgent()],
+      enabledConfig,
+      false,
+      false,
+    );
+
+    const targetDir = path.join(tmpDir, '.claude', 'prompts');
+    await expect(fs.access(targetDir)).resolves.toBeUndefined();
+
+    const disabledConfig: FoldersConfig = {
+      enabled: false,
+      agents: {
+        claude: { prompts: '.claude/prompts' },
+      },
+    };
+
+    await propagateFolders(
+      tmpDir,
+      [new ClaudeAgent()],
+      disabledConfig,
+      false,
+      true,
+    );
+
+    await expect(fs.access(targetDir)).resolves.toBeUndefined();
+  });
+
+  it('copies files when not in dry-run mode', async () => {
+    const rulerDir = path.join(tmpDir, '.ruler');
+    const promptsDir = path.join(rulerDir, 'prompts');
+    await fs.mkdir(promptsDir, { recursive: true });
+    await fs.writeFile(path.join(promptsDir, 'intro.md'), '# Intro');
+
+    const config: FoldersConfig = {
+      enabled: true,
+      agents: {
+        claude: { prompts: '.claude/prompts' },
+      },
+    };
+
+    await propagateFolders(
+      tmpDir,
+      [new ClaudeAgent()],
+      config,
+      false,
+      false,
+    );
+
+    const targetDir = path.join(tmpDir, '.claude', 'prompts');
+    const content = await fs.readFile(path.join(targetDir, 'intro.md'), 'utf8');
+    expect(content).toBe('# Intro');
+  });
+});
+
+describe('propagateFolders — edge cases', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ruler-folder-edge-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns early when folders is undefined', async () => {
+    const { generatedPaths } = await propagateFolders(
+      tmpDir,
+      [new ClaudeAgent()],
+      undefined,
+      false,
+      false,
+    );
+    expect(generatedPaths).toEqual([]);
+  });
+
+  it('returns early when folders.enabled is false', async () => {
+    const { generatedPaths } = await propagateFolders(
+      tmpDir,
+      [new ClaudeAgent()],
+      { enabled: false },
+      false,
+      false,
+    );
+    expect(generatedPaths).toEqual([]);
+  });
+
+  it('returns early when .ruler directory does not exist', async () => {
+    const config: FoldersConfig = {
+      enabled: true,
+      agents: {
+        claude: { prompts: '.claude/prompts' },
+      },
+    };
+    const { generatedPaths } = await propagateFolders(
+      tmpDir,
+      [new ClaudeAgent()],
+      config,
+      false,
+      false,
+    );
+    expect(generatedPaths).toEqual([]);
+  });
+
+  it('skips source folders that do not exist on disk', async () => {
+    const rulerDir = path.join(tmpDir, '.ruler');
+    await fs.mkdir(rulerDir, { recursive: true });
+    await fs.writeFile(path.join(rulerDir, 'AGENTS.md'), '# Root');
+    const config: FoldersConfig = {
+      enabled: true,
+      agents: {
+        claude: { prompts: '.claude/prompts' },
+      },
+    };
+    const { generatedPaths } = await propagateFolders(
+      tmpDir,
+      [new ClaudeAgent()],
+      config,
+      false,
+      false,
+    );
+    expect(generatedPaths).toEqual([]);
+    const targetDir = path.join(tmpDir, '.claude', 'prompts');
+    await expect(fs.access(targetDir)).rejects.toThrow();
+  });
+
+  it('silently skips source symlinks during copy', async () => {
+    const rulerDir = path.join(tmpDir, '.ruler');
+    const promptsDir = path.join(rulerDir, 'prompts');
+    await fs.mkdir(promptsDir, { recursive: true });
+    await fs.writeFile(path.join(promptsDir, 'real.md'), '# Real file');
+
+    const outsidePath = path.join(tmpDir, 'outside.txt');
+    await fs.writeFile(outsidePath, 'outside content');
+    try {
+      await fs.symlink(outsidePath, path.join(promptsDir, 'link.md'));
+    } catch {
+      return;
+    }
+
+    const config: FoldersConfig = {
+      enabled: true,
+      agents: {
+        claude: { prompts: '.claude/prompts' },
+      },
+    };
+    await propagateFolders(
+      tmpDir,
+      [new ClaudeAgent()],
+      config,
+      false,
+      false,
+    );
+
+    const targetDir = path.join(tmpDir, '.claude', 'prompts');
+    const realContent = await fs.readFile(
+      path.join(targetDir, 'real.md'),
+      'utf8',
+    );
+    expect(realContent).toBe('# Real file');
+
+    await expect(fs.access(path.join(targetDir, 'link.md'))).rejects.toThrow();
+  });
+
+  it('skips agents not in the selected list', async () => {
+    const rulerDir = path.join(tmpDir, '.ruler');
+    const promptsDir = path.join(rulerDir, 'prompts');
+    await fs.mkdir(promptsDir, { recursive: true });
+    await fs.writeFile(path.join(promptsDir, 'intro.md'), '# Intro');
+
+    const config: FoldersConfig = {
+      enabled: true,
+      agents: {
+        claude: { prompts: '.claude/prompts' },
+        cursor: { tools: '.cursor/tools' },
+      },
+    };
+
+    const { generatedPaths } = await propagateFolders(
+      tmpDir,
+      [new ClaudeAgent()],
+      config,
+      false,
+      false,
+    );
+
+    const cursorTarget = path.join(tmpDir, '.cursor', 'tools');
+    await expect(fs.access(cursorTarget)).rejects.toThrow();
+    expect(generatedPaths).toEqual(['.claude/prompts']);
+  });
+});
+
+describe('propagateFolders — cleanup', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ruler-folder-clean-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('removes propagated targets when folders is disabled', async () => {
+    const rulerDir = path.join(tmpDir, '.ruler');
+    const promptsDir = path.join(rulerDir, 'prompts');
+    await fs.mkdir(promptsDir, { recursive: true });
+    await fs.writeFile(path.join(promptsDir, 'intro.md'), '# Intro');
+
+    const enabledConfig: FoldersConfig = {
+      enabled: true,
+      agents: {
+        claude: { prompts: '.claude/prompts' },
+      },
+    };
+
+    await propagateFolders(
+      tmpDir,
+      [new ClaudeAgent()],
+      enabledConfig,
+      false,
+      false,
+    );
+
+    const targetDir = path.join(tmpDir, '.claude', 'prompts');
+    await expect(fs.access(targetDir)).resolves.toBeUndefined();
+
+    const disabledConfig: FoldersConfig = {
+      enabled: false,
+      agents: {
+        claude: { prompts: '.claude/prompts' },
+      },
+    };
+
+    await propagateFolders(
+      tmpDir,
+      [new ClaudeAgent()],
+      disabledConfig,
+      false,
+      false,
+    );
+
+    await expect(fs.access(targetDir)).rejects.toThrow();
+  });
+
+  it('does nothing during cleanup when target does not exist', async () => {
+    const rulerDir = path.join(tmpDir, '.ruler');
+    await fs.mkdir(rulerDir, { recursive: true });
+
+    const disabledConfig: FoldersConfig = {
+      enabled: false,
+      agents: {
+        claude: { prompts: '.claude/prompts' },
+      },
+    };
+
+    const { generatedPaths } = await propagateFolders(
+      tmpDir,
+      [new ClaudeAgent()],
+      disabledConfig,
+      false,
+      false,
+    );
+
+    expect(generatedPaths).toEqual([]);
+  });
+
+  it('does not error when folders has no agents config', async () => {
+    const { generatedPaths } = await propagateFolders(
+      tmpDir,
+      [new ClaudeAgent()],
+      { enabled: false },
+      false,
+      false,
+    );
+    expect(generatedPaths).toEqual([]);
+  });
+});


### PR DESCRIPTION
- bumped version to 0.3.45
- added support to create sub-folders from .ruler in configured agents with optional flags changing behaviour.
- explanation and sample of feature added to README.md