### PR TITLE
Drop unused Ruler workflow permission

### DIFF
--- a/.github/workflows/ruler.yml
+++ b/.github/workflows/ruler.yml
@@ -10,7 +10,6 @@ concurrency:
 
 permissions:
   contents: write
-  pull-requests: read
 
 jobs:
   apply-ruler:

--- a/tests/unit/workflows/ruler-workflow.test.ts
+++ b/tests/unit/workflows/ruler-workflow.test.ts
@@ -1,0 +1,17 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('Ruler Apply workflow', () => {
+  it('does not request unused pull request permissions', () => {
+    const workflowPath = path.join(
+      process.cwd(),
+      '.github',
+      'workflows',
+      'ruler.yml',
+    );
+    const workflow = fs.readFileSync(workflowPath, 'utf8');
+
+    expect(workflow).toContain('permissions:\n  contents: write');
+    expect(workflow).not.toContain('pull-requests:');
+  });
+});


### PR DESCRIPTION
Fixes #707.

## Summary
- remove the unused pull-requests permission from the Ruler Apply workflow
- add a workflow manifest regression to catch permission creep

## Verification
- npm ci
- npx jest tests/unit/workflows/ruler-workflow.test.ts --runInBand --coverage=false
- npm run check:package-lock
- npm run format:check
- npm run lint
- npm test
- npm run build
- npm audit --omit=dev --audit-level=moderate
- npm audit --audit-level=moderate
- npm pack --dry-run