### PR TITLE
Reject invalid revert agent selectors

### DIFF
--- a/src/revert.ts
+++ b/src/revert.ts
@@ -9,10 +9,7 @@ import {
   cleanUpAuxiliaryFiles,
   cleanUpAgentDirectories,
 } from './core/revert-engine';
-import {
-  agentMatchesFilter,
-  resolveSelectedAgents,
-} from './core/agent-selection';
+import { resolveSelectedAgents } from './core/agent-selection';
 import { mapRawAgentConfigs } from './core/config-utils';
 import {
   removeCompleteRulerBlocks,
@@ -65,58 +62,8 @@ export async function revertAllAgentConfigs(
   // Normalize per-agent config keys to agent identifiers
   config.agentConfigs = mapRawAgentConfigs(config.agentConfigs, agents);
 
-  // Select agents to revert (same logic as apply, but with backward compatibility for invalid agents)
-  let selected: IAgent[];
-  try {
-    selected = resolveSelectedAgents(config, agents);
-  } catch (error) {
-    // For backward compatibility, revert continues with available agents if some are invalid
-    // This preserves the original behavior where invalid agents were silently ignored
-    if (
-      error instanceof Error &&
-      error.message.includes('Invalid agent specified')
-    ) {
-      logVerbose(
-        `Warning: ${error.message} - continuing with valid agents only`,
-        verbose,
-      );
-
-      // Fall back to the old logic without validation
-      if (config.cliAgents && config.cliAgents.length > 0) {
-        const filters = config.cliAgents.map((n) => n.toLowerCase());
-        const validAgentIdentifiers = new Set(
-          agents.map((agent) => agent.getIdentifier()),
-        );
-        selected = agents.filter((agent) =>
-          filters.some((f) =>
-            agentMatchesFilter(agent, f, validAgentIdentifiers),
-          ),
-        );
-      } else if (config.defaultAgents && config.defaultAgents.length > 0) {
-        const defaults = config.defaultAgents.map((n) => n.toLowerCase());
-        const validAgentIdentifiers = new Set(
-          agents.map((agent) => agent.getIdentifier()),
-        );
-        selected = agents.filter((agent) => {
-          const identifier = agent.getIdentifier();
-          const override = config.agentConfigs[identifier]?.enabled;
-          if (override !== undefined) {
-            return override;
-          }
-          return defaults.some((d) =>
-            agentMatchesFilter(agent, d, validAgentIdentifiers),
-          );
-        });
-      } else {
-        selected = agents.filter(
-          (agent) =>
-            config.agentConfigs[agent.getIdentifier()]?.enabled !== false,
-        );
-      }
-    } else {
-      throw error;
-    }
-  }
+  // Select agents to revert using the same validation semantics as apply.
+  const selected = resolveSelectedAgents(config, agents);
 
   logVerbose(
     `Selected agents: ${selected.map((a) => a.getName()).join(', ')}`,

--- a/tests/integration/revert-cli.test.ts
+++ b/tests/integration/revert-cli.test.ts
@@ -162,16 +162,16 @@ describe('Revert CLI Integration', () => {
       }).toThrow();
     });
 
-    it('should handle invalid agents list gracefully', () => {
-      const output = execSync(
-        `node dist/cli/index.js revert --project-root ${tmpDir} --agents invalid-agent --dry-run`,
-        {
-          encoding: 'utf8',
-          stdio: 'pipe',
-        },
-      );
-
-      expect(output).toContain('[ruler:dry-run]');
+    it('should reject invalid agents list', () => {
+      expect(() => {
+        execSync(
+          `node dist/cli/index.js revert --project-root ${tmpDir} --agents invalid-agent --dry-run`,
+          {
+            encoding: 'utf8',
+            stdio: 'pipe',
+          },
+        );
+      }).toThrow(/Invalid agent specified: invalid-agent/);
     });
   });
 

--- a/tests/unit/core/revert.test.ts
+++ b/tests/unit/core/revert.test.ts
@@ -118,37 +118,28 @@ describe('Revert Core Functions', () => {
       consoleSpy.mockRestore();
     });
 
-    it('continues with valid CLI agents when invalid filters are present', async () => {
+    it('rejects invalid CLI agent filters', async () => {
       await fs.writeFile(
         path.join(tmpDir, 'CLAUDE.md'),
         `${GENERATED_MARKER}\nClaude content`,
       );
 
-      const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
-      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
-
-      await revertAllAgentConfigs(
-        tmpDir,
-        ['claude', 'not-a-real-agent'],
-        undefined,
-        false,
-        true,
-        false,
-      );
-
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        expect.stringContaining('Reverting Claude Code'),
-      );
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining('continuing with valid agents only'),
-      );
-      await expect(fs.access(path.join(tmpDir, 'CLAUDE.md'))).rejects.toThrow();
-
-      consoleLogSpy.mockRestore();
-      consoleErrorSpy.mockRestore();
+      await expect(
+        revertAllAgentConfigs(
+          tmpDir,
+          ['claude', 'not-a-real-agent'],
+          undefined,
+          false,
+          true,
+          false,
+        ),
+      ).rejects.toThrow('Invalid agent specified: not-a-real-agent');
+      await expect(
+        fs.access(path.join(tmpDir, 'CLAUDE.md')),
+      ).resolves.toBeUndefined();
     });
 
-    it('uses valid default agents when invalid defaults are present', async () => {
+    it('rejects invalid default agents', async () => {
       await fs.writeFile(
         path.join(tmpDir, '.ruler', 'ruler.toml'),
         'default_agents = ["claude", "not-a-real-agent"]\n',
@@ -156,33 +147,20 @@ describe('Revert Core Functions', () => {
       await fs.writeFile(path.join(tmpDir, 'CLAUDE.md'), 'Claude content');
       await fs.writeFile(path.join(tmpDir, 'AGENTS.md'), 'Agents content');
 
-      const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
-      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
-
-      await revertAllAgentConfigs(
-        tmpDir,
-        undefined,
-        undefined,
-        false,
-        true,
-        false,
+      await expect(
+        revertAllAgentConfigs(tmpDir, undefined, undefined, false, true, false),
+      ).rejects.toThrow(
+        'Invalid agent specified in default_agents: not-a-real-agent',
       );
-
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        expect.stringContaining('Reverting Claude Code'),
-      );
-      expect(consoleLogSpy).not.toHaveBeenCalledWith(
-        expect.stringContaining('Reverting AgentsMd'),
-      );
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining('continuing with valid agents only'),
-      );
-
-      consoleLogSpy.mockRestore();
-      consoleErrorSpy.mockRestore();
+      await expect(
+        fs.readFile(path.join(tmpDir, 'CLAUDE.md'), 'utf8'),
+      ).resolves.toBe('Claude content');
+      await expect(
+        fs.readFile(path.join(tmpDir, 'AGENTS.md'), 'utf8'),
+      ).resolves.toBe('Agents content');
     });
 
-    it('honors agent config overrides when falling back from invalid defaults', async () => {
+    it('rejects invalid default agents before applying overrides', async () => {
       await fs.writeFile(
         path.join(tmpDir, '.ruler', 'ruler.toml'),
         [
@@ -199,27 +177,42 @@ describe('Revert Core Functions', () => {
       await fs.writeFile(path.join(tmpDir, 'CLAUDE.md'), 'Claude content');
       await fs.writeFile(path.join(tmpDir, 'AGENTS.md'), 'Agents content');
 
+      await expect(
+        revertAllAgentConfigs(tmpDir, undefined, undefined, false, true, false),
+      ).rejects.toThrow(
+        'Invalid agent specified in default_agents: not-a-real-agent',
+      );
+      await expect(
+        fs.readFile(path.join(tmpDir, 'CLAUDE.md'), 'utf8'),
+      ).resolves.toBe('Claude content');
+      await expect(
+        fs.readFile(path.join(tmpDir, 'AGENTS.md'), 'utf8'),
+      ).resolves.toBe('Agents content');
+    });
+
+    it('continues reverting other agents when a valid selector finds no generated output', async () => {
+      await fs.writeFile(
+        path.join(tmpDir, 'CLAUDE.md'),
+        `${GENERATED_MARKER}\nClaude content`,
+      );
+
       const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
-      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
 
       await revertAllAgentConfigs(
         tmpDir,
-        undefined,
+        ['claude', 'codex'],
         undefined,
         false,
         true,
         false,
       );
 
-      expect(consoleLogSpy).not.toHaveBeenCalledWith(
+      expect(consoleLogSpy).toHaveBeenCalledWith(
         expect.stringContaining('Reverting Claude Code'),
       );
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        expect.stringContaining('Reverting AgentsMd'),
-      );
+      await expect(fs.access(path.join(tmpDir, 'CLAUDE.md'))).rejects.toThrow();
 
       consoleLogSpy.mockRestore();
-      consoleErrorSpy.mockRestore();
     });
 
     it('should keep consumed backup when keep-backups is true', async () => {


### PR DESCRIPTION
Fixes #703

## Summary
- reject invalid `ruler revert --agents` selectors instead of silently reverting a subset
- reject invalid `default_agents` during revert before mutating files
- update unit and CLI integration coverage for the stricter failure path

## Verification
- `env -u npm_config_allow_scripts npm_config_userconfig=/dev/null npx jest tests/unit/core/revert.test.ts tests/integration/revert-cli.test.ts --runInBand --coverage=false`
- `env -u npm_config_allow_scripts npm_config_userconfig=/dev/null sh -c 'set -e; npm run check:package-lock; npm run format:check; npm run lint; npm test; npm run build; npm audit --omit=dev --audit-level=moderate; npm audit --audit-level=moderate; npm pack --dry-run'`