### PR TITLE
Back up Zed settings before MCP updates

### DIFF
--- a/src/agents/ZedAgent.ts
+++ b/src/agents/ZedAgent.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import { promises as fs } from 'fs';
 import { AgentsMdAgent } from './AgentsMdAgent';
 import { IAgentConfig } from './IAgent';
-import { writeGeneratedFile } from '../core/FileSystemUtils';
+import { backupFile, writeGeneratedFile } from '../core/FileSystemUtils';
 
 /**
  * Zed editor agent adapter.
@@ -46,8 +46,10 @@ export class ZedAgent extends AgentsMdAgent {
 
       // Read existing settings
       let existingSettings: Record<string, unknown> = {};
+      let existingContent: string | null = null;
       try {
         const content = await fs.readFile(zedSettingsPath, 'utf8');
+        existingContent = content;
         existingSettings = JSON.parse(content);
       } catch (error: unknown) {
         if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
@@ -110,12 +112,17 @@ export class ZedAgent extends AgentsMdAgent {
         };
       }
 
+      const nextContent = JSON.stringify(mergedSettings, null, 2);
+      if (existingContent === nextContent) {
+        return;
+      }
+
+      if (backup && existingContent !== null) {
+        await backupFile(zedSettingsPath, projectRoot);
+      }
+
       // Write updated settings
-      await writeGeneratedFile(
-        zedSettingsPath,
-        JSON.stringify(mergedSettings, null, 2),
-        projectRoot,
-      );
+      await writeGeneratedFile(zedSettingsPath, nextContent, projectRoot);
     }
   }
 

--- a/tests/integration/settings-sidecar-safety.test.ts
+++ b/tests/integration/settings-sidecar-safety.test.ts
@@ -79,6 +79,60 @@ describe('settings sidecar safety', () => {
     }
   });
 
+  it('backs up and restores existing Zed settings when MCP settings change', async () => {
+    const originalSettings = JSON.stringify(
+      {
+        theme: 'dark',
+        context_servers: {
+          local: {
+            source: 'custom',
+            command: 'local-server',
+          },
+        },
+      },
+      null,
+      2,
+    );
+    const project = await setupTestProject({
+      '.ruler/AGENTS.md': 'Rule A',
+      '.ruler/mcp.json': JSON.stringify({
+        mcpServers: {
+          generated: {
+            type: 'stdio',
+            command: 'node',
+            args: ['server.js'],
+          },
+        },
+      }),
+      '.zed/settings.json': originalSettings,
+    });
+    const settingsPath = path.join(
+      project.projectRoot,
+      '.zed',
+      'settings.json',
+    );
+
+    try {
+      runRuler('apply --agents zed', project.projectRoot);
+
+      await expect(fs.readFile(`${settingsPath}.bak`, 'utf8')).resolves.toBe(
+        originalSettings,
+      );
+      await expect(fs.readFile(settingsPath, 'utf8')).resolves.not.toBe(
+        originalSettings,
+      );
+
+      runRuler('revert --agents zed', project.projectRoot);
+
+      await expect(fs.readFile(settingsPath, 'utf8')).resolves.toBe(
+        originalSettings,
+      );
+      await expect(fs.access(`${settingsPath}.bak`)).rejects.toThrow();
+    } finally {
+      await teardownTestProject(project.projectRoot);
+    }
+  });
+
   it('tracks generated Gemini and Qwen settings in gitignore without MCP', async () => {
     const project = await setupTestProject({
       '.ruler/AGENTS.md': 'Rule A',

--- a/tests/unit/agents/ZedAgent.test.ts
+++ b/tests/unit/agents/ZedAgent.test.ts
@@ -154,6 +154,88 @@ describe('ZedAgent', () => {
     }
   });
 
+  it('backs up existing .zed/settings.json before changing MCP settings', async () => {
+    const { projectRoot } = await setupTestProject({
+      '.ruler/AGENTS.md': 'Test rules',
+    });
+
+    try {
+      const zedDir = path.join(projectRoot, '.zed');
+      await fs.mkdir(zedDir, { recursive: true });
+      const zedSettingsPath = path.join(zedDir, 'settings.json');
+      const existingSettings = {
+        theme: 'dark',
+        context_servers: {
+          'existing-server': {
+            source: 'custom',
+            command: 'ls',
+          },
+        },
+      };
+      const originalContent = JSON.stringify(existingSettings, null, 2);
+      await fs.writeFile(zedSettingsPath, originalContent);
+
+      const agent = new ZedAgent();
+      await agent.applyRulerConfig('Test rules content', projectRoot, {
+        mcpServers: {
+          'new-server': {
+            type: 'stdio',
+            command: 'pwd',
+          },
+        },
+      });
+
+      await expect(fs.readFile(`${zedSettingsPath}.bak`, 'utf8')).resolves.toBe(
+        originalContent,
+      );
+
+      const settingsContent = await fs.readFile(zedSettingsPath, 'utf8');
+      const settings = JSON.parse(settingsContent);
+      expect(settings.context_servers['new-server']).toEqual({
+        source: 'custom',
+        command: 'pwd',
+      });
+    } finally {
+      await teardownTestProject(projectRoot);
+    }
+  });
+
+  it('does not back up existing .zed/settings.json when backups are disabled', async () => {
+    const { projectRoot } = await setupTestProject({
+      '.ruler/AGENTS.md': 'Test rules',
+    });
+
+    try {
+      const zedDir = path.join(projectRoot, '.zed');
+      await fs.mkdir(zedDir, { recursive: true });
+      const zedSettingsPath = path.join(zedDir, 'settings.json');
+      await fs.writeFile(
+        zedSettingsPath,
+        JSON.stringify({ theme: 'dark' }, null, 2),
+      );
+
+      const agent = new ZedAgent();
+      await agent.applyRulerConfig(
+        'Test rules content',
+        projectRoot,
+        {
+          mcpServers: {
+            'new-server': {
+              type: 'stdio',
+              command: 'pwd',
+            },
+          },
+        },
+        undefined,
+        false,
+      );
+
+      await expect(fs.access(`${zedSettingsPath}.bak`)).rejects.toThrow();
+    } finally {
+      await teardownTestProject(projectRoot);
+    }
+  });
+
   it('does not modify .zed/settings.json when no MCP config provided', async () => {
     const { projectRoot } = await setupTestProject({
       '.ruler/AGENTS.md': 'Test rules',


### PR DESCRIPTION
## Summary
- back up existing `.zed/settings.json` before writing changed Zed MCP settings when backups are enabled
- skip unchanged Zed settings writes to avoid unnecessary backups
- add unit and integration coverage for Zed settings backup, backup disabling, and revert restore

Fixes #693

## Verification
- `env -u npm_config_allow_scripts npm_config_userconfig=/dev/null npx jest tests/unit/agents/ZedAgent.test.ts --runInBand --coverage=false`
- `env -u npm_config_allow_scripts npm_config_userconfig=/dev/null npx jest tests/unit/agents/ZedAgent.test.ts tests/integration/settings-sidecar-safety.test.ts --runInBand --coverage=false`
- `env -u npm_config_allow_scripts npm_config_userconfig=/dev/null npm run format`