### PR TITLE
Preserve native skills and subagents

### DIFF
--- a/src/core/SkillsProcessor.ts
+++ b/src/core/SkillsProcessor.ts
@@ -23,6 +23,13 @@ import { walkSkillsTree, copySkillsDirectory } from './SkillsUtils';
 import type { IAgent } from '../agents/IAgent';
 import { assertManagedPathInsideRoot } from './FileSystemUtils';
 
+const RULER_MANAGED_MANIFEST = '.ruler-managed.json';
+
+interface ManagedManifest {
+  version: 1;
+  paths: string[];
+}
+
 /**
  * Discovers skills in the project's .ruler/skills directory.
  * Returns discovered skills and any validation warnings.
@@ -95,11 +102,19 @@ export async function getSkillsGitignorePaths(
     antigravity: ANTIGRAVITY_SKILLS_PATH,
   };
 
-  const pathSet = new Set(
-    Array.from(selectedTargets).map((target) =>
-      path.join(projectRoot, targetPaths[target]),
-    ),
-  );
+  const managedEntries = await getSourceTopLevelEntries(skillsDir);
+  if (managedEntries.length === 0) {
+    return [];
+  }
+
+  const pathSet = new Set<string>();
+  for (const target of selectedTargets) {
+    const targetPath = path.join(projectRoot, targetPaths[target]);
+    pathSet.add(path.join(targetPath, RULER_MANAGED_MANIFEST));
+    for (const managedEntry of managedEntries) {
+      pathSet.add(path.join(targetPath, managedEntry));
+    }
+  }
   return Array.from(pathSet);
 }
 
@@ -219,31 +234,36 @@ async function cleanupSkillsDirectory(
   }
 
   if (dryRun) {
-    logVerboseInfo(`DRY RUN: Would remove ${relativePath}`, verbose, dryRun);
+    logVerboseInfo(
+      `DRY RUN: Would remove Ruler-managed entries from ${relativePath}`,
+      verbose,
+      dryRun,
+    );
     return;
   }
 
   await assertManagedPathInsideRoot(
     targetPath,
     projectRoot,
-    'Refusing to remove skills directory through symlinked path',
+    'Refusing to clean skills directory through symlinked path',
   );
-  await fs.rm(targetPath, { recursive: true, force: true });
-  logVerboseInfo(`Removed ${relativePath} (skills disabled)`, verbose, dryRun);
-}
-
-async function createTempSkillsDir(
-  parentDir: string,
-  containmentRoot?: string,
-): Promise<string> {
-  if (containmentRoot) {
-    await assertManagedPathInsideRoot(
-      parentDir,
-      containmentRoot,
-      'Refusing to create temporary skills directory through symlinked path',
+  const managedPaths = await readManagedManifest(targetPath);
+  if (managedPaths.length === 0) {
+    logVerboseInfo(
+      `No Ruler-managed skills found in ${relativePath}; leaving directory unchanged`,
+      verbose,
+      dryRun,
     );
+    return;
   }
-  return fs.mkdtemp(path.join(parentDir, 'skills.tmp-'));
+  await removeManagedEntries(targetPath, managedPaths, projectRoot);
+  await removeManagedManifest(targetPath, projectRoot);
+  await removeDirectoryIfEmpty(targetPath);
+  logVerboseInfo(
+    `Removed Ruler-managed entries from ${relativePath} (skills disabled)`,
+    verbose,
+    dryRun,
+  );
 }
 
 const TRANSIENT_RENAME_ERROR_CODES = new Set(['EPERM', 'EBUSY', 'ENOTEMPTY']);
@@ -301,6 +321,151 @@ export async function replaceSkillsDirectory(
   }
 
   throw lastError;
+}
+
+function isSafeManagedRelativePath(relativePath: string): boolean {
+  return (
+    relativePath.length > 0 &&
+    !path.isAbsolute(relativePath) &&
+    !relativePath.split(path.sep).includes('..') &&
+    !relativePath.split('/').includes('..')
+  );
+}
+
+async function readManagedManifest(targetDir: string): Promise<string[]> {
+  try {
+    const content = await fs.readFile(
+      path.join(targetDir, RULER_MANAGED_MANIFEST),
+      'utf8',
+    );
+    const parsed = JSON.parse(content) as Partial<ManagedManifest>;
+    if (!Array.isArray(parsed.paths)) {
+      return [];
+    }
+    return parsed.paths.filter(
+      (entry): entry is string =>
+        typeof entry === 'string' && isSafeManagedRelativePath(entry),
+    );
+  } catch {
+    return [];
+  }
+}
+
+async function removeDirectoryIfEmpty(dirPath: string): Promise<void> {
+  try {
+    const entries = await fs.readdir(dirPath);
+    if (entries.length === 0) {
+      await fs.rmdir(dirPath);
+    }
+  } catch {
+    // Directory is missing or not empty; either state is fine.
+  }
+}
+
+async function removeEmptyParentsUntil(
+  boundaryDir: string,
+  startDir: string,
+): Promise<void> {
+  let current = startDir;
+  while (current !== boundaryDir && current.startsWith(boundaryDir)) {
+    await removeDirectoryIfEmpty(current);
+    const next = path.dirname(current);
+    if (next === current) {
+      return;
+    }
+    current = next;
+  }
+}
+
+async function removeManagedEntries(
+  targetDir: string,
+  managedPaths: string[],
+  projectRoot: string,
+): Promise<void> {
+  const sortedPaths = Array.from(new Set(managedPaths)).sort(
+    (a, b) => b.length - a.length,
+  );
+
+  for (const managedPath of sortedPaths) {
+    const outputPath = path.join(targetDir, managedPath);
+    await assertManagedPathInsideRoot(
+      outputPath,
+      projectRoot,
+      'Refusing to remove managed skills entry through symlinked path',
+    );
+    await fs.rm(outputPath, { recursive: true, force: true });
+    await removeEmptyParentsUntil(targetDir, path.dirname(outputPath));
+  }
+}
+
+async function removeManagedManifest(
+  targetDir: string,
+  projectRoot: string,
+): Promise<void> {
+  const manifestPath = path.join(targetDir, RULER_MANAGED_MANIFEST);
+  await assertManagedPathInsideRoot(
+    manifestPath,
+    projectRoot,
+    'Refusing to remove skills manifest through symlinked path',
+  );
+  await fs.rm(manifestPath, { force: true });
+}
+
+async function writeManagedManifest(
+  targetDir: string,
+  managedPaths: string[],
+  projectRoot: string,
+): Promise<void> {
+  const manifestPath = path.join(targetDir, RULER_MANAGED_MANIFEST);
+  await assertManagedPathInsideRoot(
+    manifestPath,
+    projectRoot,
+    'Refusing to write skills manifest through symlinked path',
+  );
+  const manifest: ManagedManifest = {
+    version: 1,
+    paths: Array.from(new Set(managedPaths)).sort(),
+  };
+  await fs.writeFile(
+    manifestPath,
+    `${JSON.stringify(manifest, null, 2)}\n`,
+    'utf8',
+  );
+}
+
+async function getSourceTopLevelEntries(sourceDir: string): Promise<string[]> {
+  const entries = await fs.readdir(sourceDir, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isDirectory() || entry.isFile())
+    .map((entry) => entry.name)
+    .filter(isSafeManagedRelativePath)
+    .sort();
+}
+
+async function syncSkillsDirectory(
+  sourceDir: string,
+  targetDir: string,
+  projectRoot: string,
+): Promise<void> {
+  const targetParent = path.dirname(targetDir);
+  await assertManagedPathInsideRoot(
+    targetDir,
+    projectRoot,
+    'Refusing to sync skills directory through symlinked path',
+  );
+  await fs.mkdir(targetParent, { recursive: true });
+  await fs.mkdir(targetDir, { recursive: true });
+
+  const previousManagedPaths = await readManagedManifest(targetDir);
+  await removeManagedEntries(targetDir, previousManagedPaths, projectRoot);
+  await removeManagedManifest(targetDir, projectRoot);
+
+  await copySkillsDirectory(sourceDir, targetDir);
+  await writeManagedManifest(
+    targetDir,
+    await getSourceTopLevelEntries(sourceDir),
+    projectRoot,
+  );
 }
 
 /**
@@ -527,7 +692,7 @@ export async function propagateSkills(
 
 /**
  * Propagates skills for Claude Code by copying .ruler/skills to .claude/skills.
- * Uses atomic replace to ensure safe overwriting of existing skills.
+ * Updates only Ruler-managed entries so existing native skills are preserved.
  * Returns dry-run steps if dryRun is true, otherwise returns empty array.
  */
 export async function propagateSkillsForClaude(
@@ -536,7 +701,6 @@ export async function propagateSkillsForClaude(
 ): Promise<string[]> {
   const skillsDir = path.join(projectRoot, RULER_SKILLS_PATH);
   const claudeSkillsPath = path.join(projectRoot, CLAUDE_SKILLS_PATH);
-  const claudeDir = path.dirname(claudeSkillsPath);
 
   // Check if source skills directory exists
   try {
@@ -550,42 +714,14 @@ export async function propagateSkillsForClaude(
     return [`Copy skills from ${RULER_SKILLS_PATH} to ${CLAUDE_SKILLS_PATH}`];
   }
 
-  // Ensure .claude directory exists
-  await fs.mkdir(claudeDir, { recursive: true });
-
-  // Use atomic replace: copy to temp, then rename
-  const tempDir = await createTempSkillsDir(claudeDir, projectRoot);
-
-  try {
-    // Copy to temp directory
-    await copySkillsDirectory(skillsDir, tempDir);
-
-    // Atomically replace the target
-    // First, remove existing target if it exists
-    try {
-      await fs.rm(claudeSkillsPath, { recursive: true, force: true });
-    } catch {
-      // Target didn't exist, that's fine
-    }
-
-    // Rename temp to target
-    await replaceSkillsDirectory(tempDir, claudeSkillsPath, fs, projectRoot);
-  } catch (error) {
-    // Clean up temp directory on error
-    try {
-      await fs.rm(tempDir, { recursive: true, force: true });
-    } catch {
-      // Ignore cleanup errors
-    }
-    throw error;
-  }
+  await syncSkillsDirectory(skillsDir, claudeSkillsPath, projectRoot);
 
   return [];
 }
 
 /**
  * Propagates skills for OpenAI Codex CLI by copying .ruler/skills to .agents/skills.
- * Uses atomic replace to ensure safe overwriting of existing skills.
+ * Updates only Ruler-managed entries so existing native skills are preserved.
  * Returns dry-run steps if dryRun is true, otherwise returns empty array.
  */
 export async function propagateSkillsForCodex(
@@ -594,7 +730,6 @@ export async function propagateSkillsForCodex(
 ): Promise<string[]> {
   const skillsDir = path.join(projectRoot, RULER_SKILLS_PATH);
   const agentsSkillsPath = path.join(projectRoot, CODEX_SKILLS_PATH);
-  const agentsDir = path.dirname(agentsSkillsPath);
 
   // Check if source skills directory exists
   try {
@@ -608,42 +743,14 @@ export async function propagateSkillsForCodex(
     return [`Copy skills from ${RULER_SKILLS_PATH} to ${CODEX_SKILLS_PATH}`];
   }
 
-  // Ensure .agents directory exists
-  await fs.mkdir(agentsDir, { recursive: true });
-
-  // Use atomic replace: copy to temp, then rename
-  const tempDir = await createTempSkillsDir(agentsDir, projectRoot);
-
-  try {
-    // Copy to temp directory
-    await copySkillsDirectory(skillsDir, tempDir);
-
-    // Atomically replace the target
-    // First, remove existing target if it exists
-    try {
-      await fs.rm(agentsSkillsPath, { recursive: true, force: true });
-    } catch {
-      // Target didn't exist, that's fine
-    }
-
-    // Rename temp to target
-    await replaceSkillsDirectory(tempDir, agentsSkillsPath, fs, projectRoot);
-  } catch (error) {
-    // Clean up temp directory on error
-    try {
-      await fs.rm(tempDir, { recursive: true, force: true });
-    } catch {
-      // Ignore cleanup errors
-    }
-    throw error;
-  }
+  await syncSkillsDirectory(skillsDir, agentsSkillsPath, projectRoot);
 
   return [];
 }
 
 /**
  * Propagates skills for OpenCode by copying .ruler/skills to .opencode/skills.
- * Uses atomic replace to ensure safe overwriting of existing skills.
+ * Updates only Ruler-managed entries so existing native skills are preserved.
  * Returns dry-run steps if dryRun is true, otherwise returns empty array.
  */
 export async function propagateSkillsForOpenCode(
@@ -652,7 +759,6 @@ export async function propagateSkillsForOpenCode(
 ): Promise<string[]> {
   const skillsDir = path.join(projectRoot, RULER_SKILLS_PATH);
   const opencodeSkillsPath = path.join(projectRoot, OPENCODE_SKILLS_PATH);
-  const opencodeDir = path.dirname(opencodeSkillsPath);
 
   // Check if source skills directory exists
   try {
@@ -666,42 +772,14 @@ export async function propagateSkillsForOpenCode(
     return [`Copy skills from ${RULER_SKILLS_PATH} to ${OPENCODE_SKILLS_PATH}`];
   }
 
-  // Ensure .opencode directory exists
-  await fs.mkdir(opencodeDir, { recursive: true });
-
-  // Use atomic replace: copy to temp, then rename
-  const tempDir = await createTempSkillsDir(opencodeDir, projectRoot);
-
-  try {
-    // Copy to temp directory
-    await copySkillsDirectory(skillsDir, tempDir);
-
-    // Atomically replace the target
-    // First, remove existing target if it exists
-    try {
-      await fs.rm(opencodeSkillsPath, { recursive: true, force: true });
-    } catch {
-      // Target didn't exist, that's fine
-    }
-
-    // Rename temp to target
-    await replaceSkillsDirectory(tempDir, opencodeSkillsPath, fs, projectRoot);
-  } catch (error) {
-    // Clean up temp directory on error
-    try {
-      await fs.rm(tempDir, { recursive: true, force: true });
-    } catch {
-      // Ignore cleanup errors
-    }
-    throw error;
-  }
+  await syncSkillsDirectory(skillsDir, opencodeSkillsPath, projectRoot);
 
   return [];
 }
 
 /**
  * Propagates skills for Pi Coding Agent by copying .ruler/skills to .pi/skills.
- * Uses atomic replace to ensure safe overwriting of existing skills.
+ * Updates only Ruler-managed entries so existing native skills are preserved.
  * Returns dry-run steps if dryRun is true, otherwise returns empty array.
  */
 export async function propagateSkillsForPi(
@@ -710,7 +788,6 @@ export async function propagateSkillsForPi(
 ): Promise<string[]> {
   const skillsDir = path.join(projectRoot, RULER_SKILLS_PATH);
   const piSkillsPath = path.join(projectRoot, PI_SKILLS_PATH);
-  const piDir = path.dirname(piSkillsPath);
 
   // Check if source skills directory exists
   try {
@@ -724,42 +801,14 @@ export async function propagateSkillsForPi(
     return [`Copy skills from ${RULER_SKILLS_PATH} to ${PI_SKILLS_PATH}`];
   }
 
-  // Ensure .pi directory exists
-  await fs.mkdir(piDir, { recursive: true });
-
-  // Use atomic replace: copy to temp, then rename
-  const tempDir = await createTempSkillsDir(piDir, projectRoot);
-
-  try {
-    // Copy to temp directory
-    await copySkillsDirectory(skillsDir, tempDir);
-
-    // Atomically replace the target
-    // First, remove existing target if it exists
-    try {
-      await fs.rm(piSkillsPath, { recursive: true, force: true });
-    } catch {
-      // Target didn't exist, that's fine
-    }
-
-    // Rename temp to target
-    await replaceSkillsDirectory(tempDir, piSkillsPath, fs, projectRoot);
-  } catch (error) {
-    // Clean up temp directory on error
-    try {
-      await fs.rm(tempDir, { recursive: true, force: true });
-    } catch {
-      // Ignore cleanup errors
-    }
-    throw error;
-  }
+  await syncSkillsDirectory(skillsDir, piSkillsPath, projectRoot);
 
   return [];
 }
 
 /**
  * Propagates skills for Goose by copying .ruler/skills to .agents/skills.
- * Uses atomic replace to ensure safe overwriting of existing skills.
+ * Updates only Ruler-managed entries so existing native skills are preserved.
  * Returns dry-run steps if dryRun is true, otherwise returns empty array.
  */
 export async function propagateSkillsForGoose(
@@ -768,7 +817,6 @@ export async function propagateSkillsForGoose(
 ): Promise<string[]> {
   const skillsDir = path.join(projectRoot, RULER_SKILLS_PATH);
   const gooseSkillsPath = path.join(projectRoot, GOOSE_SKILLS_PATH);
-  const gooseDir = path.dirname(gooseSkillsPath);
 
   // Check if source skills directory exists
   try {
@@ -782,42 +830,14 @@ export async function propagateSkillsForGoose(
     return [`Copy skills from ${RULER_SKILLS_PATH} to ${GOOSE_SKILLS_PATH}`];
   }
 
-  // Ensure .agents directory exists
-  await fs.mkdir(gooseDir, { recursive: true });
-
-  // Use atomic replace: copy to temp, then rename
-  const tempDir = await createTempSkillsDir(gooseDir, projectRoot);
-
-  try {
-    // Copy to temp directory
-    await copySkillsDirectory(skillsDir, tempDir);
-
-    // Atomically replace the target
-    // First, remove existing target if it exists
-    try {
-      await fs.rm(gooseSkillsPath, { recursive: true, force: true });
-    } catch {
-      // Target didn't exist, that's fine
-    }
-
-    // Rename temp to target
-    await replaceSkillsDirectory(tempDir, gooseSkillsPath, fs, projectRoot);
-  } catch (error) {
-    // Clean up temp directory on error
-    try {
-      await fs.rm(tempDir, { recursive: true, force: true });
-    } catch {
-      // Ignore cleanup errors
-    }
-    throw error;
-  }
+  await syncSkillsDirectory(skillsDir, gooseSkillsPath, projectRoot);
 
   return [];
 }
 
 /**
  * Propagates skills for Mistral Vibe by copying .ruler/skills to .vibe/skills.
- * Uses atomic replace to ensure safe overwriting of existing skills.
+ * Updates only Ruler-managed entries so existing native skills are preserved.
  * Returns dry-run steps if dryRun is true, otherwise returns empty array.
  */
 export async function propagateSkillsForVibe(
@@ -826,7 +846,6 @@ export async function propagateSkillsForVibe(
 ): Promise<string[]> {
   const skillsDir = path.join(projectRoot, RULER_SKILLS_PATH);
   const vibeSkillsPath = path.join(projectRoot, VIBE_SKILLS_PATH);
-  const vibeDir = path.dirname(vibeSkillsPath);
 
   // Check if source skills directory exists
   try {
@@ -840,42 +859,14 @@ export async function propagateSkillsForVibe(
     return [`Copy skills from ${RULER_SKILLS_PATH} to ${VIBE_SKILLS_PATH}`];
   }
 
-  // Ensure .vibe directory exists
-  await fs.mkdir(vibeDir, { recursive: true });
-
-  // Use atomic replace: copy to temp, then rename
-  const tempDir = await createTempSkillsDir(vibeDir, projectRoot);
-
-  try {
-    // Copy to temp directory
-    await copySkillsDirectory(skillsDir, tempDir);
-
-    // Atomically replace the target
-    // First, remove existing target if it exists
-    try {
-      await fs.rm(vibeSkillsPath, { recursive: true, force: true });
-    } catch {
-      // Target didn't exist, that's fine
-    }
-
-    // Rename temp to target
-    await replaceSkillsDirectory(tempDir, vibeSkillsPath, fs, projectRoot);
-  } catch (error) {
-    // Clean up temp directory on error
-    try {
-      await fs.rm(tempDir, { recursive: true, force: true });
-    } catch {
-      // Ignore cleanup errors
-    }
-    throw error;
-  }
+  await syncSkillsDirectory(skillsDir, vibeSkillsPath, projectRoot);
 
   return [];
 }
 
 /**
  * Propagates skills for Roo Code by copying .ruler/skills to .roo/skills.
- * Uses atomic replace to ensure safe overwriting of existing skills.
+ * Updates only Ruler-managed entries so existing native skills are preserved.
  * Returns dry-run steps if dryRun is true, otherwise returns empty array.
  */
 export async function propagateSkillsForRoo(
@@ -884,7 +875,6 @@ export async function propagateSkillsForRoo(
 ): Promise<string[]> {
   const skillsDir = path.join(projectRoot, RULER_SKILLS_PATH);
   const rooSkillsPath = path.join(projectRoot, ROO_SKILLS_PATH);
-  const rooDir = path.dirname(rooSkillsPath);
 
   // Check if source skills directory exists
   try {
@@ -898,42 +888,14 @@ export async function propagateSkillsForRoo(
     return [`Copy skills from ${RULER_SKILLS_PATH} to ${ROO_SKILLS_PATH}`];
   }
 
-  // Ensure .roo directory exists
-  await fs.mkdir(rooDir, { recursive: true });
-
-  // Use atomic replace: copy to temp, then rename
-  const tempDir = await createTempSkillsDir(rooDir, projectRoot);
-
-  try {
-    // Copy to temp directory
-    await copySkillsDirectory(skillsDir, tempDir);
-
-    // Atomically replace the target
-    // First, remove existing target if it exists
-    try {
-      await fs.rm(rooSkillsPath, { recursive: true, force: true });
-    } catch {
-      // Target didn't exist, that's fine
-    }
-
-    // Rename temp to target
-    await replaceSkillsDirectory(tempDir, rooSkillsPath, fs, projectRoot);
-  } catch (error) {
-    // Clean up temp directory on error
-    try {
-      await fs.rm(tempDir, { recursive: true, force: true });
-    } catch {
-      // Ignore cleanup errors
-    }
-    throw error;
-  }
+  await syncSkillsDirectory(skillsDir, rooSkillsPath, projectRoot);
 
   return [];
 }
 
 /**
  * Propagates skills for Gemini CLI by copying .ruler/skills to .gemini/skills.
- * Uses atomic replace to ensure safe overwriting of existing skills.
+ * Updates only Ruler-managed entries so existing native skills are preserved.
  * Returns dry-run steps if dryRun is true, otherwise returns empty array.
  */
 export async function propagateSkillsForGemini(
@@ -942,7 +904,6 @@ export async function propagateSkillsForGemini(
 ): Promise<string[]> {
   const skillsDir = path.join(projectRoot, RULER_SKILLS_PATH);
   const geminiSkillsPath = path.join(projectRoot, GEMINI_SKILLS_PATH);
-  const geminiDir = path.dirname(geminiSkillsPath);
 
   // Check if source skills directory exists
   try {
@@ -956,42 +917,14 @@ export async function propagateSkillsForGemini(
     return [`Copy skills from ${RULER_SKILLS_PATH} to ${GEMINI_SKILLS_PATH}`];
   }
 
-  // Ensure .gemini directory exists
-  await fs.mkdir(geminiDir, { recursive: true });
-
-  // Use atomic replace: copy to temp, then rename
-  const tempDir = await createTempSkillsDir(geminiDir, projectRoot);
-
-  try {
-    // Copy to temp directory
-    await copySkillsDirectory(skillsDir, tempDir);
-
-    // Atomically replace the target
-    // First, remove existing target if it exists
-    try {
-      await fs.rm(geminiSkillsPath, { recursive: true, force: true });
-    } catch {
-      // Target didn't exist, that's fine
-    }
-
-    // Rename temp to target
-    await replaceSkillsDirectory(tempDir, geminiSkillsPath, fs, projectRoot);
-  } catch (error) {
-    // Clean up temp directory on error
-    try {
-      await fs.rm(tempDir, { recursive: true, force: true });
-    } catch {
-      // Ignore cleanup errors
-    }
-    throw error;
-  }
+  await syncSkillsDirectory(skillsDir, geminiSkillsPath, projectRoot);
 
   return [];
 }
 
 /**
  * Propagates skills for Junie by copying .ruler/skills to .junie/skills.
- * Uses atomic replace to ensure safe overwriting of existing skills.
+ * Updates only Ruler-managed entries so existing native skills are preserved.
  * Returns dry-run steps if dryRun is true, otherwise returns empty array.
  */
 export async function propagateSkillsForJunie(
@@ -1000,7 +933,6 @@ export async function propagateSkillsForJunie(
 ): Promise<string[]> {
   const skillsDir = path.join(projectRoot, RULER_SKILLS_PATH);
   const junieSkillsPath = path.join(projectRoot, JUNIE_SKILLS_PATH);
-  const junieDir = path.dirname(junieSkillsPath);
 
   try {
     await fs.access(skillsDir);
@@ -1012,35 +944,14 @@ export async function propagateSkillsForJunie(
     return [`Copy skills from ${RULER_SKILLS_PATH} to ${JUNIE_SKILLS_PATH}`];
   }
 
-  await fs.mkdir(junieDir, { recursive: true });
-
-  const tempDir = await createTempSkillsDir(junieDir, projectRoot);
-
-  try {
-    await copySkillsDirectory(skillsDir, tempDir);
-
-    try {
-      await fs.rm(junieSkillsPath, { recursive: true, force: true });
-    } catch {
-      // Target didn't exist, that's fine
-    }
-
-    await replaceSkillsDirectory(tempDir, junieSkillsPath, fs, projectRoot);
-  } catch (error) {
-    try {
-      await fs.rm(tempDir, { recursive: true, force: true });
-    } catch {
-      // Ignore cleanup errors
-    }
-    throw error;
-  }
+  await syncSkillsDirectory(skillsDir, junieSkillsPath, projectRoot);
 
   return [];
 }
 
 /**
  * Propagates skills for Cursor by copying .ruler/skills to .cursor/skills.
- * Uses atomic replace to ensure safe overwriting of existing skills.
+ * Updates only Ruler-managed entries so existing native skills are preserved.
  * Returns dry-run steps if dryRun is true, otherwise returns empty array.
  */
 export async function propagateSkillsForCursor(
@@ -1049,7 +960,6 @@ export async function propagateSkillsForCursor(
 ): Promise<string[]> {
   const skillsDir = path.join(projectRoot, RULER_SKILLS_PATH);
   const cursorSkillsPath = path.join(projectRoot, CURSOR_SKILLS_PATH);
-  const cursorDir = path.dirname(cursorSkillsPath);
 
   // Check if source skills directory exists
   try {
@@ -1063,42 +973,14 @@ export async function propagateSkillsForCursor(
     return [`Copy skills from ${RULER_SKILLS_PATH} to ${CURSOR_SKILLS_PATH}`];
   }
 
-  // Ensure .cursor directory exists
-  await fs.mkdir(cursorDir, { recursive: true });
-
-  // Use atomic replace: copy to temp, then rename
-  const tempDir = await createTempSkillsDir(cursorDir, projectRoot);
-
-  try {
-    // Copy to temp directory
-    await copySkillsDirectory(skillsDir, tempDir);
-
-    // Atomically replace the target
-    // First, remove existing target if it exists
-    try {
-      await fs.rm(cursorSkillsPath, { recursive: true, force: true });
-    } catch {
-      // Target didn't exist, that's fine
-    }
-
-    // Rename temp to target
-    await replaceSkillsDirectory(tempDir, cursorSkillsPath, fs, projectRoot);
-  } catch (error) {
-    // Clean up temp directory on error
-    try {
-      await fs.rm(tempDir, { recursive: true, force: true });
-    } catch {
-      // Ignore cleanup errors
-    }
-    throw error;
-  }
+  await syncSkillsDirectory(skillsDir, cursorSkillsPath, projectRoot);
 
   return [];
 }
 
 /**
  * Propagates skills for Windsurf by copying .ruler/skills to .windsurf/skills.
- * Uses atomic replace to ensure safe overwriting of existing skills.
+ * Updates only Ruler-managed entries so existing native skills are preserved.
  * Returns dry-run steps if dryRun is true, otherwise returns empty array.
  */
 export async function propagateSkillsForWindsurf(
@@ -1107,7 +989,6 @@ export async function propagateSkillsForWindsurf(
 ): Promise<string[]> {
   const skillsDir = path.join(projectRoot, RULER_SKILLS_PATH);
   const windsurfSkillsPath = path.join(projectRoot, WINDSURF_SKILLS_PATH);
-  const windsurfDir = path.dirname(windsurfSkillsPath);
 
   // Check if source skills directory exists
   try {
@@ -1121,42 +1002,14 @@ export async function propagateSkillsForWindsurf(
     return [`Copy skills from ${RULER_SKILLS_PATH} to ${WINDSURF_SKILLS_PATH}`];
   }
 
-  // Ensure .windsurf directory exists
-  await fs.mkdir(windsurfDir, { recursive: true });
-
-  // Use atomic replace: copy to temp, then rename
-  const tempDir = await createTempSkillsDir(windsurfDir, projectRoot);
-
-  try {
-    // Copy to temp directory
-    await copySkillsDirectory(skillsDir, tempDir);
-
-    // Atomically replace the target
-    // First, remove existing target if it exists
-    try {
-      await fs.rm(windsurfSkillsPath, { recursive: true, force: true });
-    } catch {
-      // Target didn't exist, that's fine
-    }
-
-    // Rename temp to target
-    await replaceSkillsDirectory(tempDir, windsurfSkillsPath, fs, projectRoot);
-  } catch (error) {
-    // Clean up temp directory on error
-    try {
-      await fs.rm(tempDir, { recursive: true, force: true });
-    } catch {
-      // Ignore cleanup errors
-    }
-    throw error;
-  }
+  await syncSkillsDirectory(skillsDir, windsurfSkillsPath, projectRoot);
 
   return [];
 }
 
 /**
  * Propagates skills for Factory Droid by copying .ruler/skills to .factory/skills.
- * Uses atomic replace to ensure safe overwriting of existing skills.
+ * Updates only Ruler-managed entries so existing native skills are preserved.
  * Returns dry-run steps if dryRun is true, otherwise returns empty array.
  */
 export async function propagateSkillsForFactory(
@@ -1165,7 +1018,6 @@ export async function propagateSkillsForFactory(
 ): Promise<string[]> {
   const skillsDir = path.join(projectRoot, RULER_SKILLS_PATH);
   const factorySkillsPath = path.join(projectRoot, FACTORY_SKILLS_PATH);
-  const factoryDir = path.dirname(factorySkillsPath);
 
   // Check if source skills directory exists
   try {
@@ -1179,42 +1031,14 @@ export async function propagateSkillsForFactory(
     return [`Copy skills from ${RULER_SKILLS_PATH} to ${FACTORY_SKILLS_PATH}`];
   }
 
-  // Ensure .factory directory exists
-  await fs.mkdir(factoryDir, { recursive: true });
-
-  // Use atomic replace: copy to temp, then rename
-  const tempDir = await createTempSkillsDir(factoryDir, projectRoot);
-
-  try {
-    // Copy to temp directory
-    await copySkillsDirectory(skillsDir, tempDir);
-
-    // Atomically replace the target
-    // First, remove existing target if it exists
-    try {
-      await fs.rm(factorySkillsPath, { recursive: true, force: true });
-    } catch {
-      // Target didn't exist, that's fine
-    }
-
-    // Rename temp to target
-    await replaceSkillsDirectory(tempDir, factorySkillsPath, fs, projectRoot);
-  } catch (error) {
-    // Clean up temp directory on error
-    try {
-      await fs.rm(tempDir, { recursive: true, force: true });
-    } catch {
-      // Ignore cleanup errors
-    }
-    throw error;
-  }
+  await syncSkillsDirectory(skillsDir, factorySkillsPath, projectRoot);
 
   return [];
 }
 
 /**
  * Propagates skills for Antigravity by copying .ruler/skills to .agent/skills.
- * Uses atomic replace to ensure safe overwriting of existing skills.
+ * Updates only Ruler-managed entries so existing native skills are preserved.
  * Returns dry-run steps if dryRun is true, otherwise returns empty array.
  */
 export async function propagateSkillsForAntigravity(
@@ -1223,7 +1047,6 @@ export async function propagateSkillsForAntigravity(
 ): Promise<string[]> {
   const skillsDir = path.join(projectRoot, RULER_SKILLS_PATH);
   const antigravitySkillsPath = path.join(projectRoot, ANTIGRAVITY_SKILLS_PATH);
-  const antigravityDir = path.dirname(antigravitySkillsPath);
 
   // Check if source skills directory exists
   try {
@@ -1239,40 +1062,7 @@ export async function propagateSkillsForAntigravity(
     ];
   }
 
-  // Ensure .agent directory exists
-  await fs.mkdir(antigravityDir, { recursive: true });
-
-  // Use atomic replace: copy to temp, then rename
-  const tempDir = await createTempSkillsDir(antigravityDir, projectRoot);
-
-  try {
-    // Copy to temp directory
-    await copySkillsDirectory(skillsDir, tempDir);
-
-    // Atomically replace the target
-    // First, remove existing target if it exists
-    try {
-      await fs.rm(antigravitySkillsPath, { recursive: true, force: true });
-    } catch {
-      // Target didn't exist, that's fine
-    }
-
-    // Rename temp to target
-    await replaceSkillsDirectory(
-      tempDir,
-      antigravitySkillsPath,
-      fs,
-      projectRoot,
-    );
-  } catch (error) {
-    // Clean up temp directory on error
-    try {
-      await fs.rm(tempDir, { recursive: true, force: true });
-    } catch {
-      // Ignore cleanup errors
-    }
-    throw error;
-  }
+  await syncSkillsDirectory(skillsDir, antigravitySkillsPath, projectRoot);
 
   return [];
 }

--- a/src/core/SubagentsProcessor.ts
+++ b/src/core/SubagentsProcessor.ts
@@ -16,6 +16,13 @@ import { loadSubagentFile, mapToolsForCopilot } from './SubagentsUtils';
 import type { IAgent } from '../agents/IAgent';
 import { assertManagedPathInsideRoot } from './FileSystemUtils';
 
+const RULER_MANAGED_MANIFEST = '.ruler-managed.json';
+
+interface ManagedManifest {
+  version: 1;
+  paths: string[];
+}
+
 /**
  * Discovers subagent definitions in `.ruler/agents/`.
  * Each `.md` file is parsed for YAML frontmatter (name, description, …).
@@ -124,9 +131,24 @@ export async function getSubagentsGitignorePaths(
     return [];
   }
   const targets = getSelectedSubagentTargets(agents);
-  return Array.from(targets).map((t) =>
-    path.join(projectRoot, SUBAGENT_TARGET_PATHS[t]),
-  );
+  const { subagents } = await discoverSubagents(projectRoot);
+  if (subagents.length === 0) {
+    return [];
+  }
+
+  const generatedPaths = new Set<string>();
+  for (const target of targets) {
+    const targetPath = path.join(projectRoot, SUBAGENT_TARGET_PATHS[target]);
+    generatedPaths.add(path.join(targetPath, RULER_MANAGED_MANIFEST));
+    for (const subagent of subagents) {
+      const outputPath =
+        target === 'codex'
+          ? withExtension(getSourceRelativeMdPath(subagent), '.toml')
+          : getSourceRelativeMdPath(subagent);
+      generatedPaths.add(path.join(targetPath, outputPath));
+    }
+  }
+  return Array.from(generatedPaths);
 }
 
 /**
@@ -167,14 +189,125 @@ function ensureBodyFormatting(body: string | undefined): string {
 }
 
 /* ------------------------------------------------------------------ */
-/* Atomic directory write                                              */
+/* Managed directory write                                             */
 /* ------------------------------------------------------------------ */
 
+function isSafeManagedRelativePath(relativePath: string): boolean {
+  return (
+    relativePath.length > 0 &&
+    !path.isAbsolute(relativePath) &&
+    !relativePath.split(path.sep).includes('..') &&
+    !relativePath.split('/').includes('..')
+  );
+}
+
+async function readManagedManifest(targetDir: string): Promise<string[]> {
+  try {
+    const content = await fs.readFile(
+      path.join(targetDir, RULER_MANAGED_MANIFEST),
+      'utf8',
+    );
+    const parsed = JSON.parse(content) as Partial<ManagedManifest>;
+    if (!Array.isArray(parsed.paths)) {
+      return [];
+    }
+    return parsed.paths.filter(
+      (entry): entry is string =>
+        typeof entry === 'string' && isSafeManagedRelativePath(entry),
+    );
+  } catch {
+    return [];
+  }
+}
+
+async function removeDirectoryIfEmpty(dirPath: string): Promise<void> {
+  try {
+    const entries = await fs.readdir(dirPath);
+    if (entries.length === 0) {
+      await fs.rmdir(dirPath);
+    }
+  } catch {
+    // Directory is missing or not empty; either state is fine.
+  }
+}
+
+async function removeEmptyParentsUntil(
+  boundaryDir: string,
+  startDir: string,
+): Promise<void> {
+  let current = startDir;
+  while (current !== boundaryDir && current.startsWith(boundaryDir)) {
+    await removeDirectoryIfEmpty(current);
+    const next = path.dirname(current);
+    if (next === current) {
+      return;
+    }
+    current = next;
+  }
+}
+
+async function removeManagedEntries(
+  targetDir: string,
+  managedPaths: string[],
+  projectRoot: string,
+): Promise<void> {
+  const sortedPaths = Array.from(new Set(managedPaths)).sort(
+    (a, b) => b.length - a.length,
+  );
+
+  for (const managedPath of sortedPaths) {
+    const outputPath = path.join(targetDir, managedPath);
+    await assertManagedPathInsideRoot(
+      outputPath,
+      projectRoot,
+      'Refusing to remove managed subagent entry through symlinked path',
+    );
+    await fs.rm(outputPath, { recursive: true, force: true });
+    await removeEmptyParentsUntil(targetDir, path.dirname(outputPath));
+  }
+}
+
+async function removeManagedManifest(
+  targetDir: string,
+  projectRoot: string,
+): Promise<void> {
+  const manifestPath = path.join(targetDir, RULER_MANAGED_MANIFEST);
+  await assertManagedPathInsideRoot(
+    manifestPath,
+    projectRoot,
+    'Refusing to remove subagents manifest through symlinked path',
+  );
+  await fs.rm(manifestPath, { force: true });
+}
+
+async function writeManagedManifest(
+  targetDir: string,
+  managedPaths: string[],
+  projectRoot: string,
+): Promise<void> {
+  const manifestPath = path.join(targetDir, RULER_MANAGED_MANIFEST);
+  await assertManagedPathInsideRoot(
+    manifestPath,
+    projectRoot,
+    'Refusing to write subagents manifest through symlinked path',
+  );
+  const manifest: ManagedManifest = {
+    version: 1,
+    paths: Array.from(new Set(managedPaths)).sort(),
+  };
+  await fs.writeFile(
+    manifestPath,
+    `${JSON.stringify(manifest, null, 2)}\n`,
+    'utf8',
+  );
+}
+
 /**
- * Stages files into a temp directory and atomically swaps it into place.
- * Mirrors the pattern used by SkillsProcessor for safe overwriting.
+ * Writes generated subagent files without taking ownership of the whole native
+ * directory. The manifest lets later applies remove stale Ruler-owned files
+ * while preserving user-created native files.
  */
-async function writeAgentsDirectoryAtomic(
+async function writeManagedAgentsDirectory(
   targetDir: string,
   files: { name: string; content: string }[],
   projectRoot: string,
@@ -186,30 +319,30 @@ async function writeAgentsDirectoryAtomic(
     'Refusing to replace subagents directory through symlinked path',
   );
   await fs.mkdir(parent, { recursive: true });
+  await fs.mkdir(targetDir, { recursive: true });
 
-  const tempDir = path.join(parent, `agents.tmp-${Date.now()}`);
-  await fs.mkdir(tempDir, { recursive: true });
+  const previousManagedPaths = await readManagedManifest(targetDir);
+  await removeManagedEntries(targetDir, previousManagedPaths, projectRoot);
+  await removeManagedManifest(targetDir, projectRoot);
 
-  try {
-    for (const { name, content } of files) {
-      const outputPath = path.join(tempDir, name);
-      await fs.mkdir(path.dirname(outputPath), { recursive: true });
-      await fs.writeFile(outputPath, content, 'utf8');
+  for (const { name, content } of files) {
+    if (!isSafeManagedRelativePath(name)) {
+      throw new Error(`Refusing to write unsafe subagent path: ${name}`);
     }
-    try {
-      await fs.rm(targetDir, { recursive: true, force: true });
-    } catch {
-      // Target didn't exist; ignore.
-    }
-    await fs.rename(tempDir, targetDir);
-  } catch (error) {
-    try {
-      await fs.rm(tempDir, { recursive: true, force: true });
-    } catch {
-      // Ignore cleanup errors.
-    }
-    throw error;
+    const outputPath = path.join(targetDir, name);
+    await assertManagedPathInsideRoot(
+      outputPath,
+      projectRoot,
+      'Refusing to write subagent through symlinked path',
+    );
+    await fs.mkdir(path.dirname(outputPath), { recursive: true });
+    await fs.writeFile(outputPath, content, 'utf8');
   }
+  await writeManagedManifest(
+    targetDir,
+    files.map((file) => file.name),
+    projectRoot,
+  );
 }
 
 /* ------------------------------------------------------------------ */
@@ -345,7 +478,7 @@ export async function propagateSubagentsForClaude(
     name: getSourceRelativeMdPath(s),
     content: buildClaudeFile(s),
   }));
-  await writeAgentsDirectoryAtomic(targetDir, files, projectRoot);
+  await writeManagedAgentsDirectory(targetDir, files, projectRoot);
   return [];
 }
 
@@ -366,7 +499,7 @@ export async function propagateSubagentsForCursor(
     name: getSourceRelativeMdPath(s),
     content: buildCursorFile(s),
   }));
-  await writeAgentsDirectoryAtomic(targetDir, files, projectRoot);
+  await writeManagedAgentsDirectory(targetDir, files, projectRoot);
   return [];
 }
 
@@ -387,7 +520,7 @@ export async function propagateSubagentsForCodex(
     name: withExtension(getSourceRelativeMdPath(s), '.toml'),
     content: buildCodexFile(s),
   }));
-  await writeAgentsDirectoryAtomic(targetDir, files, projectRoot);
+  await writeManagedAgentsDirectory(targetDir, files, projectRoot);
   return [];
 }
 
@@ -416,7 +549,7 @@ export async function propagateSubagentsForCopilot(
     name: getSourceRelativeMdPath(s),
     content: buildCopilotFile(s, false, verbose).content,
   }));
-  await writeAgentsDirectoryAtomic(targetDir, files, projectRoot);
+  await writeManagedAgentsDirectory(targetDir, files, projectRoot);
   return [];
 }
 
@@ -437,16 +570,35 @@ async function cleanupSubagentsDir(
     return;
   }
   if (dryRun) {
-    logVerboseInfo(`DRY RUN: Would remove ${relPath}`, verbose, dryRun);
+    logVerboseInfo(
+      `DRY RUN: Would remove Ruler-managed entries from ${relPath}`,
+      verbose,
+      dryRun,
+    );
     return;
   }
   await assertManagedPathInsideRoot(
     target,
     projectRoot,
-    'Refusing to remove subagents directory through symlinked path',
+    'Refusing to clean subagents directory through symlinked path',
   );
-  await fs.rm(target, { recursive: true, force: true });
-  logVerboseInfo(`Removed ${relPath} (subagents disabled)`, verbose, dryRun);
+  const managedPaths = await readManagedManifest(target);
+  if (managedPaths.length === 0) {
+    logVerboseInfo(
+      `No Ruler-managed subagents found in ${relPath}; leaving directory unchanged`,
+      verbose,
+      dryRun,
+    );
+    return;
+  }
+  await removeManagedEntries(target, managedPaths, projectRoot);
+  await removeManagedManifest(target, projectRoot);
+  await removeDirectoryIfEmpty(target);
+  logVerboseInfo(
+    `Removed Ruler-managed entries from ${relPath} (subagents disabled)`,
+    verbose,
+    dryRun,
+  );
 }
 
 async function cleanupAllSubagentsDirectories(

--- a/tests/skills-propagation.test.ts
+++ b/tests/skills-propagation.test.ts
@@ -13,6 +13,7 @@ import {
 
 describe('Skills Discovery and Validation', () => {
   let tmpDir: string;
+  const managedManifest = '.ruler-managed.json';
 
   beforeEach(async () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ruler-skills-test-'));
@@ -127,12 +128,15 @@ describe('Skills Discovery and Validation', () => {
       );
       const skillsDir = path.join(tmpDir, '.ruler', 'skills');
 
-      await fs.mkdir(skillsDir, { recursive: true });
+      await fs.mkdir(path.join(skillsDir, 'skill1'), { recursive: true });
 
       const antigravityAgent = new AntigravityAgent();
       const paths = await getSkillsGitignorePaths(tmpDir, [antigravityAgent]);
 
-      expect(paths).toEqual([path.join(tmpDir, ANTIGRAVITY_SKILLS_PATH)]);
+      expect(paths).toEqual([
+        path.join(tmpDir, ANTIGRAVITY_SKILLS_PATH, managedManifest),
+        path.join(tmpDir, ANTIGRAVITY_SKILLS_PATH, 'skill1'),
+      ]);
     });
 
     it('returns claude skills path for copilot agent', async () => {
@@ -142,11 +146,14 @@ describe('Skills Discovery and Validation', () => {
       const { CopilotAgent } = await import('../src/agents/CopilotAgent');
       const skillsDir = path.join(tmpDir, '.ruler', 'skills');
 
-      await fs.mkdir(skillsDir, { recursive: true });
+      await fs.mkdir(path.join(skillsDir, 'skill1'), { recursive: true });
 
       const paths = await getSkillsGitignorePaths(tmpDir, [new CopilotAgent()]);
 
-      expect(paths).toEqual([path.join(tmpDir, CLAUDE_SKILLS_PATH)]);
+      expect(paths).toEqual([
+        path.join(tmpDir, CLAUDE_SKILLS_PATH, managedManifest),
+        path.join(tmpDir, CLAUDE_SKILLS_PATH, 'skill1'),
+      ]);
     });
 
     it('returns junie skills path for Junie agent', async () => {
@@ -156,11 +163,14 @@ describe('Skills Discovery and Validation', () => {
       const { JunieAgent } = await import('../src/agents/JunieAgent');
       const skillsDir = path.join(tmpDir, '.ruler', 'skills');
 
-      await fs.mkdir(skillsDir, { recursive: true });
+      await fs.mkdir(path.join(skillsDir, 'skill1'), { recursive: true });
 
       const paths = await getSkillsGitignorePaths(tmpDir, [new JunieAgent()]);
 
-      expect(paths).toEqual([path.join(tmpDir, JUNIE_SKILLS_PATH)]);
+      expect(paths).toEqual([
+        path.join(tmpDir, JUNIE_SKILLS_PATH, managedManifest),
+        path.join(tmpDir, JUNIE_SKILLS_PATH, 'skill1'),
+      ]);
     });
 
     it('returns windsurf skills path for Windsurf agent', async () => {
@@ -170,13 +180,16 @@ describe('Skills Discovery and Validation', () => {
       const { WindsurfAgent } = await import('../src/agents/WindsurfAgent');
       const skillsDir = path.join(tmpDir, '.ruler', 'skills');
 
-      await fs.mkdir(skillsDir, { recursive: true });
+      await fs.mkdir(path.join(skillsDir, 'skill1'), { recursive: true });
 
       const paths = await getSkillsGitignorePaths(tmpDir, [
         new WindsurfAgent(),
       ]);
 
-      expect(paths).toEqual([path.join(tmpDir, WINDSURF_SKILLS_PATH)]);
+      expect(paths).toEqual([
+        path.join(tmpDir, WINDSURF_SKILLS_PATH, managedManifest),
+        path.join(tmpDir, WINDSURF_SKILLS_PATH, 'skill1'),
+      ]);
     });
   });
 
@@ -309,7 +322,7 @@ describe('Skills Discovery and Validation', () => {
       expect(stats.isDirectory()).toBe(true);
     });
 
-    it('uses atomic replace when overwriting existing skills', async () => {
+    it('preserves existing unmanaged skills while copying Ruler skills', async () => {
       const { propagateSkillsForClaude } = await import(
         '../src/core/SkillsProcessor'
       );
@@ -318,26 +331,52 @@ describe('Skills Discovery and Validation', () => {
       const claudeSkillsDir = path.join(tmpDir, '.claude', 'skills');
       const oldSkill = path.join(claudeSkillsDir, 'old-skill');
 
-      // Create old skills
       await fs.mkdir(oldSkill, { recursive: true });
       await fs.writeFile(path.join(oldSkill, SKILL_MD_FILENAME), '# Old Skill');
 
-      // Create new skills
       await fs.mkdir(skill1, { recursive: true });
       await fs.writeFile(path.join(skill1, SKILL_MD_FILENAME), '# Skill 1');
 
       await propagateSkillsForClaude(tmpDir, { dryRun: false });
 
-      // Old skill should be replaced
       const copiedSkill = path.join(
         claudeSkillsDir,
         'skill1',
         SKILL_MD_FILENAME,
       );
       expect(await fs.readFile(copiedSkill, 'utf8')).toBe('# Skill 1');
+      expect(
+        await fs.readFile(path.join(oldSkill, SKILL_MD_FILENAME), 'utf8'),
+      ).toBe('# Old Skill');
+    });
 
-      // Old skill should not exist
-      await expect(fs.access(oldSkill)).rejects.toThrow();
+    it('removes stale Ruler-managed skills from a previous propagation', async () => {
+      const { propagateSkillsForClaude } = await import(
+        '../src/core/SkillsProcessor'
+      );
+      const skillsDir = path.join(tmpDir, '.ruler', 'skills');
+      const oldSkill = path.join(skillsDir, 'old-skill');
+      const skill1 = path.join(skillsDir, 'skill1');
+      const claudeSkillsDir = path.join(tmpDir, '.claude', 'skills');
+
+      await fs.mkdir(oldSkill, { recursive: true });
+      await fs.writeFile(path.join(oldSkill, SKILL_MD_FILENAME), '# Old Skill');
+      await propagateSkillsForClaude(tmpDir, { dryRun: false });
+
+      await fs.rm(oldSkill, { recursive: true, force: true });
+      await fs.mkdir(skill1, { recursive: true });
+      await fs.writeFile(path.join(skill1, SKILL_MD_FILENAME), '# Skill 1');
+      await propagateSkillsForClaude(tmpDir, { dryRun: false });
+
+      await expect(
+        fs.access(path.join(claudeSkillsDir, 'old-skill')),
+      ).rejects.toThrow();
+      await expect(
+        fs.readFile(
+          path.join(claudeSkillsDir, 'skill1', SKILL_MD_FILENAME),
+          'utf8',
+        ),
+      ).resolves.toBe('# Skill 1');
     });
 
     it('uses a unique temp directory instead of reusing stale temp content', async () => {
@@ -1368,7 +1407,7 @@ describe('Skills Discovery and Validation', () => {
   });
 
   describe('propagateSkills - cleanup when disabled', () => {
-    it('removes skills directories when skills are disabled', async () => {
+    it('preserves unmanaged skills directories when skills are disabled', async () => {
       const { propagateSkills } = await import('../src/core/SkillsProcessor');
       const { allAgents } = await import('../src/lib');
       const claudeSkillsDir = path.join(tmpDir, '.claude', 'skills');
@@ -1475,19 +1514,47 @@ describe('Skills Discovery and Validation', () => {
       // Run propagateSkills with skillsEnabled = false
       await propagateSkills(tmpDir, allAgents, false, false, false);
 
-      // Verify directories were removed
-      await expect(fs.access(claudeSkillsDir)).rejects.toThrow();
-      await expect(fs.access(opencodeSkillsDir)).rejects.toThrow();
-      await expect(fs.access(piSkillsDir)).rejects.toThrow();
-      await expect(fs.access(gooseSkillsDir)).rejects.toThrow();
-      await expect(fs.access(vibeSkillsDir)).rejects.toThrow();
-      await expect(fs.access(rooSkillsDir)).rejects.toThrow();
-      await expect(fs.access(geminiSkillsDir)).rejects.toThrow();
-      await expect(fs.access(junieSkillsDir)).rejects.toThrow();
-      await expect(fs.access(cursorSkillsDir)).rejects.toThrow();
-      await expect(fs.access(factorySkillsDir)).rejects.toThrow();
-      await expect(fs.access(antigravitySkillsDir)).rejects.toThrow();
-      await expect(fs.access(windsurfSkillsDir)).rejects.toThrow();
+      // Verify unmanaged directories were preserved
+      await expect(fs.access(claudeSkillsDir)).resolves.toBeUndefined();
+      await expect(fs.access(opencodeSkillsDir)).resolves.toBeUndefined();
+      await expect(fs.access(piSkillsDir)).resolves.toBeUndefined();
+      await expect(fs.access(gooseSkillsDir)).resolves.toBeUndefined();
+      await expect(fs.access(vibeSkillsDir)).resolves.toBeUndefined();
+      await expect(fs.access(rooSkillsDir)).resolves.toBeUndefined();
+      await expect(fs.access(geminiSkillsDir)).resolves.toBeUndefined();
+      await expect(fs.access(junieSkillsDir)).resolves.toBeUndefined();
+      await expect(fs.access(cursorSkillsDir)).resolves.toBeUndefined();
+      await expect(fs.access(factorySkillsDir)).resolves.toBeUndefined();
+      await expect(fs.access(antigravitySkillsDir)).resolves.toBeUndefined();
+      await expect(fs.access(windsurfSkillsDir)).resolves.toBeUndefined();
+    });
+
+    it('removes Ruler-managed skills when skills are disabled', async () => {
+      const { propagateSkills } = await import('../src/core/SkillsProcessor');
+      const { allAgents } = await import('../src/lib');
+      const sourceSkill = path.join(
+        tmpDir,
+        '.ruler',
+        'skills',
+        'managed-skill',
+      );
+      const userSkill = path.join(tmpDir, '.claude', 'skills', 'user-skill');
+
+      await fs.mkdir(sourceSkill, { recursive: true });
+      await fs.writeFile(
+        path.join(sourceSkill, SKILL_MD_FILENAME),
+        '# Managed Skill',
+      );
+      await fs.mkdir(userSkill, { recursive: true });
+      await fs.writeFile(path.join(userSkill, SKILL_MD_FILENAME), '# User');
+
+      await propagateSkills(tmpDir, allAgents, true, false, false);
+      await propagateSkills(tmpDir, allAgents, false, false, false);
+
+      await expect(
+        fs.access(path.join(tmpDir, '.claude', 'skills', 'managed-skill')),
+      ).rejects.toThrow();
+      await expect(fs.access(userSkill)).resolves.toBeUndefined();
     });
 
     it('logs cleanup in dry-run mode without actually removing directories', async () => {
@@ -1515,22 +1582,20 @@ describe('Skills Discovery and Validation', () => {
       ).resolves.toBeUndefined();
     });
 
-    it('surfaces filesystem errors during cleanup', async () => {
+    it('leaves unmanaged directories unchanged during cleanup', async () => {
       const { propagateSkills } = await import('../src/core/SkillsProcessor');
       const { allAgents } = await import('../src/lib');
       const claudeSkillsDir = path.join(tmpDir, '.claude', 'skills');
-      const claudeDir = path.dirname(claudeSkillsDir);
 
       await fs.mkdir(claudeSkillsDir, { recursive: true });
-      await fs.chmod(claudeDir, 0o555);
+      await fs.writeFile(path.join(claudeSkillsDir, 'local.md'), 'local');
 
-      try {
-        await expect(
-          propagateSkills(tmpDir, allAgents, false, false, false),
-        ).rejects.toThrow();
-      } finally {
-        await fs.chmod(claudeDir, 0o755);
-      }
+      await expect(
+        propagateSkills(tmpDir, allAgents, false, false, false),
+      ).resolves.toBeUndefined();
+      await expect(
+        fs.readFile(path.join(claudeSkillsDir, 'local.md'), 'utf8'),
+      ).resolves.toBe('local');
     });
   });
 });

--- a/tests/subagents-propagation.test.ts
+++ b/tests/subagents-propagation.test.ts
@@ -127,6 +127,27 @@ describe('Subagents per-agent propagators', () => {
       ).resolves.toBeUndefined();
     });
 
+    it('preserves existing unmanaged native subagent files', async () => {
+      const unmanagedTarget = path.join(
+        tmpDir,
+        CLAUDE_SUBAGENTS_PATH,
+        'local.md',
+      );
+      await fs.mkdir(path.dirname(unmanagedTarget), { recursive: true });
+      await fs.writeFile(unmanagedTarget, 'local agent', 'utf8');
+
+      await propagateSubagentsForClaude(tmpDir, [makeSubagent()], {
+        dryRun: false,
+      });
+
+      await expect(fs.readFile(unmanagedTarget, 'utf8')).resolves.toBe(
+        'local agent',
+      );
+      await expect(
+        fs.access(path.join(tmpDir, CLAUDE_SUBAGENTS_PATH, 'reviewer.md')),
+      ).resolves.toBeUndefined();
+    });
+
     it('preserves nested source-relative paths', async () => {
       const sub = makeSubagent({ sourceRelativePath: 'sub/reviewer.md' });
       await propagateSubagentsForClaude(tmpDir, [sub], { dryRun: false });

--- a/tests/unit/core/SubagentsProcessor.test.ts
+++ b/tests/unit/core/SubagentsProcessor.test.ts
@@ -6,6 +6,7 @@ import {
   propagateSubagentsForCursor,
   propagateSubagentsForCodex,
   propagateSubagentsForCopilot,
+  getSubagentsGitignorePaths,
   _resetExperimentalWarningForTests,
 } from '../../../src/core/SubagentsProcessor';
 import {
@@ -120,6 +121,27 @@ describe('SubagentsProcessor — propagateSubagents orchestrator', () => {
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
+  it('returns generated subagent files and manifests for gitignore paths', async () => {
+    const sourceDir = path.join(tmpDir, RULER_SUBAGENTS_PATH, 'nested');
+    await fs.mkdir(sourceDir, { recursive: true });
+    await fs.writeFile(
+      path.join(sourceDir, 'reviewer.md'),
+      '---\nname: reviewer\ndescription: Reviews code\n---\nbody\n',
+    );
+
+    await expect(
+      getSubagentsGitignorePaths(tmpDir, [
+        new ClaudeAgent(),
+        new CodexCliAgent(),
+      ]),
+    ).resolves.toEqual([
+      path.join(tmpDir, CLAUDE_SUBAGENTS_PATH, '.ruler-managed.json'),
+      path.join(tmpDir, CLAUDE_SUBAGENTS_PATH, 'nested', 'reviewer.md'),
+      path.join(tmpDir, CODEX_SUBAGENTS_PATH, '.ruler-managed.json'),
+      path.join(tmpDir, CODEX_SUBAGENTS_PATH, 'nested', 'reviewer.toml'),
+    ]);
+  });
+
   it('does not clean up target dirs when subagentsEnabled is false and cleanup_orphaned is disabled', async () => {
     // Pre-create a stale target dir.
     const staleClaude = path.join(tmpDir, CLAUDE_SUBAGENTS_PATH);
@@ -140,8 +162,24 @@ describe('SubagentsProcessor — propagateSubagents orchestrator', () => {
 
   it('cleans up all four target dirs when subagentsEnabled is false and cleanup_orphaned is enabled', async () => {
     const staleClaude = path.join(tmpDir, CLAUDE_SUBAGENTS_PATH);
-    await fs.mkdir(staleClaude, { recursive: true });
-    await fs.writeFile(path.join(staleClaude, 'old.md'), 'stale');
+    const sourceDir = path.join(tmpDir, RULER_SUBAGENTS_PATH);
+    await fs.mkdir(sourceDir, { recursive: true });
+    await fs.writeFile(
+      path.join(sourceDir, 'old.md'),
+      '---\nname: old\ndescription: old\n---\nstale\n',
+    );
+
+    await propagateSubagents(
+      tmpDir,
+      [new ClaudeAgent()],
+      true,
+      true,
+      false,
+      false,
+    );
+    await expect(
+      fs.access(path.join(staleClaude, 'old.md')),
+    ).resolves.toBeUndefined();
 
     await propagateSubagents(
       tmpDir,
@@ -157,8 +195,22 @@ describe('SubagentsProcessor — propagateSubagents orchestrator', () => {
 
   it('cleans up all targets when .ruler/agents directory does not exist and cleanup_orphaned is enabled', async () => {
     const staleCursor = path.join(tmpDir, CURSOR_SUBAGENTS_PATH);
-    await fs.mkdir(staleCursor, { recursive: true });
-    await fs.writeFile(path.join(staleCursor, 'gone.md'), 'stale');
+    const sourceDir = path.join(tmpDir, RULER_SUBAGENTS_PATH);
+    await fs.mkdir(sourceDir, { recursive: true });
+    await fs.writeFile(
+      path.join(sourceDir, 'gone.md'),
+      '---\nname: gone\ndescription: gone\n---\nstale\n',
+    );
+
+    await propagateSubagents(
+      tmpDir,
+      [new CursorAgent()],
+      true,
+      true,
+      false,
+      false,
+    );
+    await fs.rm(sourceDir, { recursive: true, force: true });
 
     // Source dir intentionally absent.
     await propagateSubagents(
@@ -176,12 +228,21 @@ describe('SubagentsProcessor — propagateSubagents orchestrator', () => {
   it('cleans up targets when .ruler/agents has no valid subagents and cleanup_orphaned is enabled', async () => {
     const sourceDir = path.join(tmpDir, RULER_SUBAGENTS_PATH);
     await fs.mkdir(sourceDir, { recursive: true });
-    // File with no frontmatter — invalid, skipped with warning.
-    await fs.writeFile(path.join(sourceDir, 'broken.md'), 'no frontmatter');
-
     const staleCodex = path.join(tmpDir, CODEX_SUBAGENTS_PATH);
-    await fs.mkdir(staleCodex, { recursive: true });
-    await fs.writeFile(path.join(staleCodex, 'leftover.toml'), 'stale');
+    await fs.writeFile(
+      path.join(sourceDir, 'leftover.md'),
+      '---\nname: leftover\ndescription: leftover\n---\nstale\n',
+    );
+    await propagateSubagents(
+      tmpDir,
+      [new CodexCliAgent()],
+      true,
+      true,
+      false,
+      false,
+    );
+    await fs.writeFile(path.join(sourceDir, 'broken.md'), 'no frontmatter');
+    await fs.rm(path.join(sourceDir, 'leftover.md'), { force: true });
 
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
@@ -237,10 +298,15 @@ describe('SubagentsProcessor — propagateSubagents orchestrator', () => {
       '---\nname: reviewer\ndescription: Reviews code\ntools: [Read]\n---\nbody\n',
     );
 
-    // Pre-existing cursor target dir from a previous run.
     const cursorDir = path.join(tmpDir, CURSOR_SUBAGENTS_PATH);
-    await fs.mkdir(cursorDir, { recursive: true });
-    await fs.writeFile(path.join(cursorDir, 'reviewer.md'), 'prev');
+    await propagateSubagents(
+      tmpDir,
+      [new CursorAgent()],
+      true,
+      true,
+      false,
+      false,
+    );
 
     // This run only selects claude — cursor dir must be reconciled away.
     await propagateSubagents(


### PR DESCRIPTION
## Summary
- stop treating native skills and subagent directories as wholly Ruler-owned
- add per-target `.ruler-managed.json` manifests so later applies remove only stale Ruler-generated entries
- preserve unmanaged native skill/subagent files during apply and optional cleanup
- narrow generated gitignore entries to managed files/directories plus manifests

Fixes #646

## Verification
- `npm run build && npx jest tests/skills-propagation.test.ts tests/subagents-propagation.test.ts tests/unit/core/SubagentsProcessor.test.ts --runInBand --coverage=false`
- `npm ci && npm run check:package-lock && npm run format:check && npm run lint && npm test && npm audit --omit=dev --audit-level=moderate && npm audit --audit-level=moderate && npm run build && npm pack --dry-run`