### PR TITLE
feat(subagents): add generic `custom` frontmatter for harness-specific config

### DIFF
--- a/README.md
+++ b/README.md
@@ -780,6 +780,9 @@ tools: [Read, Grep, Glob, Bash]
 model: inherit
 readonly: true
 is_background: false
+custom:
+  codex:
+    model_reasoning_effort: low
 ---
 
 # Code Reviewer
@@ -804,6 +807,7 @@ a structured verdict.
 | `model`         | string   | All four targets                                                                | Cursor defaults to `inherit`; others omit.         |
 | `readonly`      | boolean  | Cursor (verbatim), Codex (`sandbox_mode`), Copilot (`disable-model-invocation`) | Defaults to `false` for Cursor; omitted otherwise. |
 | `is_background` | boolean  | Cursor only                                                                     | Defaults to `false` for Cursor.                    |
+| `custom`        | object   | Codex (all keys merged into TOML)                                               | Omitted if absent.                                 |
 
 For GitHub Copilot, source `tools` (Claude vocabulary: `Read`, `Grep`, `Bash`, …) are translated to Copilot's aliases (`read`, `search`, `execute`, …). Tools that do not have a Copilot equivalent are dropped silently on a normal apply; pass `--verbose` (or use `--dry-run` to preview) to see which tools were dropped.
 

--- a/src/core/SubagentsProcessor.ts
+++ b/src/core/SubagentsProcessor.ts
@@ -280,6 +280,17 @@ function buildCodexFile(sub: SubagentInfo): string {
   if (fm.readonly === true) {
     config.sandbox_mode = 'read-only';
   }
+  // Merge any harness-specific custom config for Codex.
+  const codexCustom = fm.custom?.codex;
+  if (
+    codexCustom !== undefined &&
+    typeof codexCustom === 'object' &&
+    !Array.isArray(codexCustom)
+  ) {
+    for (const [key, value] of Object.entries(codexCustom)) {
+      config[key] = value;
+    }
+  }
   // @iarna/toml requires JsonMap; the cast is safe because every value is a
   // string/boolean/number/object that the library knows how to serialize.
   return stringifyTOML(config as Parameters<typeof stringifyTOML>[0]);

--- a/src/core/SubagentsUtils.ts
+++ b/src/core/SubagentsUtils.ts
@@ -1,7 +1,11 @@
 import * as path from 'path';
 import * as fs from 'fs/promises';
 import * as yaml from 'js-yaml';
-import type { SubagentFrontmatter, SubagentInfo } from '../types';
+import type {
+  SubagentCustomConfig,
+  SubagentFrontmatter,
+  SubagentInfo,
+} from '../types';
 
 const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/;
 
@@ -85,6 +89,26 @@ export function validateFrontmatter(
       return { error: `invalid "is_background" field; expected boolean` };
     }
     fm.is_background = meta.is_background;
+  }
+
+  if (meta.custom !== undefined) {
+    if (
+      typeof meta.custom !== 'object' ||
+      meta.custom === null ||
+      Array.isArray(meta.custom)
+    ) {
+      return { error: `invalid "custom" field; expected object` };
+    }
+    for (const [key, value] of Object.entries(
+      meta.custom as Record<string, unknown>,
+    )) {
+      if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+        return {
+          error: `invalid "custom.${key}" field; expected object, got ${typeof value}`,
+        };
+      }
+    }
+    fm.custom = meta.custom as SubagentCustomConfig;
   }
 
   return { value: fm };

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,6 +67,26 @@ export interface SubagentsConfig {
   include_in_rules?: boolean;
 }
 
+/**
+ * Supported target harnesses that accept custom subagent configuration
+ * via the `custom` frontmatter field.
+ */
+export type SubagentCustomConfigTarget = 'codex';
+/**
+ * Harness-specific custom configuration.
+ * Each key is a target harness name;
+ * keys and values are passed through verbatim to the target's output format, e.g.
+ * ```yaml
+ * custom:
+ *   codex:
+ *     model_reasoning_effort: low
+ * ```
+ */
+export type SubagentCustomConfig = Record<
+  SubagentCustomConfigTarget,
+  Record<string, unknown>
+>;
+
 /** Frontmatter fields recognised on a source subagent definition. */
 export interface SubagentFrontmatter {
   name: string;
@@ -75,6 +95,7 @@ export interface SubagentFrontmatter {
   model?: string;
   readonly?: boolean;
   is_background?: boolean;
+  custom?: SubagentCustomConfig;
 }
 
 /** Information about a discovered subagent. */

--- a/tests/subagents-propagation.test.ts
+++ b/tests/subagents-propagation.test.ts
@@ -248,6 +248,85 @@ describe('Subagents per-agent propagators', () => {
         fs.access(path.join(tmpDir, CODEX_SUBAGENTS_PATH, 'sub/reviewer.toml')),
       ).resolves.toBeUndefined();
     });
+
+    it('writes custom.codex fields into the TOML output', async () => {
+      const sub = makeSubagent({
+        frontmatter: {
+          name: 'reviewer',
+          description: 'Reviews code',
+          custom: {
+            codex: {
+              model_reasoning_effort: 'low',
+              model_provider: '9router',
+            },
+          },
+        },
+      });
+      await propagateSubagentsForCodex(tmpDir, [sub], { dryRun: false });
+      const raw = await fs.readFile(
+        path.join(tmpDir, CODEX_SUBAGENTS_PATH, 'reviewer.toml'),
+        'utf8',
+      );
+      const parsed = parseTOML(raw) as Record<string, unknown>;
+      expect(parsed.model_reasoning_effort).toBe('low');
+      expect(parsed.model_provider).toBe('9router');
+    });
+
+    it('writes model_providers table from custom.codex', async () => {
+      const sub = makeSubagent({
+        frontmatter: {
+          name: 'reviewer',
+          description: 'Reviews code',
+          custom: {
+            codex: {
+              model_provider: '9router',
+              model_providers: {
+                '9router': {
+                  name: '9Router',
+                  base_url: 'http://127.0.0.1:20128/v1',
+                  wire_api: 'responses',
+                  requires_openai_auth: false,
+                },
+              },
+            },
+          },
+        },
+      });
+      await propagateSubagentsForCodex(tmpDir, [sub], { dryRun: false });
+      const raw = await fs.readFile(
+        path.join(tmpDir, CODEX_SUBAGENTS_PATH, 'reviewer.toml'),
+        'utf8',
+      );
+      const parsed = parseTOML(raw) as Record<string, unknown>;
+      expect(parsed.model_provider).toBe('9router');
+      expect(parsed.model_providers).toBeDefined();
+      const providers = parsed.model_providers as Record<string, unknown>;
+      expect(providers['9router']).toBeDefined();
+      const provider = providers['9router'] as Record<string, unknown>;
+      expect(provider.name).toBe('9Router');
+      expect(provider.base_url).toBe('http://127.0.0.1:20128/v1');
+      expect(provider.wire_api).toBe('responses');
+      expect(provider.requires_openai_auth).toBe(false);
+    });
+
+    it('ignores empty custom.codex', async () => {
+      const sub = makeSubagent({
+        frontmatter: {
+          name: 'reviewer',
+          description: 'Reviews code',
+          custom: {
+            codex: {},
+          },
+        },
+      });
+      await propagateSubagentsForCodex(tmpDir, [sub], { dryRun: false });
+      const raw = await fs.readFile(
+        path.join(tmpDir, CODEX_SUBAGENTS_PATH, 'reviewer.toml'),
+        'utf8',
+      );
+      const parsed = parseTOML(raw) as Record<string, unknown>;
+      expect(parsed.model_reasoning_effort).toBeUndefined();
+    });
   });
 
   describe('Copilot propagator', () => {

--- a/tests/unit/core/SubagentsUtils.test.ts
+++ b/tests/unit/core/SubagentsUtils.test.ts
@@ -105,6 +105,44 @@ describe('SubagentsUtils.validateFrontmatter', () => {
     if ('error' in result) expect(result.error).toMatch(/is_background/);
   });
 
+  it('passes custom config through verbatim', () => {
+    const result = validateFrontmatter(
+      {
+        name: 'reviewer',
+        description: 'x',
+        custom: {
+          codex: { any_key: 'any_value', nested: { keep: true } },
+        },
+      },
+      'reviewer',
+    );
+    if ('value' in result) {
+      expect(result.value.custom).toEqual({
+        codex: { any_key: 'any_value', nested: { keep: true } },
+      });
+    } else {
+      throw new Error('expected success');
+    }
+  });
+
+  it('rejects custom when not a plain object', () => {
+    const result = validateFrontmatter(
+      { name: 'reviewer', description: 'x', custom: 'string' },
+      'reviewer',
+    );
+    expect('error' in result).toBe(true);
+    if ('error' in result) expect(result.error).toMatch(/custom/);
+  });
+
+  it('rejects custom value that is not a plain object', () => {
+    const result = validateFrontmatter(
+      { name: 'reviewer', description: 'x', custom: { codex: 'string' } },
+      'reviewer',
+    );
+    expect('error' in result).toBe(true);
+    if ('error' in result) expect(result.error).toMatch(/custom\.codex/);
+  });
+
   it('preserves valid optional model, readonly, is_background', () => {
     const result = validateFrontmatter(
       {


### PR DESCRIPTION
## Summary

Subagent frontmatter now supports a `custom` field for passing harness-specific configuration without adding new top-level fields. Codex used as a proof of concept.

  ```yaml
name: code-reviewer
description: Use PROACTIVELY after a feature/fix is implemented. Reviews against SOLID/DRY/KISS. Read-only.
tools: [Read, Grep, Glob, Bash]
model: inherit
readonly: true
is_background: false
custom:
    codex:
      model_reasoning_effort: low
      model_provider: 9router
      model_providers:
        9router:
          name: 9Router
          base_url: http://127.0.0.1:20128/v1
          wire_api: responses
          requires_openai_auth: false
```

## Changes

- Add generic `custom` frontmatter field to subagent definitions for harness-specific config
- New types: `SubagentCustomConfigTarget`, `SubagentCustomConfig`
- `validateFrontmatter` rejects `custom` if it's not a plain object or its values aren't plain objects
- `buildCodexFile` merges `fm.custom?.codex` entries into the TOML config
- Update README

## Test updates

`tests/subagents-propagation.test.ts`, 3 new Codex propagator tests:

- writes `custom.codex` fields into the TOML output — verifies `model_reasoning_effort` and `model_provider` appear in the parsed TOML
- writes `model_providers` table from `custom.codex` — verifies nested `[model_providers.9router]` table with `name, base_url, wire_api, requires_openai_auth`
- ignores empty `custom.codex` — verifies no extra keys leak when `custom.codex` is `{}`

`tests/unit/core/SubagentsUtils.test.ts`, 3 new validateFrontmatter tests:

- passes custom config through verbatim — arbitrary keys (`any_key`, `nested`) survive round-trip
- rejects `custom` when not a plain object — string value produces error matching `/custom/`
- rejects `custom` value that is not a plain object — `custom.codex`: 'string' produces error matching `/custom\.codex/`

## Verification

 ```
npx jest tests/unit/core/SubagentsUtils.test.ts tests/subagents-propagation.test.ts tests/unit/
core/SubagentsProcessor.test.ts --runInBand --coverage=false
npm run format:check
npm run lint
npx tsc --noEmit
npx jest --no-coverage --runInBand
npm run build
```