### PR TITLE
Preserve generated settings sidecars

### DIFF
--- a/src/agents/GeminiCliAgent.ts
+++ b/src/agents/GeminiCliAgent.ts
@@ -2,7 +2,7 @@ import { IAgentConfig } from './IAgent';
 import * as path from 'path';
 import { promises as fs } from 'fs';
 import { AgentsMdAgent } from './AgentsMdAgent';
-import { writeGeneratedFile } from '../core/FileSystemUtils';
+import { backupFile, writeGeneratedFile } from '../core/FileSystemUtils';
 
 export class GeminiCliAgent extends AgentsMdAgent {
   getIdentifier(): string {
@@ -18,6 +18,20 @@ export class GeminiCliAgent extends AgentsMdAgent {
     return path
       .relative(projectRoot, path.resolve(projectRoot, outputPath))
       .replace(/\\/g, '/');
+  }
+
+  private getSettingsPath(projectRoot: string, agentConfig?: IAgentConfig) {
+    return path.resolve(
+      projectRoot,
+      agentConfig?.outputPathConfig ?? path.join('.gemini', 'settings.json'),
+    );
+  }
+
+  getAdditionalOutputPaths(
+    projectRoot: string,
+    agentConfig?: IAgentConfig,
+  ): string[] {
+    return [this.getSettingsPath(projectRoot, agentConfig)];
   }
 
   async applyRulerConfig(
@@ -39,13 +53,12 @@ export class GeminiCliAgent extends AgentsMdAgent {
     );
 
     // Prepare settings with contextFileName and MCP configuration
-    const settingsPath = path.resolve(
-      projectRoot,
-      agentConfig?.outputPathConfig ?? path.join('.gemini', 'settings.json'),
-    );
+    const settingsPath = this.getSettingsPath(projectRoot, agentConfig);
     let existingSettings: Record<string, unknown> = {};
+    let existingContent: string | null = null;
     try {
       const raw = await fs.readFile(settingsPath, 'utf8');
+      existingContent = raw;
       existingSettings = JSON.parse(raw);
     } catch (err: unknown) {
       if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
@@ -102,11 +115,16 @@ export class GeminiCliAgent extends AgentsMdAgent {
       }
     }
 
-    await writeGeneratedFile(
-      settingsPath,
-      JSON.stringify(updated, null, 2),
-      projectRoot,
-    );
+    const nextContent = JSON.stringify(updated, null, 2);
+    if (existingContent === nextContent) {
+      return;
+    }
+
+    if (backup && existingContent !== null) {
+      await backupFile(settingsPath, projectRoot);
+    }
+
+    await writeGeneratedFile(settingsPath, nextContent, projectRoot);
   }
 
   // Ensure MCP merging uses the correct key for Gemini (.gemini/settings.json)

--- a/src/agents/IAgent.ts
+++ b/src/agents/IAgent.ts
@@ -50,6 +50,16 @@ export interface IAgent {
   getDefaultOutputPath(projectRoot: string): string | Record<string, string>;
 
   /**
+   * Returns additional generated paths that are not represented by
+   * getDefaultOutputPath, such as agent settings sidecars written alongside the
+   * primary instruction file.
+   */
+  getAdditionalOutputPaths?(
+    projectRoot: string,
+    agentConfig?: IAgentConfig,
+  ): string[];
+
+  /**
    * Returns the specific key to be used for the server object in MCP JSON.
    * Defaults to 'mcpServers' if not implemented.
    */

--- a/src/agents/QwenCodeAgent.ts
+++ b/src/agents/QwenCodeAgent.ts
@@ -2,7 +2,7 @@ import { IAgentConfig } from './IAgent';
 import * as path from 'path';
 import { promises as fs } from 'fs';
 import { AgentsMdAgent } from './AgentsMdAgent';
-import { writeGeneratedFile } from '../core/FileSystemUtils';
+import { backupFile, writeGeneratedFile } from '../core/FileSystemUtils';
 
 export class QwenCodeAgent extends AgentsMdAgent {
   getIdentifier(): string {
@@ -18,6 +18,20 @@ export class QwenCodeAgent extends AgentsMdAgent {
     return path
       .relative(projectRoot, path.resolve(projectRoot, outputPath))
       .replace(/\\/g, '/');
+  }
+
+  private getSettingsPath(projectRoot: string, agentConfig?: IAgentConfig) {
+    return path.resolve(
+      projectRoot,
+      agentConfig?.outputPathConfig ?? path.join('.qwen', 'settings.json'),
+    );
+  }
+
+  getAdditionalOutputPaths(
+    projectRoot: string,
+    agentConfig?: IAgentConfig,
+  ): string[] {
+    return [this.getSettingsPath(projectRoot, agentConfig)];
   }
 
   async applyRulerConfig(
@@ -39,10 +53,12 @@ export class QwenCodeAgent extends AgentsMdAgent {
     );
 
     // Ensure .qwen/settings.json has contextFileName set to AGENTS.md
-    const settingsPath = path.join(projectRoot, '.qwen', 'settings.json');
+    const settingsPath = this.getSettingsPath(projectRoot, agentConfig);
     let existingSettings: Record<string, unknown> = {};
+    let existingContent: string | null = null;
     try {
       const raw = await fs.readFile(settingsPath, 'utf8');
+      existingContent = raw;
       existingSettings = JSON.parse(raw);
     } catch (err: unknown) {
       if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
@@ -55,11 +71,16 @@ export class QwenCodeAgent extends AgentsMdAgent {
       contextFileName: this.getContextFileName(projectRoot, agentConfig),
     } as Record<string, unknown>;
 
-    await writeGeneratedFile(
-      settingsPath,
-      JSON.stringify(updated, null, 2),
-      projectRoot,
-    );
+    const nextContent = JSON.stringify(updated, null, 2);
+    if (existingContent === nextContent) {
+      return;
+    }
+
+    if (backup && existingContent !== null) {
+      await backupFile(settingsPath, projectRoot);
+    }
+
+    await writeGeneratedFile(settingsPath, nextContent, projectRoot);
   }
 
   // Ensure MCP merging uses the correct key for Qwen Code (.qwen/settings.json)

--- a/src/agents/agent-utils.ts
+++ b/src/agents/agent-utils.ts
@@ -45,5 +45,9 @@ export function getAgentOutputPaths(
     }
   }
 
+  if (agent.getAdditionalOutputPaths) {
+    paths.push(...agent.getAdditionalOutputPaths(projectRoot, agentConfig));
+  }
+
   return paths;
 }

--- a/tests/integration/settings-sidecar-safety.test.ts
+++ b/tests/integration/settings-sidecar-safety.test.ts
@@ -1,0 +1,101 @@
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { runRuler, setupTestProject, teardownTestProject } from '../harness';
+
+describe('settings sidecar safety', () => {
+  it.each([
+    {
+      agent: 'gemini-cli',
+      settingsPath: path.join('.gemini', 'settings.json'),
+    },
+    {
+      agent: 'qwen',
+      settingsPath: path.join('.qwen', 'settings.json'),
+    },
+  ])(
+    'backs up and restores existing $agent settings',
+    async ({ agent, settingsPath }) => {
+      const originalSettings = JSON.stringify(
+        { theme: 'dark', contextFileName: 'USER.md' },
+        null,
+        2,
+      );
+      const project = await setupTestProject({
+        '.ruler/AGENTS.md': 'Rule A',
+        [settingsPath]: originalSettings,
+      });
+      const fullSettingsPath = path.join(project.projectRoot, settingsPath);
+
+      try {
+        runRuler(`apply --agents ${agent} --no-mcp`, project.projectRoot);
+
+        await expect(
+          fs.readFile(`${fullSettingsPath}.bak`, 'utf8'),
+        ).resolves.toBe(originalSettings);
+        await expect(fs.readFile(fullSettingsPath, 'utf8')).resolves.not.toBe(
+          originalSettings,
+        );
+
+        runRuler(`revert --agents ${agent}`, project.projectRoot);
+
+        await expect(fs.readFile(fullSettingsPath, 'utf8')).resolves.toBe(
+          originalSettings,
+        );
+        await expect(fs.access(`${fullSettingsPath}.bak`)).rejects.toThrow();
+      } finally {
+        await teardownTestProject(project.projectRoot);
+      }
+    },
+  );
+
+  it('honours Qwen output_path_config for settings writes', async () => {
+    const project = await setupTestProject({
+      '.ruler/AGENTS.md': 'Rule A',
+      '.ruler/ruler.toml': [
+        '[agents.qwen]',
+        'output_path_config = "custom/qwen-settings.json"',
+        '',
+      ].join('\n'),
+    });
+    const customSettingsPath = path.join(
+      project.projectRoot,
+      'custom',
+      'qwen-settings.json',
+    );
+    const defaultSettingsPath = path.join(
+      project.projectRoot,
+      '.qwen',
+      'settings.json',
+    );
+
+    try {
+      runRuler('apply --agents qwen --no-mcp', project.projectRoot);
+
+      const raw = await fs.readFile(customSettingsPath, 'utf8');
+      expect(JSON.parse(raw).contextFileName).toBe('AGENTS.md');
+      await expect(fs.access(defaultSettingsPath)).rejects.toThrow();
+    } finally {
+      await teardownTestProject(project.projectRoot);
+    }
+  });
+
+  it('tracks generated Gemini and Qwen settings in gitignore without MCP', async () => {
+    const project = await setupTestProject({
+      '.ruler/AGENTS.md': 'Rule A',
+    });
+
+    try {
+      runRuler('apply --agents gemini-cli,qwen --no-mcp', project.projectRoot);
+
+      const gitignore = await fs.readFile(
+        path.join(project.projectRoot, '.gitignore'),
+        'utf8',
+      );
+
+      expect(gitignore).toContain('/.gemini/settings.json');
+      expect(gitignore).toContain('/.qwen/settings.json');
+    } finally {
+      await teardownTestProject(project.projectRoot);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- back up changed Gemini and Qwen settings sidecars before overwriting them
- make Qwen respect `output_path_config` for its settings file
- include Gemini and Qwen generated settings sidecars in generated-path tracking even when MCP is disabled
- add regression coverage for apply/revert, Qwen custom settings paths, and gitignore bookkeeping

Closes #642
Closes #647
Closes #648
Closes #649

## Verification

- `npm run build && npx jest tests/integration/settings-sidecar-safety.test.ts --runInBand --coverage=false` (failed before fix)
- `npm run build && npx jest tests/integration/settings-sidecar-safety.test.ts tests/mcp-backup-prevention.test.ts tests/gemini-no-backup.test.ts tests/mcp-key-gemini.test.ts --runInBand --coverage=false`
- `npm run format`
- `npm run format:check`
- `npm run lint`
- `npm test`
- `npm audit --omit=dev --audit-level=moderate`
- `npm run build && npm pack --dry-run`
