### PR TITLE
Build and chmod package install artifacts

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "test:integration": "jest tests/e2e tests/integration --verbose",
     "clean": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\"",
     "build": "npm run clean && tsc",
+    "postbuild": "node -e \"require('node:fs').chmodSync('dist/cli/index.js', 0o755)\"",
     "check:package-lock": "node -e \"const pkg=require('./package.json'); const lock=require('./package-lock.json'); const root=lock.packages?.['']; if (lock.version !== pkg.version || root?.version !== pkg.version) { console.error('package-lock.json version metadata must match package.json version'); process.exit(1); }\"",
+    "prepare": "npm run build",
     "prepublishOnly": "npm run build"
   },
   "repository": {

--- a/tests/integration/cli-version.test.ts
+++ b/tests/integration/cli-version.test.ts
@@ -22,7 +22,7 @@ describe('packaged CLI version', () => {
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
-  it('reports the package version from a packed install', () => {
+  it('reports the package version from a packed install', async () => {
     const originalAllowScripts = process.env.npm_config_allow_scripts;
 
     try {
@@ -44,6 +44,9 @@ describe('packaged CLI version', () => {
         env: npmEnv,
       }).trim();
       tarballPath = path.join(process.cwd(), tarballName);
+      const extractedDir = path.join(tmpDir, 'extracted');
+      await fs.mkdir(extractedDir);
+      execFileSync('tar', ['-xzf', tarballPath, '-C', extractedDir]);
 
       execFileSync('npm', ['install', '--prefix', tmpDir, tarballPath], {
         stdio: 'pipe',
@@ -57,6 +60,21 @@ describe('packaged CLI version', () => {
       ).trim();
 
       expect(output).toBe(packageJson.version);
+
+      const extractedCliPath = path.join(
+        extractedDir,
+        'package',
+        'dist',
+        'cli',
+        'index.js',
+      );
+      const extractedCliStat = await fs.stat(extractedCliPath);
+      expect(extractedCliStat.mode & 0o111).not.toBe(0);
+      expect(
+        execFileSync(extractedCliPath, ['--version'], {
+          encoding: 'utf8',
+        }).trim(),
+      ).toBe(packageJson.version);
     } finally {
       if (originalAllowScripts === undefined) {
         delete process.env.npm_config_allow_scripts;

--- a/tests/integration/cli-version.test.ts
+++ b/tests/integration/cli-version.test.ts
@@ -39,10 +39,14 @@ describe('packaged CLI version', () => {
       ) as { version: string };
 
       const npmEnv = createIsolatedNpmEnv(npmUserConfigPath);
-      const tarballName = execFileSync('npm', ['pack', '--silent'], {
-        encoding: 'utf8',
-        env: npmEnv,
-      }).trim();
+      const tarballName = execFileSync(
+        'npm',
+        ['pack', '--silent', '--ignore-scripts'],
+        {
+          encoding: 'utf8',
+          env: npmEnv,
+        },
+      ).trim();
       tarballPath = path.join(process.cwd(), tarballName);
       const extractedDir = path.join(tmpDir, 'extracted');
       await fs.mkdir(extractedDir);

--- a/tests/integration/cli-version.test.ts
+++ b/tests/integration/cli-version.test.ts
@@ -39,15 +39,17 @@ describe('packaged CLI version', () => {
       ) as { version: string };
 
       const npmEnv = createIsolatedNpmEnv(npmUserConfigPath);
+      const packageRoot = await createCleanPackageRoot(tmpDir);
       const tarballName = execFileSync(
         'npm',
-        ['pack', '--silent', '--ignore-scripts'],
+        ['pack', '--silent', '--pack-destination', tmpDir],
         {
           encoding: 'utf8',
+          cwd: packageRoot,
           env: npmEnv,
         },
       ).trim();
-      tarballPath = path.join(process.cwd(), tarballName);
+      tarballPath = path.join(tmpDir, tarballName);
       const extractedDir = path.join(tmpDir, 'extracted');
       await fs.mkdir(extractedDir);
       execFileSync('tar', ['-xzf', tarballPath, '-C', extractedDir]);
@@ -101,4 +103,33 @@ function createIsolatedNpmEnv(userConfigPath: string): NodeJS.ProcessEnv {
   }
   env.npm_config_userconfig = userConfigPath;
   return env;
+}
+
+async function createCleanPackageRoot(tmpDir: string): Promise<string> {
+  const packageRoot = path.join(tmpDir, 'package-root');
+  await fs.mkdir(packageRoot);
+
+  const trackedFiles = execFileSync('git', ['ls-files', '-z'], {
+    encoding: 'utf8',
+  })
+    .split('\0')
+    .filter(Boolean)
+    .filter((filePath) => !filePath.startsWith('dist/'));
+
+  await Promise.all(
+    trackedFiles.map(async (filePath) => {
+      const sourcePath = path.join(process.cwd(), filePath);
+      const destinationPath = path.join(packageRoot, filePath);
+      await fs.mkdir(path.dirname(destinationPath), { recursive: true });
+      await fs.copyFile(sourcePath, destinationPath);
+    }),
+  );
+
+  await fs.symlink(
+    path.join(process.cwd(), 'node_modules'),
+    path.join(packageRoot, 'node_modules'),
+    'dir',
+  );
+
+  return packageRoot;
 }

--- a/tests/unit/package-json.test.ts
+++ b/tests/unit/package-json.test.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 describe('package manifest', () => {
-  it('does not run builds during install-time lifecycle hooks', () => {
+  it('builds installable artifacts for git and packed installs', () => {
     const packageJsonPath = path.join(process.cwd(), 'package.json');
     const packageJson = JSON.parse(
       fs.readFileSync(packageJsonPath, 'utf8'),
@@ -10,7 +10,7 @@ describe('package manifest', () => {
       scripts?: Record<string, string>;
     };
 
-    expect(packageJson.scripts?.prepare).toBeUndefined();
+    expect(packageJson.scripts?.prepare).toBe('npm run build');
     expect(packageJson.scripts?.prepublishOnly).toBe('npm run build');
   });
 
@@ -26,6 +26,9 @@ describe('package manifest', () => {
     expect(packageJson.scripts?.clean).toContain('recursive: true');
     expect(packageJson.scripts?.clean).toContain('force: true');
     expect(packageJson.scripts?.build).toBe('npm run clean && tsc');
+    expect(packageJson.scripts?.postbuild).toContain(
+      "chmodSync('dist/cli/index.js', 0o755)",
+    );
     expect(packageJson.scripts?.prepublishOnly).toBe('npm run build');
   });
 


### PR DESCRIPTION
## Summary
- build package artifacts during prepare so git installs have a dist tree
- chmod the generated CLI entrypoint after build so packed installs can execute it directly
- extend package tests to inspect the packed tarball and execute the extracted CLI

Fixes #705
Fixes #706

## Verification
- env -u npm_config_allow_scripts npm_config_userconfig=/dev/null npx jest tests/unit/package-json.test.ts tests/integration/cli-version.test.ts --runInBand --coverage=false
- env -u npm_config_allow_scripts npm_config_userconfig=/dev/null sh -c 'set -e; npm run check:package-lock; npm run format:check; npm run lint; npm test; npm run build; npm audit --omit=dev --audit-level=moderate; npm audit --audit-level=moderate; npm pack --dry-run'