### PR TITLE
Fix linked worktree local ignore handling

### DIFF
--- a/src/core/GitignoreUtils.ts
+++ b/src/core/GitignoreUtils.ts
@@ -1,9 +1,13 @@
 import { promises as fs } from 'fs';
 import * as path from 'path';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
 import { writeGeneratedFile } from './FileSystemUtils';
+import { isPathInsideOrEqual } from './path-utils';
 
 const RULER_START_MARKER = '# START Ruler Generated Files';
 const RULER_END_MARKER = '# END Ruler Generated Files';
+const execFileAsync = promisify(execFile);
 
 export interface RulerBlockRange {
   start: number;
@@ -13,6 +17,11 @@ export interface RulerBlockRange {
 export interface RemoveRulerBlocksResult {
   content: string;
   removed: boolean;
+}
+
+export interface ResolvedIgnoreFile {
+  path: string;
+  containmentRoot: string;
 }
 
 /**
@@ -28,7 +37,8 @@ export async function updateGitignore(
   paths: string[],
   ignoreFile = '.gitignore',
 ): Promise<void> {
-  const gitignorePath = await resolveIgnoreFilePath(projectRoot, ignoreFile);
+  const ignoreTarget = await resolveIgnoreFileTarget(projectRoot, ignoreFile);
+  const gitignorePath = ignoreTarget.path;
 
   // Read existing .gitignore or start with empty content
   let existingContent = '';
@@ -85,7 +95,11 @@ export async function updateGitignore(
   const newContent = updateGitignoreContent(existingContent, allRulerPaths);
 
   // Write the updated content
-  await writeGeneratedFile(gitignorePath, newContent);
+  await writeGeneratedFile(
+    gitignorePath,
+    newContent,
+    ignoreTarget.containmentRoot,
+  );
 }
 
 /**
@@ -97,30 +111,88 @@ export async function resolveIgnoreFilePath(
   projectRoot: string,
   ignoreFile: string,
 ): Promise<string> {
+  return (await resolveIgnoreFileTarget(projectRoot, ignoreFile)).path;
+}
+
+export async function resolveIgnoreFileTarget(
+  projectRoot: string,
+  ignoreFile: string,
+): Promise<ResolvedIgnoreFile> {
   if (ignoreFile !== '.git/info/exclude') {
-    return path.join(projectRoot, ignoreFile);
+    return {
+      path: path.join(projectRoot, ignoreFile),
+      containmentRoot: projectRoot,
+    };
   }
 
   const dotGitPath = path.join(projectRoot, '.git');
+  let dotGitStat;
   try {
-    const dotGitStat = await fs.lstat(dotGitPath);
-    if (dotGitStat.isFile()) {
-      const dotGitContent = await fs.readFile(dotGitPath, 'utf8');
-      const gitDirMatch = dotGitContent.match(/^gitdir:\s*(.+)\s*$/m);
-      if (gitDirMatch) {
-        const gitDir = gitDirMatch[1];
-        const resolvedGitDir = path.isAbsolute(gitDir)
-          ? gitDir
-          : path.resolve(projectRoot, gitDir);
-        return path.join(resolvedGitDir, 'info', 'exclude');
-      }
-    }
+    dotGitStat = await fs.lstat(dotGitPath);
   } catch {
     // Fall back to the historical project-root path for non-git test fixtures
     // and unusual repositories where `.git` cannot be inspected.
+    return {
+      path: path.join(projectRoot, ignoreFile),
+      containmentRoot: projectRoot,
+    };
   }
 
-  return path.join(projectRoot, ignoreFile);
+  if (dotGitStat.isFile()) {
+    const dotGitContent = await fs.readFile(dotGitPath, 'utf8');
+    const gitDirMatch = dotGitContent.match(/^gitdir:\s*(.+)\s*$/m);
+    if (gitDirMatch) {
+      const gitDir = gitDirMatch[1];
+      const resolvedGitDir = path.isAbsolute(gitDir)
+        ? gitDir
+        : path.resolve(projectRoot, gitDir);
+      await assertTrustedGitDir(projectRoot, resolvedGitDir);
+      return {
+        path: path.join(resolvedGitDir, 'info', 'exclude'),
+        containmentRoot: resolvedGitDir,
+      };
+    }
+  } else if (dotGitStat.isDirectory()) {
+    return {
+      path: path.join(dotGitPath, 'info', 'exclude'),
+      containmentRoot: projectRoot,
+    };
+  }
+
+  return {
+    path: path.join(projectRoot, ignoreFile),
+    containmentRoot: projectRoot,
+  };
+}
+
+async function assertTrustedGitDir(
+  projectRoot: string,
+  resolvedGitDir: string,
+): Promise<void> {
+  const realProjectRoot = await fs.realpath(projectRoot);
+  const realGitDir = await fs.realpath(resolvedGitDir);
+  if (isPathInsideOrEqual(realProjectRoot, realGitDir)) {
+    return;
+  }
+
+  try {
+    const { stdout } = await execFileAsync('git', [
+      '-C',
+      projectRoot,
+      'rev-parse',
+      '--absolute-git-dir',
+    ]);
+    const realVerifiedGitDir = await fs.realpath(stdout.trim());
+    if (realVerifiedGitDir === realGitDir) {
+      return;
+    }
+  } catch {
+    // Fall through to the fail-closed error below.
+  }
+
+  throw new Error(
+    `Refusing to use untrusted gitdir for .git/info/exclude: ${resolvedGitDir}`,
+  );
 }
 
 /**

--- a/src/revert.ts
+++ b/src/revert.ts
@@ -16,7 +16,7 @@ import {
 import { mapRawAgentConfigs } from './core/config-utils';
 import {
   removeCompleteRulerBlocks,
-  resolveIgnoreFilePath,
+  resolveIgnoreFileTarget,
 } from './core/GitignoreUtils';
 
 const agents: IAgent[] = allAgents;
@@ -221,7 +221,8 @@ async function cleanIgnoreFile(
   verbose: boolean,
   dryRun: boolean,
 ): Promise<boolean> {
-  const ignorePath = await resolveIgnoreFilePath(projectRoot, ignoreFile);
+  const ignoreTarget = await resolveIgnoreFileTarget(projectRoot, ignoreFile);
+  const ignorePath = ignoreTarget.path;
 
   try {
     await fs.access(ignorePath);
@@ -232,12 +233,16 @@ async function cleanIgnoreFile(
 
   await FileSystemUtils.assertManagedPathInsideRoot(
     ignorePath,
-    projectRoot,
+    ignoreTarget.containmentRoot,
     `Refusing to clean ${ignoreFile} through symlinked path`,
   );
   await FileSystemUtils.assertNotSymbolicLink(
     ignorePath,
     `Refusing to clean symlinked ${ignoreFile}`,
+  );
+  await FileSystemUtils.assertNotHardLinked(
+    ignorePath,
+    `Refusing to clean hard-linked ${ignoreFile}`,
   );
 
   const content = await fs.readFile(ignorePath, 'utf8');

--- a/tests/integration/revert-cli.test.ts
+++ b/tests/integration/revert-cli.test.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs/promises';
 import * as fsSync from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { execSync } from 'child_process';
+import { execFileSync, execSync } from 'child_process';
 
 describe('Revert CLI Integration', () => {
   let tmpDir: string;
@@ -266,6 +266,95 @@ describe('Revert CLI Integration', () => {
       );
 
       await expect(fs.access(outputPath)).rejects.toThrow();
+    });
+
+    it('cleans gitignore-local entries in linked worktrees', async () => {
+      const parentDir = await fs.mkdtemp(
+        path.join(os.tmpdir(), 'ruler-linked-worktree-'),
+      );
+      const repoDir = path.join(parentDir, 'repo');
+      const linkedWorktreeDir = path.join(parentDir, 'linked');
+
+      try {
+        execFileSync('git', ['init', repoDir], { stdio: 'pipe' });
+        execFileSync(
+          'git',
+          ['-C', repoDir, 'config', 'user.email', 'test@example.com'],
+          { stdio: 'pipe' },
+        );
+        execFileSync('git', ['-C', repoDir, 'config', 'user.name', 'Test'], {
+          stdio: 'pipe',
+        });
+
+        await fs.mkdir(path.join(repoDir, '.ruler'), { recursive: true });
+        await fs.writeFile(path.join(repoDir, '.ruler', 'AGENTS.md'), 'Rule\n');
+        execFileSync('git', ['-C', repoDir, 'add', '.ruler/AGENTS.md'], {
+          stdio: 'pipe',
+        });
+        execFileSync('git', ['-C', repoDir, 'commit', '-m', 'init'], {
+          stdio: 'pipe',
+        });
+        execFileSync(
+          'git',
+          [
+            '-C',
+            repoDir,
+            'worktree',
+            'add',
+            '-b',
+            'ruler-linked-test',
+            linkedWorktreeDir,
+          ],
+          { stdio: 'pipe' },
+        );
+
+        execFileSync(
+          'node',
+          [
+            'dist/cli/index.js',
+            'apply',
+            '--project-root',
+            linkedWorktreeDir,
+            '--agents',
+            'claude',
+            '--gitignore-local',
+            '--no-backup',
+          ],
+          { stdio: 'pipe' },
+        );
+
+        const dotGitContent = await fs.readFile(
+          path.join(linkedWorktreeDir, '.git'),
+          'utf8',
+        );
+        const gitDirMatch = dotGitContent.match(/^gitdir:\s*(.+)\s*$/m);
+        expect(gitDirMatch).not.toBeNull();
+        const gitDir = gitDirMatch?.[1] ?? '';
+        const resolvedGitDir = path.isAbsolute(gitDir)
+          ? gitDir
+          : path.resolve(linkedWorktreeDir, gitDir);
+        const excludePath = path.join(resolvedGitDir, 'info', 'exclude');
+
+        await expect(fs.readFile(excludePath, 'utf8')).resolves.toContain(
+          '# START Ruler Generated Files',
+        );
+
+        execFileSync(
+          'node',
+          ['dist/cli/index.js', 'revert', '--project-root', linkedWorktreeDir],
+          { stdio: 'pipe' },
+        );
+
+        await expect(
+          fs.access(path.join(linkedWorktreeDir, 'CLAUDE.md')),
+        ).rejects.toThrow();
+        const cleanedExclude = await fs
+          .readFile(excludePath, 'utf8')
+          .catch(() => '');
+        expect(cleanedExclude).not.toContain('# START Ruler Generated Files');
+      } finally {
+        await fs.rm(parentDir, { recursive: true, force: true });
+      }
     });
   });
 });

--- a/tests/unit/core/GitignoreUtils.test.ts
+++ b/tests/unit/core/GitignoreUtils.test.ts
@@ -192,6 +192,32 @@ CLAUDE.md
       ).rejects.toThrow();
     });
 
+    it('refuses local ignores through a symlinked gitdir info directory', async () => {
+      const actualGitDir = path.join(tmpDir, '.git-worktree');
+      const outsideDir = path.join(
+        path.dirname(tmpDir),
+        `${path.basename(tmpDir)}-outside`,
+      );
+      await fs.mkdir(actualGitDir, { recursive: true });
+      await fs.mkdir(outsideDir, { recursive: true });
+      await fs.symlink(outsideDir, path.join(actualGitDir, 'info'));
+      await fs.writeFile(
+        path.join(tmpDir, '.git'),
+        `gitdir: ${actualGitDir}\n`,
+      );
+
+      try {
+        await expect(
+          updateGitignore(tmpDir, ['CLAUDE.md'], '.git/info/exclude'),
+        ).rejects.toThrow('Refusing to write generated file');
+        await expect(
+          fs.access(path.join(outsideDir, 'exclude')),
+        ).rejects.toThrow();
+      } finally {
+        await fs.rm(outsideDir, { recursive: true, force: true });
+      }
+    });
+
     it('removes duplicate complete Ruler blocks when updating', async () => {
       const paths = ['CLAUDE.md'];
       const gitignorePath = path.join(tmpDir, '.gitignore');

--- a/tests/unit/core/revert.test.ts
+++ b/tests/unit/core/revert.test.ts
@@ -495,6 +495,38 @@ describe('Revert Core Functions', () => {
       ).rejects.toThrow();
     });
 
+    it('refuses to clean a hard-linked .gitignore', async () => {
+      const outsideFile = path.join(
+        path.dirname(tmpDir),
+        `${path.basename(tmpDir)}-outside-gitignore`,
+      );
+      const content = [
+        'node_modules/',
+        '# START Ruler Generated Files',
+        '/AGENTS.md',
+        '# END Ruler Generated Files',
+        '',
+      ].join('\n');
+      await fs.writeFile(outsideFile, content);
+      await fs.link(outsideFile, path.join(tmpDir, '.gitignore'));
+
+      try {
+        await expect(
+          revertAllAgentConfigs(
+            tmpDir,
+            undefined,
+            undefined,
+            false,
+            false,
+            false,
+          ),
+        ).rejects.toThrow('Refusing to clean hard-linked .gitignore');
+        await expect(fs.readFile(outsideFile, 'utf8')).resolves.toBe(content);
+      } finally {
+        await fs.rm(outsideFile, { force: true });
+      }
+    });
+
     it('leaves .gitignore unchanged during dry-run cleanup', async () => {
       const gitignoreContent = [
         '# START Ruler Generated Files',


### PR DESCRIPTION
## Summary
- resolve `.git/info/exclude` through trusted gitdir metadata for linked worktrees
- keep generated ignore writes contained to the resolved ignore-file root
- allow revert to clean linked-worktree excludes while still rejecting symlinked and hard-linked ignore files

Fixes #667
Fixes #668

## Verification
- `env -u npm_config_allow_scripts -u NPM_CONFIG_ALLOW_SCRIPTS npm_config_userconfig=/dev/null NPM_CONFIG_USERCONFIG=/dev/null npm run format`
- `env -u npm_config_allow_scripts -u NPM_CONFIG_ALLOW_SCRIPTS npm_config_userconfig=/dev/null NPM_CONFIG_USERCONFIG=/dev/null npm run check:package-lock`
- `env -u npm_config_allow_scripts -u NPM_CONFIG_ALLOW_SCRIPTS npm_config_userconfig=/dev/null NPM_CONFIG_USERCONFIG=/dev/null npm run format:check`
- `env -u npm_config_allow_scripts -u NPM_CONFIG_ALLOW_SCRIPTS npm_config_userconfig=/dev/null NPM_CONFIG_USERCONFIG=/dev/null npm run lint`
- `env -u npm_config_allow_scripts -u NPM_CONFIG_ALLOW_SCRIPTS npm_config_userconfig=/dev/null NPM_CONFIG_USERCONFIG=/dev/null npm test`
- `env -u npm_config_allow_scripts -u NPM_CONFIG_ALLOW_SCRIPTS npm_config_userconfig=/dev/null NPM_CONFIG_USERCONFIG=/dev/null npm run build`
- `env -u npm_config_allow_scripts -u NPM_CONFIG_ALLOW_SCRIPTS npm_config_userconfig=/dev/null NPM_CONFIG_USERCONFIG=/dev/null npm audit --omit=dev --audit-level=moderate`
- `env -u npm_config_allow_scripts -u NPM_CONFIG_ALLOW_SCRIPTS npm_config_userconfig=/dev/null NPM_CONFIG_USERCONFIG=/dev/null npm audit --audit-level=moderate`
- `env -u npm_config_allow_scripts -u NPM_CONFIG_ALLOW_SCRIPTS npm_config_userconfig=/dev/null NPM_CONFIG_USERCONFIG=/dev/null npm pack --dry-run`