### PR TITLE
Harden managed path writes

### DIFF
--- a/src/agents/CodexCliAgent.ts
+++ b/src/agents/CodexCliAgent.ts
@@ -3,7 +3,10 @@ import { promises as fs } from 'fs';
 import { parse as parseTOML, stringify } from '@iarna/toml';
 import { IAgent, IAgentConfig } from './IAgent';
 import { AgentsMdAgent } from './AgentsMdAgent';
-import { writeGeneratedFile } from '../core/FileSystemUtils';
+import {
+  assertManagedPathInsideRoot,
+  writeGeneratedFile,
+} from '../core/FileSystemUtils';
 import { DEFAULT_RULES_FILENAME } from '../constants';
 
 /**
@@ -84,8 +87,11 @@ export class CodexCliAgent implements IAgent {
       // Determine the config file path using proper precedence
       const configPath = agentConfig?.outputPathConfig ?? defaults.config;
 
-      // Ensure the parent directory exists
-      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      await assertManagedPathInsideRoot(
+        configPath,
+        projectRoot,
+        'Refusing to write generated file outside project',
+      );
 
       // Get the merge strategy
       const strategy = agentConfig?.mcp?.strategy ?? 'merge';

--- a/src/agents/CrushAgent.ts
+++ b/src/agents/CrushAgent.ts
@@ -1,7 +1,11 @@
 import { IAgent, IAgentConfig } from './IAgent';
 import * as fs from 'fs/promises';
 import * as path from 'path';
-import { backupFile, writeGeneratedFile } from '../core/FileSystemUtils';
+import {
+  assertManagedPathInsideRoot,
+  backupFile,
+  writeGeneratedFile,
+} from '../core/FileSystemUtils';
 
 export class CrushAgent implements IAgent {
   getIdentifier(): string {
@@ -77,7 +81,6 @@ export class CrushAgent implements IAgent {
       agentConfig?.outputPathConfig ?? outputPaths['mcp'],
     );
 
-    await fs.mkdir(path.dirname(instructionsPath), { recursive: true });
     if (backup) {
       await backupFile(instructionsPath, projectRoot);
     }
@@ -88,6 +91,11 @@ export class CrushAgent implements IAgent {
 
     const strategy = agentConfig?.mcp?.strategy ?? 'merge';
 
+    await assertManagedPathInsideRoot(
+      mcpPath,
+      projectRoot,
+      'Refusing to write generated file outside project',
+    );
     try {
       const existingMcpConfig = JSON.parse(await fs.readFile(mcpPath, 'utf-8'));
       if (existingMcpConfig && typeof existingMcpConfig === 'object') {
@@ -121,7 +129,6 @@ export class CrushAgent implements IAgent {
     }
 
     if (Object.keys(finalMcpConfig.mcp).length > 0) {
-      await fs.mkdir(path.dirname(mcpPath), { recursive: true });
       if (backup) {
         await backupFile(mcpPath, projectRoot);
       }

--- a/src/agents/MistralVibeAgent.ts
+++ b/src/agents/MistralVibeAgent.ts
@@ -3,7 +3,11 @@ import { promises as fs } from 'fs';
 import { parse as parseTOML, stringify } from '@iarna/toml';
 import { IAgent, IAgentConfig } from './IAgent';
 import { AgentsMdAgent } from './AgentsMdAgent';
-import { backupFile, writeGeneratedFile } from '../core/FileSystemUtils';
+import {
+  assertManagedPathInsideRoot,
+  backupFile,
+  writeGeneratedFile,
+} from '../core/FileSystemUtils';
 import { DEFAULT_RULES_FILENAME } from '../constants';
 
 /**
@@ -101,8 +105,11 @@ export class MistralVibeAgent implements IAgent {
       // Determine the config file path
       const configPath = agentConfig?.outputPathConfig ?? defaults.config;
 
-      // Ensure the parent directory exists
-      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      await assertManagedPathInsideRoot(
+        configPath,
+        projectRoot,
+        'Refusing to write generated file outside project',
+      );
 
       // Get the merge strategy
       const strategy = agentConfig?.mcp?.strategy ?? 'merge';

--- a/src/agents/OpenCodeAgent.ts
+++ b/src/agents/OpenCodeAgent.ts
@@ -1,7 +1,11 @@
 import { IAgent, IAgentConfig } from './IAgent';
 import * as fs from 'fs/promises';
 import * as path from 'path';
-import { backupFile, writeGeneratedFile } from '../core/FileSystemUtils';
+import {
+  assertManagedPathInsideRoot,
+  backupFile,
+  writeGeneratedFile,
+} from '../core/FileSystemUtils';
 
 export class OpenCodeAgent implements IAgent {
   getIdentifier(): string {
@@ -38,7 +42,6 @@ export class OpenCodeAgent implements IAgent {
       agentConfig?.outputPathConfig ?? outputPaths['mcp'],
     );
 
-    await fs.mkdir(path.dirname(instructionsPath), { recursive: true });
     if (backup) {
       await backupFile(instructionsPath, projectRoot);
     }
@@ -54,6 +57,11 @@ export class OpenCodeAgent implements IAgent {
       mcp: {},
     };
 
+    await assertManagedPathInsideRoot(
+      mcpPath,
+      projectRoot,
+      'Refusing to write generated file outside project',
+    );
     try {
       const existingMcpConfig = JSON.parse(await fs.readFile(mcpPath, 'utf-8'));
       if (existingMcpConfig && typeof existingMcpConfig === 'object') {
@@ -79,7 +87,6 @@ export class OpenCodeAgent implements IAgent {
     }
 
     // Always write the config file, even if MCP is empty
-    await fs.mkdir(path.dirname(mcpPath), { recursive: true });
     if (backup) {
       await backupFile(mcpPath, projectRoot);
     }

--- a/src/core/FileSystemUtils.ts
+++ b/src/core/FileSystemUtils.ts
@@ -50,6 +50,24 @@ export async function assertNotSymbolicLink(
   }
 }
 
+async function isHardLinkedFile(filePath: string): Promise<boolean> {
+  try {
+    const stat = await fs.lstat(filePath);
+    return stat.isFile() && stat.nlink > 1;
+  } catch {
+    return false;
+  }
+}
+
+export async function assertNotHardLinked(
+  filePath: string,
+  action: string,
+): Promise<void> {
+  if (await isHardLinkedFile(filePath)) {
+    throw new Error(`${action}: ${filePath}`);
+  }
+}
+
 async function assertContainingDirectoryInsideRoot(
   filePath: string,
   rootPath: string,
@@ -122,8 +140,11 @@ export async function findRulerDir(
   while (current) {
     const candidate = path.join(current, '.ruler');
     try {
-      const stat = await fs.stat(candidate);
-      if (stat.isDirectory()) {
+      const stat = await fs.lstat(candidate);
+      const candidateIsDirectory = stat.isSymbolicLink()
+        ? await symlinkedDirectoryStaysInside(candidate, current)
+        : stat.isDirectory();
+      if (candidateIsDirectory) {
         return candidate;
       }
     } catch {
@@ -156,6 +177,24 @@ export async function findRulerDir(
   }
 
   return null;
+}
+
+async function symlinkedDirectoryStaysInside(
+  candidate: string,
+  containingDir: string,
+): Promise<boolean> {
+  try {
+    const [realContainingDir, realCandidate] = await Promise.all([
+      fs.realpath(containingDir),
+      fs.realpath(candidate),
+    ]);
+    if (!isPathInsideOrEqual(realContainingDir, realCandidate)) {
+      return false;
+    }
+    return (await fs.stat(candidate)).isDirectory();
+  } catch {
+    return false;
+  }
 }
 
 export function resolveProjectRootForRulerDir(
@@ -368,6 +407,10 @@ export async function writeGeneratedFile(
     filePath,
     'Refusing to write generated file through symlink',
   );
+  await assertNotHardLinked(
+    filePath,
+    'Refusing to write generated file through hard link',
+  );
   if (containmentRoot) {
     await assertContainingDirectoryInsideRoot(
       filePath,
@@ -403,6 +446,11 @@ export async function backupFile(
   await assertNotSymbolicLink(
     backupPath,
     'Refusing to use symlinked backup file',
+  );
+  await assertNotHardLinked(filePath, 'Refusing to back up hard-linked file');
+  await assertNotHardLinked(
+    backupPath,
+    'Refusing to use hard-linked backup file',
   );
 
   try {

--- a/src/core/revert-engine.ts
+++ b/src/core/revert-engine.ts
@@ -14,6 +14,7 @@ import {
 import { isPathInsideOrEqual } from './path-utils';
 import {
   assertManagedPathInsideRoot,
+  assertNotHardLinked,
   assertNotSymbolicLink,
 } from './FileSystemUtils';
 
@@ -177,6 +178,14 @@ async function restoreFromBackup(
       backupPath,
       'Refusing to restore from symlinked backup path',
     );
+    await assertNotHardLinked(
+      filePath,
+      'Refusing to restore backup through hard-linked output path',
+    );
+    await assertNotHardLinked(
+      backupPath,
+      'Refusing to restore from hard-linked backup path',
+    );
     await fs.copyFile(backupPath, filePath);
     logVerbose(`${prefix} Restored: ${filePath} from backup`, verbose);
   }
@@ -233,6 +242,10 @@ async function removeGeneratedFile(
       filePath,
       'Refusing to remove symlinked generated file',
     );
+    await assertNotHardLinked(
+      filePath,
+      'Refusing to remove hard-linked generated file',
+    );
     await fs.unlink(filePath);
     logVerbose(`${prefix} Removed generated file: ${filePath}`, verbose);
   }
@@ -271,6 +284,10 @@ async function removeBackupFile(
     await assertNotSymbolicLink(
       backupPath,
       'Refusing to remove symlinked backup file',
+    );
+    await assertNotHardLinked(
+      backupPath,
+      'Refusing to remove hard-linked backup file',
     );
     await fs.unlink(backupPath);
     logVerbose(`${prefix} Removed backup file: ${backupPath}`, verbose);
@@ -511,6 +528,10 @@ async function removeAdditionalAgentFiles(
           await assertNotSymbolicLink(
             fullPath,
             'Refusing to remove symlinked additional file',
+          );
+          await assertNotHardLinked(
+            fullPath,
+            'Refusing to remove hard-linked additional file',
           );
           await fs.unlink(fullPath);
           logVerbose(`${prefix} Removed additional file: ${fullPath}`, verbose);

--- a/tests/integration/symlink-output-safety.test.ts
+++ b/tests/integration/symlink-output-safety.test.ts
@@ -52,6 +52,34 @@ describe('Symlink output safety', () => {
     );
   });
 
+  it('does not overwrite a hard-linked output target outside the project', async () => {
+    const outputPath = path.join(projectRoot, 'AGENTS.md');
+    await fs.link(outsideFile, outputPath);
+
+    expect(() =>
+      execFileSync(
+        'node',
+        [
+          path.resolve('dist/cli/index.js'),
+          'apply',
+          '--project-root',
+          projectRoot,
+          '--agents',
+          'agentsmd',
+          '--no-backup',
+          '--no-gitignore',
+        ],
+        {
+          stdio: 'pipe',
+        },
+      ),
+    ).toThrow();
+
+    await expect(fs.readFile(outsideFile, 'utf8')).resolves.toBe(
+      'outside original',
+    );
+  });
+
   it('does not overwrite an MCP config symlink target outside the project', async () => {
     await fs.writeFile(
       path.join(projectRoot, '.ruler', 'ruler.toml'),
@@ -173,6 +201,49 @@ describe('Symlink output safety', () => {
 
       await expect(
         fs.access(path.join(outsideDir, 'CLAUDE.md')),
+      ).rejects.toThrow();
+    } finally {
+      await fs.rm(outsideDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not create directories through a symlinked parent before failing', async () => {
+    const outsideDir = path.join(
+      projectRoot,
+      '..',
+      `${path.basename(projectRoot)}-outside-parent-dir`,
+    );
+    await fs.mkdir(outsideDir);
+    await fs.symlink(outsideDir, path.join(projectRoot, 'linked'));
+    await fs.writeFile(
+      path.join(projectRoot, '.ruler', 'ruler.toml'),
+      ['[agents.opencode]', 'output_path = "linked/newdir/AGENTS.md"', ''].join(
+        '\n',
+      ),
+    );
+
+    try {
+      expect(() =>
+        execFileSync(
+          'node',
+          [
+            path.resolve('dist/cli/index.js'),
+            'apply',
+            '--project-root',
+            projectRoot,
+            '--agents',
+            'opencode',
+            '--no-backup',
+            '--no-gitignore',
+          ],
+          {
+            stdio: 'pipe',
+          },
+        ),
+      ).toThrow();
+
+      await expect(
+        fs.access(path.join(outsideDir, 'newdir')),
       ).rejects.toThrow();
     } finally {
       await fs.rm(outsideDir, { recursive: true, force: true });

--- a/tests/unit/agents/OpenCodeAgent.test.ts
+++ b/tests/unit/agents/OpenCodeAgent.test.ts
@@ -5,6 +5,7 @@ import { writeGeneratedFile } from '../../../src/core/FileSystemUtils';
 // Mock fs module
 jest.mock('fs/promises');
 jest.mock('../../../src/core/FileSystemUtils', () => ({
+  assertManagedPathInsideRoot: jest.fn(),
   backupFile: jest.fn(),
   writeGeneratedFile: jest.fn(),
 }));

--- a/tests/unit/core/FileSystemUtils.test.ts
+++ b/tests/unit/core/FileSystemUtils.test.ts
@@ -35,6 +35,18 @@ describe('FileSystemUtils', () => {
       expect(found).toBeNull();
     });
 
+    it('rejects a local .ruler symlink that resolves outside the project', async () => {
+      const projectDir = path.join(tmpDir, 'project-with-external-ruler-link');
+      const externalRulerDir = path.join(tmpDir, 'external-ruler');
+      await fs.mkdir(projectDir, { recursive: true });
+      await fs.mkdir(externalRulerDir, { recursive: true });
+      await fs.symlink(externalRulerDir, path.join(projectDir, '.ruler'));
+
+      const found = await findRulerDir(projectDir, false);
+
+      expect(found).toBeNull();
+    });
+
     it('does not log an error when optional global config is absent', async () => {
       const originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
       const xdgConfigHome = path.join(tmpDir, 'missing-global-config');


### PR DESCRIPTION
## Summary

- reject hard-linked managed outputs and backup paths before writing, restoring, or removing files
- ignore `.ruler` symlinks that resolve outside their containing project directory
- validate bespoke-agent MCP/config paths before creating parent directories

Closes #639
Closes #640
Closes #641

## Verification

- `npx jest tests/integration/symlink-output-safety.test.ts tests/unit/core/FileSystemUtils.test.ts --runInBand --coverage=false` (failed before fix)
- `npx jest tests/unit/agents/OpenCodeAgent.test.ts tests/integration/symlink-output-safety.test.ts tests/unit/core/FileSystemUtils.test.ts --runInBand --coverage=false`
- `npm run format`
- `npm run format:check`
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit --omit=dev --audit-level=moderate`
- `npm pack --dry-run`
