### PR TITLE
Restrict WRITEME manual dispatch to main

### DIFF
--- a/.github/workflows/writeme.yml
+++ b/.github/workflows/writeme.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   create-copilot-job:
+    if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/tests/unit/workflows/writeme-workflow.test.ts
+++ b/tests/unit/workflows/writeme-workflow.test.ts
@@ -27,4 +27,19 @@ describe('WRITEME workflow', () => {
 
     expect(workflow).toContain('persist-credentials: false');
   });
+
+  it('only submits Copilot jobs from the main branch', () => {
+    const workflowPath = path.join(
+      process.cwd(),
+      '.github',
+      'workflows',
+      'writeme.yml',
+    );
+    const workflow = fs.readFileSync(workflowPath, 'utf8');
+    const jobCondition =
+      workflow.match(/^\s+if:\s+\${{(?<condition>.+)}}$/m)?.groups?.condition ??
+      '';
+
+    expect(jobCondition).toBe(" github.ref == 'refs/heads/main' ");
+  });
 });


### PR DESCRIPTION
Fixes #700

## Summary
- add a main-branch guard to the WRITEME Copilot job submission step
- cover the manual-dispatch branch guard in workflow tests

## Verification
- env -u npm_config_allow_scripts npm_config_userconfig=/dev/null npx jest tests/unit/workflows/writeme-workflow.test.ts --runInBand --coverage=false
- env -u npm_config_allow_scripts npm_config_userconfig=/dev/null sh -c 'set -e; npm run check:package-lock; npm run format:check; npm run lint; npm test; npm run build; npm audit --omit=dev --audit-level=moderate; npm audit --audit-level=moderate; npm pack --dry-run'