### PR TITLE
Verify release recovery commit SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,10 @@ on:
         description: 'Existing release tag to publish, for release recovery runs'
         required: false
         type: string
+      release_sha:
+        description: 'Expected immutable commit SHA for release recovery runs'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -33,6 +37,7 @@ jobs:
           REF_TYPE: ${{ github.ref_type }}
           RELEASE_TAG_FROM_EVENT: ${{ github.event.release.tag_name }}
           RELEASE_TAG_FROM_INPUT: ${{ inputs.release_tag }}
+          RELEASE_SHA_FROM_INPUT: ${{ inputs.release_sha }}
           RELEASE_PRERELEASE: ${{ github.event.release.prerelease }}
         run: |
           PACKAGE_NAME="$(node -p "require('./package.json').name")"
@@ -60,10 +65,29 @@ jobs:
             exit 1
           fi
 
+          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
+            if ! printf '%s' "${RELEASE_SHA_FROM_INPUT}" | grep -Eq '^[0-9a-fA-F]{40}$'; then
+              echo "::error::Manual release recovery runs must provide release_sha as the intended 40-character commit SHA."
+              exit 1
+            fi
+            RELEASE_SHA="$(printf '%s' "${RELEASE_SHA_FROM_INPUT}" | tr '[:upper:]' '[:lower:]')"
+          fi
+
           git fetch --force --tags origin
           git fetch origin main
           TAG_SHA="$(git rev-list -n 1 "${RELEASE_TAG}")"
           HEAD_SHA="$(git rev-parse HEAD)"
+          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
+            if [ "${TAG_SHA}" != "${RELEASE_SHA}" ]; then
+              echo "::error::Release tag ${RELEASE_TAG} resolves to ${TAG_SHA}, not intended release_sha ${RELEASE_SHA}."
+              exit 1
+            fi
+            if [ "${HEAD_SHA}" != "${RELEASE_SHA}" ]; then
+              echo "::error::Release workflow checked out ${HEAD_SHA}, not intended release_sha ${RELEASE_SHA}."
+              exit 1
+            fi
+          fi
+
           if [ "${HEAD_SHA}" != "${TAG_SHA}" ]; then
             echo "::error::Release workflow checked out ${HEAD_SHA}, but ${RELEASE_TAG} resolves to ${TAG_SHA}."
             exit 1

--- a/tests/unit/workflows/release-workflow.test.ts
+++ b/tests/unit/workflows/release-workflow.test.ts
@@ -54,4 +54,39 @@ describe('release workflow', () => {
     expect(publishIndex).toBeGreaterThanOrEqual(0);
     expect(validateIndex).toBeLessThan(publishIndex);
   });
+
+  it('requires an immutable release SHA for manual recovery runs', () => {
+    const workflowPath = path.join(
+      process.cwd(),
+      '.github',
+      'workflows',
+      'release.yml',
+    );
+    const workflow = fs.readFileSync(workflowPath, 'utf8');
+
+    const validateIndex = workflow.indexOf('- name: Validate release target');
+    const publishIndex = workflow.indexOf('npm publish --access public');
+
+    expect(workflow).toContain('release_sha:');
+    expect(workflow).toContain(
+      "description: 'Expected immutable commit SHA for release recovery runs'",
+    );
+    expect(workflow).toContain('required: true');
+    expect(workflow).toContain(
+      'RELEASE_SHA_FROM_INPUT: ${{ inputs.release_sha }}',
+    );
+    expect(workflow).toContain("grep -Eq '^[0-9a-fA-F]{40}$'");
+    expect(workflow).toContain(
+      'Manual release recovery runs must provide release_sha as the intended 40-character commit SHA.',
+    );
+    expect(workflow).toContain(
+      'Release tag ${RELEASE_TAG} resolves to ${TAG_SHA}, not intended release_sha ${RELEASE_SHA}.',
+    );
+    expect(workflow).toContain(
+      'Release workflow checked out ${HEAD_SHA}, not intended release_sha ${RELEASE_SHA}.',
+    );
+    expect(validateIndex).toBeGreaterThanOrEqual(0);
+    expect(publishIndex).toBeGreaterThanOrEqual(0);
+    expect(validateIndex).toBeLessThan(publishIndex);
+  });
 });


### PR DESCRIPTION
## Summary
- add a required manual release recovery input for the intended immutable commit SHA
- validate release_sha is a full 40-character hex SHA
- require both the release tag target and checked-out HEAD to match release_sha before publishing
- add workflow text coverage for the recovery guard

Fixes #698

## Verification
- env -u npm_config_allow_scripts npm_config_userconfig=/dev/null npx jest tests/unit/workflows/release-workflow.test.ts --runInBand --coverage=false
- env -u npm_config_allow_scripts npm_config_userconfig=/dev/null npm run format:check