### PR TITLE
Pass remote MCP headers to mcp-remote

### DIFF
--- a/src/mcp/capabilities.ts
+++ b/src/mcp/capabilities.ts
@@ -26,6 +26,16 @@ export function agentSupportsMcp(agent: IAgent): boolean {
   return capabilities.supportsStdio || capabilities.supportsRemote;
 }
 
+function getMcpRemoteHeaderArgs(headers: unknown): string[] {
+  if (!headers || typeof headers !== 'object' || Array.isArray(headers)) {
+    return [];
+  }
+
+  return Object.entries(headers).flatMap(([key, value]) =>
+    typeof value === 'string' ? ['--header', `${key}: ${value}`] : [],
+  );
+}
+
 /**
  * Filters MCP configuration based on agent capabilities
  */
@@ -70,12 +80,14 @@ export function filterMcpConfigForAgent(
       // Transform remote server to stdio server using mcp-remote
       const preservedFields = Object.fromEntries(
         Object.entries(config).filter(
-          ([key]) => !['url', 'command', 'args', 'type'].includes(key),
+          ([key]) =>
+            !['url', 'command', 'args', 'type', 'headers'].includes(key),
         ),
       );
+      const headerArgs = getMcpRemoteHeaderArgs(config.headers);
       const transformedConfig = {
         command: 'npx',
-        args: ['-y', 'mcp-remote@latest', config.url as string],
+        args: ['-y', 'mcp-remote@latest', config.url as string, ...headerArgs],
         ...preservedFields,
       };
       filteredServers[serverName] = transformedConfig;

--- a/tests/remote-to-stdio-transformation.test.ts
+++ b/tests/remote-to-stdio-transformation.test.ts
@@ -66,11 +66,12 @@ Authorization = "Bearer TOKEN123"
       '-y',
       'mcp-remote@latest',
       'https://example.com/mcp',
+      '--header',
+      'Authorization: Bearer TOKEN123',
+      '--header',
+      'X-API-Version: v1',
     ]);
-    expect(servers.remote_with_headers.headers).toEqual({
-      Authorization: 'Bearer TOKEN123',
-      'X-API-Version': 'v1',
-    });
+    expect(servers.remote_with_headers.headers).toBeUndefined();
   });
 
   it('does not transform remote servers for agents that support both stdio and remote', async () => {

--- a/tests/unit/mcp/capabilities.test.ts
+++ b/tests/unit/mcp/capabilities.test.ts
@@ -138,8 +138,13 @@ describe('MCP Capabilities', () => {
       expect(filtered!.mcpServers).toEqual({
         remote_with_wrapper_like_fields: {
           command: 'npx',
-          args: ['-y', 'mcp-remote@latest', 'https://api.example.com/mcp'],
-          headers: { Authorization: 'Bearer TOKEN' },
+          args: [
+            '-y',
+            'mcp-remote@latest',
+            'https://api.example.com/mcp',
+            '--header',
+            'Authorization: Bearer TOKEN',
+          ],
         },
       });
     });
@@ -203,12 +208,15 @@ describe('MCP Capabilities', () => {
         },
         remote_with_headers: {
           command: 'npx',
-          args: ['-y', 'mcp-remote@latest', 'https://api.example.com/mcp'],
-          // Note: headers should be preserved as env variables or similar mechanism
-          headers: {
-            Authorization: 'Bearer token123',
-            'Content-Type': 'application/json',
-          },
+          args: [
+            '-y',
+            'mcp-remote@latest',
+            'https://api.example.com/mcp',
+            '--header',
+            'Authorization: Bearer token123',
+            '--header',
+            'Content-Type: application/json',
+          ],
         },
         stdio_server: {
           command: 'node',


### PR DESCRIPTION
Fixes #716

## Summary
- translate remote MCP headers into repeated `mcp-remote --header` arguments for stdio-only agents
- stop carrying unsupported `headers` fields into converted stdio configs
- update unit and integration coverage for header-bearing remote servers

## Verification
- env -u npm_config_allow_scripts npm_config_userconfig=/dev/null npx jest tests/unit/mcp/capabilities.test.ts tests/remote-to-stdio-transformation.test.ts --runInBand --coverage=false
- env -u npm_config_allow_scripts npm_config_userconfig=/dev/null sh -c 'set -e; npm run check:package-lock; npm run format:check; npm run lint; npm test; npm run build; npm audit --omit=dev --audit-level=moderate; npm audit --audit-level=moderate; npm pack --dry-run'