### PR TITLE
Preserve unmanaged subagent files

### DIFF
--- a/src/core/SubagentsProcessor.ts
+++ b/src/core/SubagentsProcessor.ts
@@ -280,6 +280,15 @@ async function removeManagedManifest(
   await fs.rm(manifestPath, { force: true });
 }
 
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 async function writeManagedManifest(
   targetDir: string,
   managedPaths: string[],
@@ -322,9 +331,11 @@ async function writeManagedAgentsDirectory(
   await fs.mkdir(targetDir, { recursive: true });
 
   const previousManagedPaths = await readManagedManifest(targetDir);
+  const previousManagedPathSet = new Set(previousManagedPaths);
   await removeManagedEntries(targetDir, previousManagedPaths, projectRoot);
   await removeManagedManifest(targetDir, projectRoot);
 
+  const writtenFiles: string[] = [];
   for (const { name, content } of files) {
     if (!isSafeManagedRelativePath(name)) {
       throw new Error(`Refusing to write unsafe subagent path: ${name}`);
@@ -335,14 +346,17 @@ async function writeManagedAgentsDirectory(
       projectRoot,
       'Refusing to write subagent through symlinked path',
     );
+    if (!previousManagedPathSet.has(name) && (await pathExists(outputPath))) {
+      logWarn(
+        `Skipping native subagent file that is not Ruler-managed: ${path.relative(projectRoot, outputPath)}`,
+      );
+      continue;
+    }
     await fs.mkdir(path.dirname(outputPath), { recursive: true });
     await fs.writeFile(outputPath, content, 'utf8');
+    writtenFiles.push(name);
   }
-  await writeManagedManifest(
-    targetDir,
-    files.map((file) => file.name),
-    projectRoot,
-  );
+  await writeManagedManifest(targetDir, writtenFiles, projectRoot);
 }
 
 /* ------------------------------------------------------------------ */

--- a/tests/subagents-propagation.test.ts
+++ b/tests/subagents-propagation.test.ts
@@ -17,6 +17,8 @@ import {
 } from '../src/constants';
 import type { SubagentInfo } from '../src/types';
 
+const RULER_MANAGED_MANIFEST = '.ruler-managed.json';
+
 function makeSubagent(overrides: Partial<SubagentInfo> = {}): SubagentInfo {
   return {
     name: 'reviewer',
@@ -44,6 +46,12 @@ function readFrontmatter(content: string): {
   return { meta, body: match[2] };
 }
 
+type Propagator = (
+  projectRoot: string,
+  subagents: SubagentInfo[],
+  options: { dryRun: boolean; verbose?: boolean },
+) => Promise<string[]>;
+
 describe('Subagents per-agent propagators', () => {
   let tmpDir: string;
 
@@ -54,6 +62,54 @@ describe('Subagents per-agent propagators', () => {
   afterEach(async () => {
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
+
+  it.each([
+    [
+      'Claude',
+      propagateSubagentsForClaude,
+      CLAUDE_SUBAGENTS_PATH,
+      'reviewer.md',
+    ],
+    [
+      'Cursor',
+      propagateSubagentsForCursor,
+      CURSOR_SUBAGENTS_PATH,
+      'reviewer.md',
+    ],
+    [
+      'Codex',
+      propagateSubagentsForCodex,
+      CODEX_SUBAGENTS_PATH,
+      'reviewer.toml',
+    ],
+    [
+      'Copilot',
+      propagateSubagentsForCopilot,
+      COPILOT_SUBAGENTS_PATH,
+      'reviewer.md',
+    ],
+  ] as [string, Propagator, string, string][])(
+    'preserves unmanaged %s files that collide with generated subagents',
+    async (_name, propagate, targetRelPath, outputRelPath) => {
+      const targetPath = path.join(tmpDir, targetRelPath, outputRelPath);
+      await fs.mkdir(path.dirname(targetPath), { recursive: true });
+      await fs.writeFile(targetPath, 'native agent', 'utf8');
+
+      await propagate(tmpDir, [makeSubagent()], { dryRun: false });
+
+      await expect(fs.readFile(targetPath, 'utf8')).resolves.toBe(
+        'native agent',
+      );
+      await expect(
+        fs
+          .readFile(
+            path.join(tmpDir, targetRelPath, RULER_MANAGED_MANIFEST),
+            'utf8',
+          )
+          .then((content) => JSON.parse(content).paths),
+      ).resolves.toEqual([]);
+    },
+  );
 
   describe('Claude propagator', () => {
     it('writes a passthrough markdown file preserving all source frontmatter', async () => {


### PR DESCRIPTION
Fixes #686

## Summary
- skip native subagent files that already exist but were not listed in Ruler's managed manifest
- keep the managed manifest limited to files written by the current apply
- add cross-target regression coverage for Claude, Cursor, Codex, and Copilot native subagent collisions

## Verification
- env -u npm_config_allow_scripts npm_config_userconfig=/dev/null npx jest tests/subagents-propagation.test.ts --runInBand --coverage=false
- env -u npm_config_allow_scripts npm_config_userconfig=/dev/null sh -c 'set -e; npm run check:package-lock; npm run format:check; npm run lint; npm test; npm run build; npm audit --omit=dev --audit-level=moderate; npm audit --audit-level=moderate; npm pack --dry-run'