### PR TITLE
Isolate package version npm subprocesses

### DIFF
--- a/tests/integration/cli-version.test.ts
+++ b/tests/integration/cli-version.test.ts
@@ -5,10 +5,13 @@ import * as path from 'path';
 
 describe('packaged CLI version', () => {
   let tmpDir: string;
+  let npmUserConfigPath: string;
   let tarballPath: string | undefined;
 
   beforeEach(async () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ruler-version-'));
+    npmUserConfigPath = path.join(tmpDir, 'empty-npmrc');
+    await fs.writeFile(npmUserConfigPath, '');
   });
 
   afterEach(async () => {
@@ -20,31 +23,60 @@ describe('packaged CLI version', () => {
   });
 
   it('reports the package version from a packed install', () => {
-    const packageJson = JSON.parse(
-      execFileSync(
-        'node',
-        ['-p', "JSON.stringify(require('./package.json'))"],
-        {
-          encoding: 'utf8',
-        },
-      ),
-    ) as { version: string };
+    const originalAllowScripts = process.env.npm_config_allow_scripts;
 
-    const tarballName = execFileSync('npm', ['pack', '--silent'], {
-      encoding: 'utf8',
-    }).trim();
-    tarballPath = path.join(process.cwd(), tarballName);
+    try {
+      process.env.npm_config_allow_scripts = 'better-sqlite3';
 
-    execFileSync('npm', ['install', '--prefix', tmpDir, tarballPath], {
-      stdio: 'pipe',
-    });
+      const packageJson = JSON.parse(
+        execFileSync(
+          'node',
+          ['-p', "JSON.stringify(require('./package.json'))"],
+          {
+            encoding: 'utf8',
+          },
+        ),
+      ) as { version: string };
 
-    const output = execFileSync(
-      path.join(tmpDir, 'node_modules', '.bin', 'ruler'),
-      ['--version'],
-      { encoding: 'utf8' },
-    ).trim();
+      const npmEnv = createIsolatedNpmEnv(npmUserConfigPath);
+      const tarballName = execFileSync('npm', ['pack', '--silent'], {
+        encoding: 'utf8',
+        env: npmEnv,
+      }).trim();
+      tarballPath = path.join(process.cwd(), tarballName);
 
-    expect(output).toBe(packageJson.version);
+      execFileSync('npm', ['install', '--prefix', tmpDir, tarballPath], {
+        stdio: 'pipe',
+        env: npmEnv,
+      });
+
+      const output = execFileSync(
+        path.join(tmpDir, 'node_modules', '.bin', 'ruler'),
+        ['--version'],
+        { encoding: 'utf8' },
+      ).trim();
+
+      expect(output).toBe(packageJson.version);
+    } finally {
+      if (originalAllowScripts === undefined) {
+        delete process.env.npm_config_allow_scripts;
+      } else {
+        process.env.npm_config_allow_scripts = originalAllowScripts;
+      }
+    }
   });
 });
+
+function createIsolatedNpmEnv(userConfigPath: string): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  for (const key of Object.keys(env)) {
+    if (
+      key.toLowerCase() === 'npm_config_allow_scripts' ||
+      key.toLowerCase() === 'npm_config_userconfig'
+    ) {
+      delete env[key];
+    }
+  }
+  env.npm_config_userconfig = userConfigPath;
+  return env;
+}


### PR DESCRIPTION
## Summary

- run the package CLI version test's `npm pack` and `npm install` subprocesses with an isolated npm user config
- strip inherited `npm_config_allow_scripts` from those subprocesses
- simulate the polluted environment in the test so the regression is covered

Fixes #689.

## Verification

- `env -u npm_config_allow_scripts npm_config_userconfig=/dev/null npx jest tests/integration/cli-version.test.ts --runInBand --coverage=false`
- `env -u npm_config_allow_scripts npm_config_userconfig=/dev/null sh -c 'set -e; npm run check:package-lock; npm run format:check; npm run lint; npm test; npm run build; npm audit --omit=dev --audit-level=moderate; npm audit --audit-level=moderate; npm pack --dry-run'`
