### PR TITLE
Revert nested apply outputs

### DIFF
--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -165,6 +165,11 @@ export function createCli(argv: string[] = hideBin(process.argv)): Argv {
             description:
               'Only search for local .ruler directories, ignore global config',
             default: false,
+          })
+          .option('nested', {
+            type: 'boolean',
+            description:
+              'Enable nested revert processing for nested .ruler directories (default: from config or disabled)',
           });
       },
       revertHandler,

--- a/src/cli/handlers.ts
+++ b/src/cli/handlers.ts
@@ -39,6 +39,7 @@ export interface RevertArgs {
   verbose: boolean;
   'dry-run': boolean;
   'local-only': boolean;
+  nested?: boolean;
 }
 
 function assertNotInsideRulerDir(projectRoot: string): void {
@@ -117,7 +118,7 @@ function parseCliAgents(
 }
 
 async function resolveNestedPreference(
-  argv: ApplyArgs,
+  argv: { nested?: boolean },
   projectRoot: string,
   configPath: string | undefined,
   localOnly: boolean,
@@ -339,6 +340,12 @@ export async function revertHandler(argv: RevertArgs): Promise<void> {
     assertNotInsideRulerDir(projectRoot);
     const configPath = parseOptionalStringOption(argv.config, 'config');
     const agents = parseCliAgents(argv.agents);
+    const nested = await resolveNestedPreference(
+      argv,
+      projectRoot,
+      configPath,
+      localOnly,
+    );
 
     await revertAllAgentConfigs(
       projectRoot,
@@ -348,6 +355,7 @@ export async function revertHandler(argv: RevertArgs): Promise<void> {
       verbose,
       dryRun,
       localOnly,
+      nested,
     );
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);

--- a/src/revert.ts
+++ b/src/revert.ts
@@ -1,14 +1,24 @@
 import { promises as fs } from 'fs';
+import * as path from 'path';
 import * as FileSystemUtils from './core/FileSystemUtils';
 import { loadConfig } from './core/ConfigLoader';
 import { IAgent } from './agents/IAgent';
 import { allAgents } from './agents';
-import { createRulerError, logVerbose, actionPrefix } from './constants';
+import {
+  createRulerError,
+  logVerbose,
+  actionPrefix,
+  logWarn,
+} from './constants';
 import {
   revertAgentConfiguration,
   cleanUpAuxiliaryFiles,
   cleanUpAgentDirectories,
 } from './core/revert-engine';
+import {
+  HierarchicalRulerConfiguration,
+  loadNestedConfigurations,
+} from './core/apply-engine';
 import { resolveSelectedAgents } from './core/agent-selection';
 import { mapRawAgentConfigs } from './core/config-utils';
 import {
@@ -32,7 +42,21 @@ export async function revertAllAgentConfigs(
   verbose = false,
   dryRun = false,
   localOnly = false,
+  nested = false,
 ): Promise<void> {
+  if (nested) {
+    await revertNestedAgentConfigs(
+      projectRoot,
+      includedAgents,
+      configPath,
+      keepBackups,
+      verbose,
+      dryRun,
+      localOnly,
+    );
+    return;
+  }
+
   const rulerDir = await FileSystemUtils.findRulerDir(projectRoot, !localOnly);
   if (!rulerDir) {
     throw createRulerError(
@@ -139,6 +163,177 @@ export async function revertAllAgentConfigs(
   for (const ignoreFile of cleanedIgnoreFiles) {
     console.log(`  ${ignoreFile} cleaned: yes`);
   }
+}
+
+async function revertNestedAgentConfigs(
+  projectRoot: string,
+  includedAgents: string[] | undefined,
+  configPath: string | undefined,
+  keepBackups: boolean,
+  verbose: boolean,
+  dryRun: boolean,
+  localOnly: boolean,
+): Promise<void> {
+  logVerbose(
+    `Loading nested configurations for revert from project root: ${projectRoot}`,
+    verbose,
+  );
+
+  const configurations = await loadNestedConfigurations(
+    projectRoot,
+    configPath,
+    localOnly,
+    true,
+  );
+  if (configurations.length === 0) {
+    throw new Error('No .ruler directories found');
+  }
+
+  logWarn(
+    'Nested mode is experimental and may change in future releases.',
+    dryRun,
+  );
+
+  for (const configEntry of configurations) {
+    configEntry.config.agentConfigs = mapRawAgentConfigs(
+      configEntry.config.agentConfigs,
+      agents,
+    );
+  }
+
+  const rootConfigEntry = selectRootConfiguration(configurations, projectRoot);
+  const rootConfig = rootConfigEntry.config;
+  rootConfig.cliAgents = includedAgents;
+
+  const selected = resolveSelectedAgents(rootConfig, agents);
+  logVerbose(
+    `Selected agents: ${selected.map((a) => a.getName()).join(', ')}`,
+    verbose,
+  );
+
+  const isFullRevert = !includedAgents || includedAgents.length === 0;
+  let totalFilesProcessed = 0;
+  let totalFilesRestored = 0;
+  let totalFilesRemoved = 0;
+  let totalBackupsRemoved = 0;
+  let totalDirectoriesRemoved = 0;
+  const cleanedIgnoreFiles: string[] = [];
+  const processedPaths = new Set<string>();
+
+  for (const configEntry of configurations) {
+    const effectiveProjectRoot = configEntry.projectRoot;
+    logVerbose(
+      `Reverting nested .ruler directory: ${configEntry.rulerDir}`,
+      verbose,
+    );
+
+    for (const agent of selected) {
+      const prefix = actionPrefix(dryRun);
+      console.log(`${prefix} Reverting ${agent.getName()}...`);
+
+      const agentConfig =
+        configEntry.config.agentConfigs[agent.getIdentifier()];
+      const result = await revertAgentConfiguration(
+        agent,
+        effectiveProjectRoot,
+        agentConfig,
+        keepBackups,
+        verbose,
+        dryRun,
+        processedPaths,
+      );
+
+      totalFilesProcessed += result.restored + result.removed;
+      totalFilesRestored += result.restored;
+      totalFilesRemoved += result.removed;
+      totalBackupsRemoved += result.backupsRemoved;
+
+      totalDirectoriesRemoved += await cleanUpAgentDirectories(
+        agent,
+        effectiveProjectRoot,
+        agentConfig,
+        verbose,
+        dryRun,
+      );
+    }
+
+    if (isFullRevert) {
+      const cleanupResult = await cleanUpAuxiliaryFiles(
+        effectiveProjectRoot,
+        verbose,
+        dryRun,
+      );
+      totalFilesRemoved += cleanupResult.additionalFilesRemoved;
+      totalDirectoriesRemoved += cleanupResult.directoriesRemoved;
+
+      const cleaned = await cleanManagedIgnoreFiles(
+        effectiveProjectRoot,
+        verbose,
+        dryRun,
+      );
+      cleanedIgnoreFiles.push(
+        ...cleaned.map((ignoreFile) =>
+          path.join(
+            path.relative(projectRoot, effectiveProjectRoot),
+            ignoreFile,
+          ),
+        ),
+      );
+    }
+  }
+
+  const prefix = actionPrefix(dryRun);
+
+  if (dryRun) {
+    console.log(`${prefix} Revert summary (dry run):`);
+  } else {
+    console.log(`${prefix} Revert completed successfully.`);
+  }
+
+  console.log(`  Files processed: ${totalFilesProcessed}`);
+  console.log(`  Files restored from backup: ${totalFilesRestored}`);
+  console.log(`  Generated files removed: ${totalFilesRemoved}`);
+  console.log(`  Backup files removed: ${totalBackupsRemoved}`);
+  if (totalDirectoriesRemoved > 0) {
+    console.log(`  Empty directories removed: ${totalDirectoriesRemoved}`);
+  }
+  for (const ignoreFile of cleanedIgnoreFiles) {
+    console.log(`  ${ignoreFile} cleaned: yes`);
+  }
+}
+
+function selectRootConfiguration(
+  configurations: HierarchicalRulerConfiguration[],
+  projectRoot: string,
+): HierarchicalRulerConfiguration {
+  if (configurations.length === 0) {
+    throw new Error('No hierarchical configurations available');
+  }
+
+  const normalizedProjectRoot = path.resolve(projectRoot);
+  let bestIndex = -1;
+  let bestDepth = Number.POSITIVE_INFINITY;
+
+  for (let i = 0; i < configurations.length; i++) {
+    const entry = configurations[i];
+    const normalizedDir = path.resolve(entry.rulerDir);
+
+    if (!normalizedDir.startsWith(normalizedProjectRoot)) {
+      continue;
+    }
+
+    const depth = normalizedDir.split(path.sep).length;
+    if (depth < bestDepth) {
+      bestDepth = depth;
+      bestIndex = i;
+    }
+  }
+
+  if (bestIndex === -1) {
+    return configurations[0];
+  }
+
+  return configurations[bestIndex];
 }
 
 /**

--- a/tests/unit/cli/commands.test.ts
+++ b/tests/unit/cli/commands.test.ts
@@ -144,6 +144,10 @@ describe('CLI command wiring', () => {
       'local-only',
       expect.objectContaining({ type: 'boolean' }),
     );
+    expect(revertArgv.option).toHaveBeenCalledWith(
+      'nested',
+      expect.objectContaining({ type: 'boolean' }),
+    );
     expect(revertArgv.alias).toHaveBeenCalledWith('verbose', 'v');
   });
 

--- a/tests/unit/cli/handlers.test.ts
+++ b/tests/unit/cli/handlers.test.ts
@@ -896,6 +896,7 @@ describe('CLI Handlers', () => {
         verbose: true,
         'dry-run': false,
         'local-only': false,
+        nested: true,
       };
 
       await revertHandler(argv);
@@ -908,6 +909,7 @@ describe('CLI Handlers', () => {
         true,
         false,
         false,
+        true,
       );
     });
 
@@ -1005,6 +1007,7 @@ describe('CLI Handlers', () => {
         verbose: false,
         'dry-run': false,
         'local-only': false,
+        nested: false,
       };
 
       await revertHandler(argv);
@@ -1013,6 +1016,7 @@ describe('CLI Handlers', () => {
         mockProjectRoot,
         undefined,
         undefined,
+        false,
         false,
         false,
         false,

--- a/tests/unit/core/revert.test.ts
+++ b/tests/unit/core/revert.test.ts
@@ -318,6 +318,81 @@ describe('Revert Core Functions', () => {
       );
     });
 
+    it('does not revert nested child outputs unless nested mode is enabled', async () => {
+      const childRoot = path.join(tmpDir, 'packages', 'child');
+      await fs.mkdir(path.join(childRoot, '.ruler'), { recursive: true });
+      await fs.writeFile(
+        path.join(tmpDir, '.ruler', 'ruler.toml'),
+        'default_agents = ["claude"]\nnested = true\n',
+      );
+      await fs.writeFile(
+        path.join(childRoot, '.ruler', 'instructions.md'),
+        'Child Rule',
+      );
+      await fs.writeFile(
+        path.join(tmpDir, 'CLAUDE.md'),
+        `${GENERATED_MARKER}\nRoot generated content`,
+      );
+      await fs.writeFile(
+        path.join(childRoot, 'CLAUDE.md'),
+        `${GENERATED_MARKER}\nChild generated content`,
+      );
+
+      await revertAllAgentConfigs(
+        tmpDir,
+        undefined,
+        undefined,
+        false,
+        false,
+        false,
+      );
+
+      await expect(fs.access(path.join(tmpDir, 'CLAUDE.md'))).rejects.toThrow();
+      await expect(
+        fs.readFile(path.join(childRoot, 'CLAUDE.md'), 'utf8'),
+      ).resolves.toBe(`${GENERATED_MARKER}\nChild generated content`);
+    });
+
+    it('reverts nested child outputs in nested mode', async () => {
+      const childRoot = path.join(tmpDir, 'packages', 'child');
+      const childOutput = path.join(childRoot, 'CLAUDE.md');
+      const childBackup = `${childOutput}.bak`;
+
+      await fs.mkdir(path.join(childRoot, '.ruler'), { recursive: true });
+      await fs.writeFile(
+        path.join(tmpDir, '.ruler', 'ruler.toml'),
+        'default_agents = ["claude"]\nnested = true\n',
+      );
+      await fs.writeFile(
+        path.join(childRoot, '.ruler', 'instructions.md'),
+        'Child Rule',
+      );
+      await fs.writeFile(
+        path.join(tmpDir, 'CLAUDE.md'),
+        `${GENERATED_MARKER}\nRoot generated content`,
+      );
+      await fs.writeFile(childBackup, 'Original child content');
+      await writeBackupProvenance(childBackup);
+      await fs.writeFile(childOutput, 'Updated child content');
+
+      await revertAllAgentConfigs(
+        tmpDir,
+        undefined,
+        undefined,
+        false,
+        false,
+        false,
+        false,
+        true,
+      );
+
+      await expect(fs.access(path.join(tmpDir, 'CLAUDE.md'))).rejects.toThrow();
+      await expect(fs.readFile(childOutput, 'utf8')).resolves.toBe(
+        'Original child content',
+      );
+      await expect(fs.access(childBackup)).rejects.toThrow();
+    });
+
     it('should clean up empty directories', async () => {
       const githubDir = path.join(tmpDir, '.github');
       const cursorDir = path.join(tmpDir, '.cursor');


### PR DESCRIPTION
Fixes #694

## Summary
- add nested revert mode and CLI plumbing for `ruler revert --nested` / TOML `nested = true`
- reuse nested configuration loading so each nested `.ruler` directory reverts outputs relative to its own root
- add focused tests for default single-root revert and nested child output restore/removal

## Verification
- `env -u npm_config_allow_scripts npm_config_userconfig=/dev/null npm run format`
- `env -u npm_config_allow_scripts npm_config_userconfig=/dev/null npx jest tests/unit/core/revert.test.ts tests/unit/cli/commands.test.ts tests/unit/cli/handlers.test.ts --runInBand --coverage=false`
- `env -u npm_config_allow_scripts npm_config_userconfig=/dev/null npm run lint`
- `env -u npm_config_allow_scripts npm_config_userconfig=/dev/null npm run build`