### PR TITLE
Respect RooCode MCP enablement and strategy

### DIFF
--- a/src/agents/RooCodeAgent.ts
+++ b/src/agents/RooCodeAgent.ts
@@ -8,6 +8,7 @@ import {
   ensureDirExists,
   writeGeneratedFile,
 } from '../core/FileSystemUtils';
+import { mergeMcp } from '../mcp/merge';
 import { writeMcpProvenance } from '../paths/mcp';
 
 /**
@@ -54,6 +55,10 @@ export class RooCodeAgent implements IAgent {
       backup,
     );
 
+    if (agentConfig?.mcp?.enabled === false) {
+      return;
+    }
+
     // Now handle .roo/mcp.json configuration
     const outputPaths = this.getDefaultOutputPath(projectRoot);
     const mcpPath = path.resolve(
@@ -68,11 +73,6 @@ export class RooCodeAgent implements IAgent {
     );
     await ensureDirExists(path.dirname(mcpPath));
 
-    // Create base structure with mcpServers
-    let finalMcpConfig: { mcpServers: Record<string, unknown> } = {
-      mcpServers: {},
-    };
-
     // Try to read existing .roo/mcp.json
     let existingConfig: Record<string, unknown> = {};
     try {
@@ -86,26 +86,17 @@ export class RooCodeAgent implements IAgent {
       existingConfig = {};
     }
 
-    // Merge MCP servers if we have ruler config
-    if (rulerMcpJson?.mcpServers) {
-      const existingServers =
-        (existingConfig.mcpServers as Record<string, unknown>) || {};
-      const newServers = rulerMcpJson.mcpServers as Record<string, unknown>;
-
-      // Shallow merge: new servers override existing with same name
-      finalMcpConfig = {
-        mcpServers: {
-          ...existingServers,
-          ...newServers,
-        },
-      };
-    } else if (existingConfig.mcpServers) {
-      // Keep existing servers if no new ones to add
-      finalMcpConfig = {
-        mcpServers: existingConfig.mcpServers as Record<string, unknown>,
-      };
-    }
-    // If neither condition is met, finalMcpConfig remains { mcpServers: {} }
+    const finalMcpConfig = rulerMcpJson
+      ? mergeMcp(
+          existingConfig,
+          rulerMcpJson,
+          agentConfig?.mcp?.strategy ?? 'merge',
+          'mcpServers',
+        )
+      : {
+          mcpServers:
+            (existingConfig.mcpServers as Record<string, unknown>) || {},
+        };
 
     // Write the config file with pretty JSON (2 spaces)
     const newContent = JSON.stringify(finalMcpConfig, null, 2);

--- a/tests/integration/RooCodeAgent.integration.test.ts
+++ b/tests/integration/RooCodeAgent.integration.test.ts
@@ -144,4 +144,124 @@ command = "updated-cmd"`;
       type: 'stdio',
     });
   });
+
+  it('honours global MCP overwrite strategy', async () => {
+    const { projectRoot } = testProject;
+
+    await fs.mkdir(path.join(projectRoot, '.roo'), { recursive: true });
+    await fs.writeFile(
+      path.join(projectRoot, '.roo', 'mcp.json'),
+      JSON.stringify({
+        mcpServers: {
+          old: { command: 'old-cmd' },
+        },
+      }),
+    );
+
+    await fs.writeFile(
+      path.join(projectRoot, '.ruler', 'ruler.toml'),
+      `[mcp]
+merge_strategy = "overwrite"
+
+[mcp_servers.new]
+command = "new-cmd"`,
+    );
+
+    runRuler('apply --agents roo', projectRoot);
+
+    const mcpJson = JSON.parse(
+      await fs.readFile(path.join(projectRoot, '.roo', 'mcp.json'), 'utf8'),
+    );
+    expect(mcpJson.mcpServers).toEqual({
+      new: { command: 'new-cmd', type: 'stdio' },
+    });
+  });
+
+  it('honours RooCode-specific MCP overwrite strategy', async () => {
+    const { projectRoot } = testProject;
+
+    await fs.mkdir(path.join(projectRoot, '.roo'), { recursive: true });
+    await fs.writeFile(
+      path.join(projectRoot, '.roo', 'mcp.json'),
+      JSON.stringify({
+        mcpServers: {
+          old: { command: 'old-cmd' },
+        },
+      }),
+    );
+
+    await fs.writeFile(
+      path.join(projectRoot, '.ruler', 'ruler.toml'),
+      `[agents.roo.mcp]
+merge_strategy = "overwrite"
+
+[mcp_servers.new]
+command = "new-cmd"`,
+    );
+
+    runRuler('apply --agents roo', projectRoot);
+
+    const mcpJson = JSON.parse(
+      await fs.readFile(path.join(projectRoot, '.roo', 'mcp.json'), 'utf8'),
+    );
+    expect(mcpJson.mcpServers).toEqual({
+      new: { command: 'new-cmd', type: 'stdio' },
+    });
+  });
+
+  it('leaves RooCode MCP untouched with --no-mcp', async () => {
+    const { projectRoot } = testProject;
+    const mcpPath = path.join(projectRoot, '.roo', 'mcp.json');
+    const existingContent = '{"mcpServers":{"old":{"command":"old-cmd"}}}';
+
+    await fs.mkdir(path.dirname(mcpPath), { recursive: true });
+    await fs.writeFile(mcpPath, existingContent, 'utf8');
+    await fs.writeFile(
+      path.join(projectRoot, '.ruler', 'ruler.toml'),
+      `[mcp_servers.new]
+command = "new-cmd"`,
+    );
+
+    runRuler('apply --agents roo --no-mcp', projectRoot);
+
+    await expect(fs.readFile(mcpPath, 'utf8')).resolves.toBe(existingContent);
+    await expect(fs.access(`${mcpPath}.bak`)).rejects.toThrow();
+    await expect(fs.access(`${mcpPath}.ruler-generated`)).rejects.toThrow();
+  });
+
+  it('does not create RooCode MCP config when global MCP is disabled', async () => {
+    const { projectRoot } = testProject;
+    const mcpPath = path.join(projectRoot, '.roo', 'mcp.json');
+
+    await fs.writeFile(
+      path.join(projectRoot, '.ruler', 'ruler.toml'),
+      `[mcp]
+enabled = false
+
+[mcp_servers.new]
+command = "new-cmd"`,
+    );
+
+    runRuler('apply --agents roo', projectRoot);
+
+    await expect(fs.access(mcpPath)).rejects.toThrow();
+  });
+
+  it('does not create RooCode MCP config when RooCode MCP is disabled', async () => {
+    const { projectRoot } = testProject;
+    const mcpPath = path.join(projectRoot, '.roo', 'mcp.json');
+
+    await fs.writeFile(
+      path.join(projectRoot, '.ruler', 'ruler.toml'),
+      `[agents.roo.mcp]
+enabled = false
+
+[mcp_servers.new]
+command = "new-cmd"`,
+    );
+
+    runRuler('apply --agents roo', projectRoot);
+
+    await expect(fs.access(mcpPath)).rejects.toThrow();
+  });
 });

--- a/tests/unit/agents/RooCodeAgent.test.ts
+++ b/tests/unit/agents/RooCodeAgent.test.ts
@@ -190,6 +190,41 @@ describe('RooCodeAgent Unit Tests', () => {
       });
     });
 
+    it('overwrites all existing MCP servers when strategy is overwrite', async () => {
+      const mcpPath = path.join(tmpDir, '.roo', 'mcp.json');
+      await fs.mkdir(path.dirname(mcpPath), { recursive: true });
+      await fs.writeFile(
+        mcpPath,
+        JSON.stringify(
+          {
+            mcpServers: {
+              old: { command: 'old-command' },
+            },
+          },
+          null,
+          2,
+        ),
+      );
+
+      await agent.applyRulerConfig(
+        'rules',
+        tmpDir,
+        {
+          mcpServers: {
+            new: { command: 'new-command' },
+          },
+        },
+        { mcp: { enabled: true, strategy: 'overwrite' } },
+        false,
+      );
+
+      await expect(readJson(mcpPath)).resolves.toEqual({
+        mcpServers: {
+          new: { command: 'new-command' },
+        },
+      });
+    });
+
     it('keeps existing MCP servers when no MCP config is provided', async () => {
       const mcpPath = path.join(tmpDir, '.roo', 'mcp.json');
       const existingConfig = {
@@ -203,6 +238,30 @@ describe('RooCodeAgent Unit Tests', () => {
       await agent.applyRulerConfig('rules', tmpDir, null, undefined, false);
 
       await expect(readJson(mcpPath)).resolves.toEqual(existingConfig);
+    });
+
+    it('does not touch MCP config when MCP is disabled', async () => {
+      const mcpPath = path.join(tmpDir, '.roo', 'mcp.json');
+      const existingContent =
+        '{"mcpServers":{"existing":{"command":"old-command"}}}';
+      await fs.mkdir(path.dirname(mcpPath), { recursive: true });
+      await fs.writeFile(mcpPath, existingContent, 'utf8');
+
+      await agent.applyRulerConfig(
+        'rules',
+        tmpDir,
+        {
+          mcpServers: {
+            new: { command: 'new-command' },
+          },
+        },
+        { mcp: { enabled: false } },
+        true,
+      );
+
+      await expect(fs.readFile(mcpPath, 'utf8')).resolves.toBe(existingContent);
+      await expect(fs.access(`${mcpPath}.bak`)).rejects.toThrow();
+      await expect(fs.access(`${mcpPath}.ruler-generated`)).rejects.toThrow();
     });
 
     it('creates an empty MCP config when no MCP config or existing servers are available', async () => {


### PR DESCRIPTION
Fixes #714
Fixes #715

## Summary
- skip RooCode MCP writes when resolved MCP config is disabled
- use the shared MCP merge helper so RooCode honours merge and overwrite strategies
- add unit and integration coverage for global disable, per-agent disable, CLI --no-mcp, and overwrite strategy paths

## Verification
- env -u npm_config_allow_scripts npm_config_userconfig=/dev/null npx jest tests/unit/agents/RooCodeAgent.test.ts tests/integration/RooCodeAgent.integration.test.ts --runInBand --coverage=false
- env -u npm_config_allow_scripts npm_config_userconfig=/dev/null sh -c 'set -e; npm run check:package-lock; npm run format:check; npm run lint; npm test; npm run build; npm audit --omit=dev --audit-level=moderate; npm audit --audit-level=moderate; npm pack --dry-run'