### PR TITLE
Expand integration test script scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "test:integration": "jest tests/e2e/ruler.integration.test.ts --verbose",
+    "test:integration": "jest tests/e2e tests/integration --verbose",
     "clean": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\"",
     "build": "npm run clean && tsc",
     "check:package-lock": "node -e \"const pkg=require('./package.json'); const lock=require('./package-lock.json'); const root=lock.packages?.['']; if (lock.version !== pkg.version || root?.version !== pkg.version) { console.error('package-lock.json version metadata must match package.json version'); process.exit(1); }\"",

--- a/tests/unit/package-json.test.ts
+++ b/tests/unit/package-json.test.ts
@@ -51,4 +51,18 @@ describe('package manifest', () => {
       }
     }
   });
+
+  it('runs the intended integration and e2e test roots', () => {
+    const packageJsonPath = path.join(process.cwd(), 'package.json');
+    const packageJson = JSON.parse(
+      fs.readFileSync(packageJsonPath, 'utf8'),
+    ) as {
+      scripts?: Record<string, string>;
+    };
+
+    const script = packageJson.scripts?.['test:integration'] ?? '';
+    expect(script).toContain('tests/e2e');
+    expect(script).toContain('tests/integration');
+    expect(script).not.toContain('ruler.integration.test.ts');
+  });
 });


### PR DESCRIPTION
Fixes #713.

## Summary
- make test:integration cover both tests/e2e and tests/integration
- add a package-manifest regression so the script scope remains explicit

## Verification
- npm ci
- npx jest tests/unit/package-json.test.ts --runInBand --coverage=false
- npm run test:integration -- --listTests
- npm run check:package-lock
- npm run format:check
- npm run lint
- npm test
- npm run build
- npm audit --omit=dev --audit-level=moderate
- npm audit --audit-level=moderate
- npm pack --dry-run