### PR TITLE
Reject init roots inside ruler directories

### DIFF
--- a/src/cli/handlers.ts
+++ b/src/cli/handlers.ts
@@ -42,13 +42,30 @@ export interface RevertArgs {
 }
 
 function assertNotInsideRulerDir(projectRoot: string): void {
-  const normalized = path.resolve(projectRoot);
-  const segments = normalized.split(path.sep);
-  if (segments.includes('.ruler')) {
+  if (getContainingRulerDir(projectRoot) !== undefined) {
     throw new Error(
       'Cannot run from inside a .ruler directory. Please run from your project root.',
     );
   }
+}
+
+function assertInitRootNotInsideRulerDir(projectRoot: string): void {
+  const containingRulerDir = getContainingRulerDir(projectRoot);
+  if (containingRulerDir !== undefined) {
+    throw new Error(
+      `Cannot initialise inside an existing .ruler directory (${containingRulerDir}). Please choose the project root.`,
+    );
+  }
+}
+
+function getContainingRulerDir(projectRoot: string): string | undefined {
+  const normalized = path.resolve(projectRoot);
+  const segments = normalized.split(path.sep);
+  const rulerIndex = segments.indexOf('.ruler');
+  if (rulerIndex === -1) {
+    return undefined;
+  }
+  return segments.slice(0, rulerIndex + 1).join(path.sep) || path.sep;
 }
 
 function formatCliError(message: string): string {
@@ -216,6 +233,9 @@ export async function initHandler(argv: InitArgs): Promise<void> {
       argv['project-root'],
       'project-root',
     );
+    if (!isGlobal) {
+      assertInitRootNotInsideRulerDir(projectRoot);
+    }
     const rulerDir = isGlobal
       ? path.join(
           process.env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config'),

--- a/tests/e2e/ruler.init.test.ts
+++ b/tests/e2e/ruler.init.test.ts
@@ -70,4 +70,28 @@ describe('End-to-End ruler init command', () => {
     );
     await teardownTestProject(projectRoot);
   });
+
+  it.each(['.ruler', path.join('.ruler', 'nested')])(
+    'rejects project roots inside an existing .ruler directory: %s',
+    async (relativeRoot) => {
+      const { projectRoot } = await setupTestProject();
+      try {
+        const nestedRoot = path.join(projectRoot, relativeRoot);
+        await fs.mkdir(nestedRoot, { recursive: true });
+
+        expect(() =>
+          execSync(
+            `node dist/cli/index.js init --project-root ${JSON.stringify(nestedRoot)}`,
+            { stdio: 'pipe', encoding: 'utf8' },
+          ),
+        ).toThrow(/Cannot initialise inside an existing \.ruler directory/);
+
+        await expect(
+          fs.stat(path.join(nestedRoot, '.ruler')),
+        ).rejects.toThrow();
+      } finally {
+        await teardownTestProject(projectRoot);
+      }
+    },
+  );
 });

--- a/tests/unit/cli/handlers.test.ts
+++ b/tests/unit/cli/handlers.test.ts
@@ -688,6 +688,35 @@ describe('CLI Handlers', () => {
       );
     });
 
+    it.each([['/mock/project/.ruler'], ['/mock/project/.ruler/nested']])(
+      'should fail fast when initialising inside a .ruler directory: %s',
+      async (projectRoot) => {
+        const exitSpy = jest
+          .spyOn(process, 'exit')
+          .mockImplementation((code?: string | number | null | undefined) => {
+            throw new Error(`process.exit: ${code}`);
+          });
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+        const argv = {
+          'project-root': projectRoot,
+          global: false,
+        };
+
+        await expect(initHandler(argv)).rejects.toThrow('process.exit: 1');
+
+        expect(errorSpy).toHaveBeenCalledWith(
+          '[ruler] Cannot initialise inside an existing .ruler directory (/mock/project/.ruler). Please choose the project root.',
+        );
+        expect(fs.mkdir).not.toHaveBeenCalled();
+        expect(fs.writeFile).not.toHaveBeenCalled();
+        expect(exitSpy).toHaveBeenCalledWith(1);
+
+        exitSpy.mockRestore();
+        errorSpy.mockRestore();
+      },
+    );
+
     it('should NOT create mcp.json file', async () => {
       const argv = {
         'project-root': mockProjectRoot,


### PR DESCRIPTION
Fixes #704

## Summary
- reject local `ruler init` when `--project-root` points at or below an existing `.ruler` directory
- keep global init unaffected
- add unit and e2e coverage for direct and nested `.ruler` project roots

## Verification
- `env -u npm_config_allow_scripts npm_config_userconfig=/dev/null npx jest tests/unit/cli/handlers.test.ts tests/e2e/ruler.init.test.ts --runInBand --coverage=false`
- `env -u npm_config_allow_scripts npm_config_userconfig=/dev/null sh -c 'set -e; npm run check:package-lock; npm run format:check; npm run lint; npm test; npm run build; npm audit --omit=dev --audit-level=moderate; npm audit --audit-level=moderate; npm pack --dry-run'`