### PR TITLE
Clean agent directories during full revert

### DIFF
--- a/src/revert.ts
+++ b/src/revert.ts
@@ -99,15 +99,13 @@ export async function revertAllAgentConfigs(
     totalFilesRemoved += result.removed;
     totalBackupsRemoved += result.backupsRemoved;
 
-    if (!isFullRevert) {
-      totalDirectoriesRemoved += await cleanUpAgentDirectories(
-        agent,
-        effectiveProjectRoot,
-        agentConfig,
-        verbose,
-        dryRun,
-      );
-    }
+    totalDirectoriesRemoved += await cleanUpAgentDirectories(
+      agent,
+      effectiveProjectRoot,
+      agentConfig,
+      verbose,
+      dryRun,
+    );
   }
 
   // Clean up auxiliary files and directories only when reverting all agents.

--- a/tests/unit/core/revert.test.ts
+++ b/tests/unit/core/revert.test.ts
@@ -361,6 +361,51 @@ describe('Revert Core Functions', () => {
       ).resolves.toBeUndefined();
     });
 
+    it('removes empty nested agent directories during full revert', async () => {
+      const kiroDir = path.join(tmpDir, '.kiro');
+      const steeringDir = path.join(kiroDir, 'steering');
+      const outputPath = path.join(steeringDir, 'ruler_kiro_instructions.md');
+      await fs.mkdir(steeringDir, { recursive: true });
+      await fs.writeFile(outputPath, `${GENERATED_MARKER}\nKiro content`);
+
+      await revertAllAgentConfigs(
+        tmpDir,
+        undefined,
+        undefined,
+        false,
+        false,
+        false,
+      );
+
+      await expect(fs.access(outputPath)).rejects.toThrow();
+      await expect(fs.access(steeringDir)).rejects.toThrow();
+      await expect(fs.access(kiroDir)).rejects.toThrow();
+    });
+
+    it('preserves non-empty nested agent directories during full revert', async () => {
+      const kiroDir = path.join(tmpDir, '.kiro');
+      const steeringDir = path.join(kiroDir, 'steering');
+      const outputPath = path.join(steeringDir, 'ruler_kiro_instructions.md');
+      const keepPath = path.join(steeringDir, 'keep.txt');
+      await fs.mkdir(steeringDir, { recursive: true });
+      await fs.writeFile(outputPath, `${GENERATED_MARKER}\nKiro content`);
+      await fs.writeFile(keepPath, 'User content');
+
+      await revertAllAgentConfigs(
+        tmpDir,
+        undefined,
+        undefined,
+        false,
+        false,
+        false,
+      );
+
+      await expect(fs.access(outputPath)).rejects.toThrow();
+      await expect(fs.readFile(keepPath, 'utf8')).resolves.toBe('User content');
+      await expect(fs.access(steeringDir)).resolves.toBeUndefined();
+      await expect(fs.access(kiroDir)).resolves.toBeUndefined();
+    });
+
     it('removes the ruler-managed block from .gitignore', async () => {
       await fs.writeFile(
         path.join(tmpDir, '.gitignore'),


### PR DESCRIPTION
Fixes #696

## Summary
- clean empty generated agent directories during full revert as well as partial revert
- preserve non-empty parent directories while removing generated files
- cover full-revert cleanup for nested agent output directories

## Verification
- env -u npm_config_allow_scripts npm_config_userconfig=/dev/null npx jest tests/unit/core/revert.test.ts --runInBand --coverage=false
- env -u npm_config_allow_scripts npm_config_userconfig=/dev/null sh -c 'set -e; npm run check:package-lock; npm run format:check; npm run lint; npm test; npm run build; npm audit --omit=dev --audit-level=moderate; npm audit --audit-level=moderate; npm pack --dry-run'