### PR TITLE
Clean up managed skills when disabled

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -113,6 +113,10 @@ export async function applyAllAgentConfigs(
   let generatedPaths: string[];
   let loadedConfig: LoadedConfig;
   let outputProjectRoot = projectRoot;
+  const gitignoreConfigurations: Array<{
+    projectRoot: string;
+    config: LoadedConfig;
+  }> = [];
 
   if (nested) {
     const hierarchicalConfigs = await loadNestedConfigurations(
@@ -159,28 +163,29 @@ export async function applyAllAgentConfigs(
       verbose,
     );
 
-    // Propagate skills if enabled - do this for each nested directory
-    const skillsEnabledResolved = resolveSkillsEnabled(
-      skillsEnabled,
-      rootConfig.skills?.enabled,
-    );
-    if (skillsEnabledResolved) {
-      const { propagateSkills } = await import('./core/SkillsProcessor');
-      // Propagate skills for each nested .ruler directory
-      for (const configEntry of hierarchicalConfigs) {
-        const nestedRoot = path.dirname(configEntry.rulerDir);
-        logVerbose(
-          `Propagating skills for nested directory: ${nestedRoot}`,
-          verbose,
-        );
-        await propagateSkills(
-          nestedRoot,
-          selectedAgents,
-          skillsEnabledResolved,
-          verbose,
-          dryRun,
-        );
-      }
+    const { propagateSkills } = await import('./core/SkillsProcessor');
+    // Propagate or clean up skills for each nested .ruler directory.
+    for (const configEntry of hierarchicalConfigs) {
+      const nestedRoot = path.dirname(configEntry.rulerDir);
+      gitignoreConfigurations.push({
+        projectRoot: nestedRoot,
+        config: configEntry.config,
+      });
+      const skillsEnabledResolved = resolveSkillsEnabled(
+        skillsEnabled,
+        configEntry.config.skills?.enabled,
+      );
+      logVerbose(
+        `Propagating skills for nested directory: ${nestedRoot}`,
+        verbose,
+      );
+      await propagateSkills(
+        nestedRoot,
+        selectedAgents,
+        skillsEnabledResolved,
+        verbose,
+        dryRun,
+      );
     }
 
     // Propagate subagents (mirrors skills handling for nested mode).
@@ -233,6 +238,10 @@ export async function applyAllAgentConfigs(
     outputProjectRoot = singleProjectRoot;
 
     loadedConfig = singleConfig.config;
+    gitignoreConfigurations.push({
+      projectRoot: singleProjectRoot,
+      config: singleConfig.config,
+    });
     singleConfig.config.cliAgents = includedAgents;
 
     logVerbose(
@@ -257,16 +266,14 @@ export async function applyAllAgentConfigs(
       skillsEnabled,
       singleConfig.config.skills?.enabled,
     );
-    if (skillsEnabledResolved) {
-      const { propagateSkills } = await import('./core/SkillsProcessor');
-      await propagateSkills(
-        singleProjectRoot,
-        selectedAgents,
-        skillsEnabledResolved,
-        verbose,
-        dryRun,
-      );
-    }
+    const { propagateSkills } = await import('./core/SkillsProcessor');
+    await propagateSkills(
+      singleProjectRoot,
+      selectedAgents,
+      skillsEnabledResolved,
+      verbose,
+      dryRun,
+    );
 
     // Propagate subagents (mirrors skills handling).
     const subagentsEnabledResolvedSingle = resolveSubagentsEnabled(
@@ -306,18 +313,19 @@ export async function applyAllAgentConfigs(
 
   // Add skills-generated paths to gitignore if skills are enabled
   let allGeneratedPaths = generatedPaths;
-  const skillsEnabledForGitignore = resolveSkillsEnabled(
-    skillsEnabled,
-    loadedConfig.skills?.enabled,
+  const skillsEnabledGitignoreConfigurations = gitignoreConfigurations.filter(
+    (entry) =>
+      resolveSkillsEnabled(skillsEnabled, entry.config.skills?.enabled),
   );
-  if (skillsEnabledForGitignore) {
-    // Skills enabled by default or explicitly
+  if (skillsEnabledGitignoreConfigurations.length > 0) {
     const { getSkillsGitignorePaths } = await import('./core/SkillsProcessor');
-    const skillsPaths = await getSkillsGitignorePaths(
-      outputProjectRoot,
-      selectedAgents,
-    );
-    allGeneratedPaths = [...allGeneratedPaths, ...skillsPaths];
+    for (const entry of skillsEnabledGitignoreConfigurations) {
+      const skillsPaths = await getSkillsGitignorePaths(
+        entry.projectRoot,
+        selectedAgents,
+      );
+      allGeneratedPaths = [...allGeneratedPaths, ...skillsPaths];
+    }
   }
 
   // Add subagents-generated paths to gitignore if subagents are enabled.

--- a/tests/integration/skills-config-precedence.test.ts
+++ b/tests/integration/skills-config-precedence.test.ts
@@ -57,6 +57,152 @@ enabled = false
     await expect(fs.access(claudeSkillsDir)).rejects.toThrow();
   });
 
+  it('removes previously managed native skills when skills are disabled', async () => {
+    const rulerDir = path.join(tmpDir, '.ruler');
+    const skillDir = path.join(rulerDir, 'skills', 'test-skill');
+
+    await fs.mkdir(skillDir, { recursive: true });
+    await fs.writeFile(path.join(skillDir, SKILL_MD_FILENAME), '# Test Skill');
+    await fs.writeFile(path.join(rulerDir, 'AGENTS.md'), '# Test Rules');
+    await fs.writeFile(
+      path.join(rulerDir, 'ruler.toml'),
+      `
+[skills]
+enabled = true
+`,
+    );
+
+    await applyAllAgentConfigs(
+      tmpDir,
+      ['claude'],
+      undefined,
+      true,
+      undefined,
+      undefined,
+      false,
+      false,
+      false,
+      false,
+      true,
+      undefined,
+    );
+
+    const copiedSkill = path.join(
+      tmpDir,
+      '.claude',
+      'skills',
+      'test-skill',
+      SKILL_MD_FILENAME,
+    );
+    expect(await fs.readFile(copiedSkill, 'utf8')).toBe('# Test Skill');
+
+    await fs.writeFile(
+      path.join(rulerDir, 'ruler.toml'),
+      `
+[skills]
+enabled = false
+`,
+    );
+
+    await applyAllAgentConfigs(
+      tmpDir,
+      ['claude'],
+      undefined,
+      true,
+      undefined,
+      undefined,
+      false,
+      false,
+      false,
+      false,
+      true,
+      undefined,
+    );
+
+    await expect(fs.access(copiedSkill)).rejects.toThrow();
+  });
+
+  it('removes nested native skills when child config disables skills', async () => {
+    const rootRulerDir = path.join(tmpDir, '.ruler');
+    const childRoot = path.join(tmpDir, 'packages', 'core');
+    const childRulerDir = path.join(childRoot, '.ruler');
+    const childSkillDir = path.join(childRulerDir, 'skills', 'child-skill');
+
+    await fs.mkdir(rootRulerDir, { recursive: true });
+    await fs.mkdir(childSkillDir, { recursive: true });
+    await fs.writeFile(path.join(rootRulerDir, 'AGENTS.md'), '# Root Rules');
+    await fs.writeFile(path.join(childRulerDir, 'AGENTS.md'), '# Child Rules');
+    await fs.writeFile(
+      path.join(childSkillDir, SKILL_MD_FILENAME),
+      '# Child Skill',
+    );
+    await fs.writeFile(
+      path.join(rootRulerDir, 'ruler.toml'),
+      `
+nested = true
+
+[skills]
+enabled = true
+`,
+    );
+    await fs.writeFile(
+      path.join(childRulerDir, 'ruler.toml'),
+      `
+[skills]
+enabled = true
+`,
+    );
+
+    await applyAllAgentConfigs(
+      tmpDir,
+      ['claude'],
+      undefined,
+      true,
+      undefined,
+      undefined,
+      false,
+      false,
+      false,
+      true,
+      true,
+      undefined,
+    );
+
+    const copiedSkill = path.join(
+      childRoot,
+      '.claude',
+      'skills',
+      'child-skill',
+      SKILL_MD_FILENAME,
+    );
+    expect(await fs.readFile(copiedSkill, 'utf8')).toBe('# Child Skill');
+
+    await fs.writeFile(
+      path.join(childRulerDir, 'ruler.toml'),
+      `
+[skills]
+enabled = false
+`,
+    );
+
+    await applyAllAgentConfigs(
+      tmpDir,
+      ['claude'],
+      undefined,
+      true,
+      undefined,
+      undefined,
+      false,
+      false,
+      false,
+      true,
+      true,
+      undefined,
+    );
+
+    await expect(fs.access(copiedSkill)).rejects.toThrow();
+  });
+
   it('honors skills.enabled = true in ruler.toml', async () => {
     // Setup .ruler directory with skills
     const rulerDir = path.join(tmpDir, '.ruler');


### PR DESCRIPTION
## Summary

- always route skills through `propagateSkills` so disabled skills trigger existing cleanup logic
- cover the two-apply regression where a managed native skill is copied, then `[skills] enabled = false` should remove it

Fixes #687.

## Verification

- `env -u npm_config_allow_scripts npm_config_userconfig=/dev/null npx jest tests/integration/skills-config-precedence.test.ts --runInBand --coverage=false`
- `env -u npm_config_allow_scripts npm_config_userconfig=/dev/null sh -c 'set -e; npm run check:package-lock; npm run format:check; npm run lint; npm test; npm run build; npm audit --omit=dev --audit-level=moderate; npm audit --audit-level=moderate; npm pack --dry-run'`
