### PR TITLE
Track only generated output paths

### DIFF
--- a/src/agents/agent-utils.ts
+++ b/src/agents/agent-utils.ts
@@ -51,3 +51,46 @@ export function getAgentOutputPaths(
 
   return paths;
 }
+
+/**
+ * Gets output paths that the primary rule-application phase is expected to
+ * write before external MCP propagation runs.
+ */
+export function getAgentApplyOutputPaths(
+  agent: IAgent,
+  projectRoot: string,
+  agentConfig?: IAgentConfig,
+): string[] {
+  const paths: string[] = [];
+  const defaults = agent.getDefaultOutputPath(projectRoot);
+
+  if (typeof defaults === 'string') {
+    paths.push(agentConfig?.outputPath ?? defaults);
+  } else {
+    const defaultPaths = defaults as Record<string, string>;
+
+    if ('instructions' in defaultPaths) {
+      paths.push(
+        agentConfig?.outputPath ??
+          agentConfig?.outputPathInstructions ??
+          defaultPaths.instructions,
+      );
+    }
+
+    if ('config' in defaultPaths && agent.getIdentifier() === 'aider') {
+      paths.push(agentConfig?.outputPathConfig ?? defaultPaths.config);
+    }
+
+    for (const [key, defaultPath] of Object.entries(defaultPaths)) {
+      if (key !== 'instructions' && key !== 'config' && key !== 'mcp') {
+        paths.push(defaultPath);
+      }
+    }
+  }
+
+  if (agent.getAdditionalOutputPaths) {
+    paths.push(...agent.getAdditionalOutputPaths(projectRoot, agentConfig));
+  }
+
+  return paths;
+}

--- a/src/core/GitignoreUtils.ts
+++ b/src/core/GitignoreUtils.ts
@@ -73,10 +73,7 @@ export async function updateGitignore(
       }
       return relative.replace(/\\/g, '/'); // Convert to POSIX format
     })
-    .filter((p) => {
-      // Never include any path that resides inside a .ruler directory (inputs, not outputs)
-      return !p.includes('/.ruler/') && !p.startsWith('.ruler/');
-    })
+    .filter((p) => !isRulerSourcePath(p))
     .map((p) => {
       // Always write full repository-relative paths (prefix with leading /)
       return p.startsWith('/') ? p : `/${p}`;
@@ -100,6 +97,20 @@ export async function updateGitignore(
     newContent,
     ignoreTarget.containmentRoot,
   );
+}
+
+function isRulerSourcePath(relativePath: string): boolean {
+  const segments = relativePath.split('/');
+
+  for (let index = 0; index < segments.length; index++) {
+    if (segments[index] !== '.ruler') {
+      continue;
+    }
+
+    return segments[index + 1] !== '.generated';
+  }
+
+  return false;
 }
 
 /**

--- a/src/core/apply-engine.ts
+++ b/src/core/apply-engine.ts
@@ -17,7 +17,10 @@ import {
 } from '../paths/mcp';
 import { propagateMcpToOpenHands } from '../mcp/propagateOpenHandsMcp';
 import { propagateMcpToOpenCode } from '../mcp/propagateOpenCodeMcp';
-import { getAgentOutputPaths } from '../agents/agent-utils';
+import {
+  getAgentApplyOutputPaths,
+  getAgentOutputPaths,
+} from '../agents/agent-utils';
 import { agentSupportsMcp, filterMcpConfigForAgent } from '../mcp/capabilities';
 import { isPathInsideOrEqual } from './path-utils';
 import {
@@ -478,8 +481,27 @@ export async function applyConfigurationsToAgents(
     const agentConfig = config.agentConfigs[agent.getIdentifier()];
     const agentRulerMcpJson = mergeAgentMcpServers(rulerMcpJson, agentConfig);
 
-    // Collect output paths for .gitignore
-    const outputPaths = getAgentOutputPaths(agent, projectRoot, agentConfig);
+    // Collect paths written by the rules phase for .gitignore. MCP-only
+    // sidecars are added by the MCP handling path once there is a compatible
+    // MCP payload to write.
+    const outputPaths = getAgentApplyOutputPaths(
+      agent,
+      projectRoot,
+      agentConfig,
+    );
+    const allOutputPaths = getAgentOutputPaths(agent, projectRoot, agentConfig);
+    const optionalOutputPaths = allOutputPaths.filter(
+      (outputPath) => !outputPaths.includes(outputPath),
+    );
+    const optionalOutputPathExistedBefore = new Map<string, boolean>();
+    if (!dryRun) {
+      for (const outputPath of optionalOutputPaths) {
+        optionalOutputPathExistedBefore.set(
+          outputPath,
+          await pathExists(resolveOutputPath(projectRoot, outputPath)),
+        );
+      }
+    }
     logVerbose(
       `Agent ${agent.getName()} output paths: ${outputPaths.join(', ')}`,
       verbose,
@@ -541,6 +563,14 @@ export async function applyConfigurationsToAgents(
           finalAgentConfig,
           backup,
         );
+        for (const outputPath of optionalOutputPaths) {
+          if (optionalOutputPathExistedBefore.get(outputPath)) {
+            continue;
+          }
+          if (await pathExists(resolveOutputPath(projectRoot, outputPath))) {
+            generatedPaths.push(outputPath);
+          }
+        }
       }
     }
 
@@ -561,6 +591,12 @@ export async function applyConfigurationsToAgents(
   }
 
   return generatedPaths;
+}
+
+function resolveOutputPath(projectRoot: string, outputPath: string): string {
+  return path.isAbsolute(outputPath)
+    ? outputPath
+    : path.resolve(projectRoot, outputPath);
 }
 
 async function handleMcpConfiguration(

--- a/tests/integration/output-path-recursion.test.ts
+++ b/tests/integration/output-path-recursion.test.ts
@@ -44,4 +44,19 @@ output_path = ".ruler/.generated/codex-instructions.md"
       '<!-- Source: .ruler/.generated/codex-instructions.md -->',
     );
   });
+
+  it('tracks configured generated markdown outputs under .ruler/.generated in gitignore', async () => {
+    runRuler(
+      'apply --agents codex --no-backup --no-skills --no-subagents --local-only',
+      projectRoot,
+    );
+
+    const gitignoreContent = await fs.readFile(
+      path.join(projectRoot, '.gitignore'),
+      'utf8',
+    );
+    expect(gitignoreContent).toContain(
+      '/.ruler/.generated/codex-instructions.md',
+    );
+  });
 });

--- a/tests/unit/core/GitignoreUtils-anchored.test.ts
+++ b/tests/unit/core/GitignoreUtils-anchored.test.ts
@@ -60,6 +60,23 @@ describe('GitignoreUtils - Root Anchored Paths', () => {
     expect(content).not.toContain('.ruler/config.toml');
   });
 
+  it('should allow configured generated outputs under .ruler/.generated', async () => {
+    const paths = [
+      '.ruler/AGENTS.md',
+      '.ruler/.generated/codex-instructions.md',
+      'subpkg/.ruler/.generated/AGENTS.md',
+    ];
+
+    await updateGitignore(tmpDir, paths);
+
+    const gitignorePath = path.join(tmpDir, '.gitignore');
+    const content = await fs.readFile(gitignorePath, 'utf8');
+
+    expect(content).toContain('/.ruler/.generated/codex-instructions.md');
+    expect(content).toContain('/subpkg/.ruler/.generated/AGENTS.md');
+    expect(content).not.toContain('/.ruler/AGENTS.md');
+  });
+
   it('should create specific backup patterns instead of broad wildcards', async () => {
     const paths = [
       'AGENTS.md',

--- a/tests/unit/core/apply-engine.test.ts
+++ b/tests/unit/core/apply-engine.test.ts
@@ -15,6 +15,8 @@ import { IAgent } from '../../../src/agents/IAgent';
 import { ClaudeAgent } from '../../../src/agents/ClaudeAgent';
 import { CopilotAgent } from '../../../src/agents/CopilotAgent';
 import { JunieAgent } from '../../../src/agents/JunieAgent';
+import { AiderAgent } from '../../../src/agents/AiderAgent';
+import { CodexCliAgent } from '../../../src/agents/CodexCliAgent';
 import { LoadedConfig } from '../../../src/core/ConfigLoader';
 import * as FileSystemUtils from '../../../src/core/FileSystemUtils';
 import * as Constants from '../../../src/constants';
@@ -602,6 +604,29 @@ command = "sub-cmd"
       );
 
       expect(result).toContain(`${tmpDir}/.claude/config.json`);
+    });
+
+    it('omits optional MCP sidecars when no MCP config is applied', async () => {
+      const config: LoadedConfig = { agentConfigs: {} };
+      const rules = '# Test rules';
+
+      const result = await applyConfigurationsToAgents(
+        [new AiderAgent(), new CodexCliAgent()],
+        rules,
+        null,
+        config,
+        tmpDir,
+        false,
+        false,
+        true,
+        undefined,
+        false,
+      );
+
+      expect(result).toContain(path.join(tmpDir, 'AGENTS.md'));
+      expect(result).toContain(path.join(tmpDir, '.aider.conf.yml'));
+      expect(result).not.toContain(path.join(tmpDir, '.mcp.json'));
+      expect(result).not.toContain(path.join(tmpDir, '.codex', 'config.toml'));
     });
 
     it('logs warning and strips MCP timeouts for agents without timeout support', async () => {


### PR DESCRIPTION
Fixes #690
Fixes #692

## Summary
- separate direct apply outputs from broader revert output candidates
- avoid adding optional MCP sidecars to generated path tracking unless apply actually creates them or MCP propagation writes them
- allow configured generated outputs under .ruler/.generated/** in Ruler-managed ignore blocks while still filtering ordinary .ruler source files

## Verification
- env -u npm_config_allow_scripts npm_config_userconfig=/dev/null npx jest tests/unit/core/apply-engine.test.ts tests/unit/core/GitignoreUtils-anchored.test.ts tests/integration/output-path-recursion.test.ts --runInBand --coverage=false
- env -u npm_config_allow_scripts npm_config_userconfig=/dev/null sh -c 'set -e; npm run check:package-lock; npm run format:check; npm run lint; npm test; npm run build; npm audit --omit=dev --audit-level=moderate; npm audit --audit-level=moderate; npm pack --dry-run'