### PR TITLE
Disable persisted checkout credentials in read-only workflows

### DIFF
--- a/.github/workflows/this-codebase-smells.yml
+++ b/.github/workflows/this-codebase-smells.yml
@@ -35,6 +35,8 @@ jobs:
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         if: ${{ steps.gate.outputs.run != 'false' }}
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         if: ${{ steps.gate.outputs.run != 'false' }}

--- a/.github/workflows/writeme.yml
+++ b/.github/workflows/writeme.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Read prompt file
         id: prompt

--- a/tests/unit/workflows/this-codebase-smells-workflow.test.ts
+++ b/tests/unit/workflows/this-codebase-smells-workflow.test.ts
@@ -39,4 +39,16 @@ describe('This Codebase Smells workflow', () => {
     expect(tokenIndex).toBeGreaterThanOrEqual(0);
     expect(installIndex).toBeLessThan(tokenIndex);
   });
+
+  it('does not persist checkout credentials', () => {
+    const workflowPath = path.join(
+      process.cwd(),
+      '.github',
+      'workflows',
+      'this-codebase-smells.yml',
+    );
+    const workflow = fs.readFileSync(workflowPath, 'utf8');
+
+    expect(workflow).toContain('persist-credentials: false');
+  });
 });

--- a/tests/unit/workflows/writeme-workflow.test.ts
+++ b/tests/unit/workflows/writeme-workflow.test.ts
@@ -15,4 +15,16 @@ describe('WRITEME workflow', () => {
     expect(workflow).not.toContain('contents: write');
     expect(workflow).not.toContain('pull-requests: write');
   });
+
+  it('does not persist checkout credentials', () => {
+    const workflowPath = path.join(
+      process.cwd(),
+      '.github',
+      'workflows',
+      'writeme.yml',
+    );
+    const workflow = fs.readFileSync(workflowPath, 'utf8');
+
+    expect(workflow).toContain('persist-credentials: false');
+  });
 });


### PR DESCRIPTION
Fixes #701.

## Summary
- set persist-credentials: false for WRITEME checkout
- set persist-credentials: false for This Codebase Smells checkout
- add workflow tests for both read-only checkouts

## Verification
- npm ci
- npx jest tests/unit/workflows/writeme-workflow.test.ts tests/unit/workflows/this-codebase-smells-workflow.test.ts --runInBand --coverage=false
- npm run check:package-lock
- npm run format:check
- npm run lint
- npm test
- npm run build
- npm audit --omit=dev --audit-level=moderate
- npm audit --audit-level=moderate
- npm pack --dry-run