### PR TITLE
Write provenance for adapter MCP configs

### DIFF
--- a/src/agents/GeminiCliAgent.ts
+++ b/src/agents/GeminiCliAgent.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { promises as fs } from 'fs';
 import { AgentsMdAgent } from './AgentsMdAgent';
 import { backupFile, writeGeneratedFile } from '../core/FileSystemUtils';
+import { writeMcpProvenance } from '../paths/mcp';
 
 export class GeminiCliAgent extends AgentsMdAgent {
   getIdentifier(): string {
@@ -125,6 +126,9 @@ export class GeminiCliAgent extends AgentsMdAgent {
     }
 
     await writeGeneratedFile(settingsPath, nextContent, projectRoot);
+    if (existingContent === null) {
+      await writeMcpProvenance(settingsPath, projectRoot);
+    }
   }
 
   // Ensure MCP merging uses the correct key for Gemini (.gemini/settings.json)

--- a/src/agents/RooCodeAgent.ts
+++ b/src/agents/RooCodeAgent.ts
@@ -8,6 +8,7 @@ import {
   ensureDirExists,
   writeGeneratedFile,
 } from '../core/FileSystemUtils';
+import { writeMcpProvenance } from '../paths/mcp';
 
 /**
  * Agent for RooCode that writes to AGENTS.md and generates .roo/mcp.json
@@ -127,6 +128,9 @@ export class RooCodeAgent implements IAgent {
       await backupFile(mcpPath, projectRoot);
     }
     await writeGeneratedFile(mcpPath, newContent, projectRoot);
+    if (existingContent === null) {
+      await writeMcpProvenance(mcpPath, projectRoot);
+    }
   }
 
   supportsMcpStdio(): boolean {

--- a/tests/integration/mcp-provenance.test.ts
+++ b/tests/integration/mcp-provenance.test.ts
@@ -57,4 +57,80 @@ describe('MCP provenance', () => {
       await teardownTestProject(project.projectRoot);
     }
   });
+
+  it('reverts generated Gemini settings when backup and gitignore tracking are disabled', async () => {
+    const project = await setupTestProject({
+      '.ruler/ruler.toml': [
+        '[gitignore]',
+        'enabled = false',
+        '',
+        '[backup]',
+        'enabled = false',
+        '',
+        '[mcp_servers.generated]',
+        'command = "node"',
+        'args = ["server.js"]',
+        '',
+      ].join('\n'),
+    });
+    const settingsPath = path.join(
+      project.projectRoot,
+      '.gemini',
+      'settings.json',
+    );
+    const provenancePath = `${settingsPath}.ruler-generated`;
+
+    try {
+      runRuler('apply --agents gemini', project.projectRoot);
+
+      await expect(fs.access(settingsPath)).resolves.toBeUndefined();
+      await expect(fs.access(provenancePath)).resolves.toBeUndefined();
+      await expect(
+        fs.access(path.join(project.projectRoot, '.gitignore')),
+      ).rejects.toThrow();
+
+      runRuler('revert --agents gemini', project.projectRoot);
+
+      await expect(fs.access(settingsPath)).rejects.toThrow();
+      await expect(fs.access(provenancePath)).rejects.toThrow();
+    } finally {
+      await teardownTestProject(project.projectRoot);
+    }
+  });
+
+  it('reverts generated RooCode MCP config when backup and gitignore tracking are disabled', async () => {
+    const project = await setupTestProject({
+      '.ruler/ruler.toml': [
+        '[gitignore]',
+        'enabled = false',
+        '',
+        '[backup]',
+        'enabled = false',
+        '',
+        '[mcp_servers.generated]',
+        'command = "node"',
+        'args = ["server.js"]',
+        '',
+      ].join('\n'),
+    });
+    const mcpPath = path.join(project.projectRoot, '.roo', 'mcp.json');
+    const provenancePath = `${mcpPath}.ruler-generated`;
+
+    try {
+      runRuler('apply --agents roo', project.projectRoot);
+
+      await expect(fs.access(mcpPath)).resolves.toBeUndefined();
+      await expect(fs.access(provenancePath)).resolves.toBeUndefined();
+      await expect(
+        fs.access(path.join(project.projectRoot, '.gitignore')),
+      ).rejects.toThrow();
+
+      runRuler('revert --agents roo', project.projectRoot);
+
+      await expect(fs.access(mcpPath)).rejects.toThrow();
+      await expect(fs.access(provenancePath)).rejects.toThrow();
+    } finally {
+      await teardownTestProject(project.projectRoot);
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- write Ruler provenance sidecars when Gemini creates `.gemini/settings.json`
- write Ruler provenance sidecars when RooCode creates `.roo/mcp.json`
- add integration coverage proving backup/gitignore-disabled apply can be reverted for both adapters

Fixes #669

## Verification
- `env -u npm_config_allow_scripts -u NPM_CONFIG_ALLOW_SCRIPTS npm_config_userconfig=/dev/null NPM_CONFIG_USERCONFIG=/dev/null npx jest tests/integration/mcp-provenance.test.ts --runInBand` (failed before fix, passed after fix)
- `env -u npm_config_allow_scripts -u NPM_CONFIG_ALLOW_SCRIPTS npm_config_userconfig=/dev/null NPM_CONFIG_USERCONFIG=/dev/null npx jest tests/unit/agents/GeminiCliAgent.test.ts tests/unit/agents/RooCodeAgent.test.ts --runInBand`
- `env -u npm_config_allow_scripts -u NPM_CONFIG_ALLOW_SCRIPTS npm_config_userconfig=/dev/null NPM_CONFIG_USERCONFIG=/dev/null npm run format`
- `env -u npm_config_allow_scripts -u NPM_CONFIG_ALLOW_SCRIPTS npm_config_userconfig=/dev/null NPM_CONFIG_USERCONFIG=/dev/null npm run check:package-lock`
- `env -u npm_config_allow_scripts -u NPM_CONFIG_ALLOW_SCRIPTS npm_config_userconfig=/dev/null NPM_CONFIG_USERCONFIG=/dev/null npm run format:check`
- `env -u npm_config_allow_scripts -u NPM_CONFIG_ALLOW_SCRIPTS npm_config_userconfig=/dev/null NPM_CONFIG_USERCONFIG=/dev/null npm run lint`
- `env -u npm_config_allow_scripts -u NPM_CONFIG_ALLOW_SCRIPTS npm_config_userconfig=/dev/null NPM_CONFIG_USERCONFIG=/dev/null npm test`
- `env -u npm_config_allow_scripts -u NPM_CONFIG_ALLOW_SCRIPTS npm_config_userconfig=/dev/null NPM_CONFIG_USERCONFIG=/dev/null npm run build`
- `env -u npm_config_allow_scripts -u NPM_CONFIG_ALLOW_SCRIPTS npm_config_userconfig=/dev/null NPM_CONFIG_USERCONFIG=/dev/null npm audit --omit=dev --audit-level=moderate`
- `env -u npm_config_allow_scripts -u NPM_CONFIG_ALLOW_SCRIPTS npm_config_userconfig=/dev/null NPM_CONFIG_USERCONFIG=/dev/null npm audit --audit-level=moderate`
- `env -u npm_config_allow_scripts -u NPM_CONFIG_ALLOW_SCRIPTS npm_config_userconfig=/dev/null NPM_CONFIG_USERCONFIG=/dev/null npm pack --dry-run`