### PR TITLE
Restrict Ruler manual dispatch to main

### DIFF
--- a/.github/workflows/ruler.yml
+++ b/.github/workflows/ruler.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   apply-ruler:
-    if: ${{ (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') && !contains(github.event.head_commit.message || '', 'Ruler:') }}
+    if: ${{ github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message || '', 'Ruler:') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/tests/unit/workflows/ruler-workflow.test.ts
+++ b/tests/unit/workflows/ruler-workflow.test.ts
@@ -14,4 +14,22 @@ describe('Ruler Apply workflow', () => {
     expect(workflow).toContain('permissions:\n  contents: write');
     expect(workflow).not.toContain('pull-requests:');
   });
+
+  it('does not allow workflow dispatch to bypass the main branch check', () => {
+    const workflowPath = path.join(
+      process.cwd(),
+      '.github',
+      'workflows',
+      'ruler.yml',
+    );
+    const workflow = fs.readFileSync(workflowPath, 'utf8');
+    const jobCondition =
+      workflow.match(/^\s+if:\s+\${{(?<condition>.+)}}$/m)?.groups?.condition ??
+      '';
+
+    expect(jobCondition).toContain("github.ref == 'refs/heads/main'");
+    expect(jobCondition).not.toContain(
+      "|| github.event_name == 'workflow_dispatch'",
+    );
+  });
 });


### PR DESCRIPTION
Fixes #699.

## Summary
- require the Ruler Apply job to run only on refs/heads/main, including workflow_dispatch runs
- add a workflow regression for the manual-dispatch condition

## Verification
- npm ci
- npx jest tests/unit/workflows/ruler-workflow.test.ts --runInBand --coverage=false
- npm run check:package-lock
- npm run format:check
- npm run lint
- npm test
- npm run build
- npm audit --omit=dev --audit-level=moderate
- npm audit --audit-level=moderate
- npm pack --dry-run