### PR TITLE
Reject unsafe ruler symlinks in config loaders

### DIFF
--- a/src/core/ConfigLoader.ts
+++ b/src/core/ConfigLoader.ts
@@ -13,6 +13,7 @@ import {
   SubagentsConfig,
 } from '../types';
 import { createRulerError, logWarn } from '../constants';
+import { isSafeRulerDirectory, pathExists } from './FileSystemUtils';
 
 // One-shot guard so the deprecation message fires once per process even when
 // `loadConfig` is called multiple times (e.g. nested mode walks every
@@ -579,11 +580,18 @@ async function resolveImplicitConfigFile(
   checkGlobal: boolean,
 ): Promise<string | undefined> {
   const localRulerDir = await findNearestLocalRulerDir(projectRoot);
-  const localConfigFile = localRulerDir
-    ? path.join(localRulerDir, 'ruler.toml')
-    : path.join(projectRoot, '.ruler', 'ruler.toml');
-  if (await configFileExists(localConfigFile)) {
-    return localConfigFile;
+  const projectRulerDir = path.join(projectRoot, '.ruler');
+  const unsafeProjectRulerDir =
+    !localRulerDir &&
+    (await pathExists(projectRulerDir)) &&
+    !(await isSafeRulerDirectory(projectRulerDir, projectRoot));
+  if (!unsafeProjectRulerDir) {
+    const localConfigFile = localRulerDir
+      ? path.join(localRulerDir, 'ruler.toml')
+      : path.join(projectRulerDir, 'ruler.toml');
+    if (await configFileExists(localConfigFile)) {
+      return localConfigFile;
+    }
   }
 
   if (!checkGlobal) {
@@ -607,13 +615,8 @@ async function findNearestLocalRulerDir(
 
   while (current) {
     const candidate = path.join(current, '.ruler');
-    try {
-      const stat = await fs.stat(candidate);
-      if (stat.isDirectory()) {
-        return candidate;
-      }
-    } catch {
-      // Keep walking; missing or inaccessible candidates simply do not match.
+    if (await isSafeRulerDirectory(candidate, current)) {
+      return candidate;
     }
 
     const parent = path.dirname(current);

--- a/src/core/FileSystemUtils.ts
+++ b/src/core/FileSystemUtils.ts
@@ -156,16 +156,8 @@ export async function findRulerDir(
   let current = startPath;
   while (current) {
     const candidate = path.join(current, '.ruler');
-    try {
-      const stat = await fs.lstat(candidate);
-      const candidateIsDirectory = stat.isSymbolicLink()
-        ? await symlinkedDirectoryStaysInside(candidate, current)
-        : stat.isDirectory();
-      if (candidateIsDirectory) {
-        return candidate;
-      }
-    } catch {
-      // ignore errors when checking for .ruler directory
+    if (await isSafeRulerDirectory(candidate, current)) {
+      return candidate;
     }
     const parent = path.dirname(current);
     if (parent === current) {
@@ -194,6 +186,32 @@ export async function findRulerDir(
   }
 
   return null;
+}
+
+export async function isSafeRulerDirectory(
+  candidate: string,
+  containingDir: string,
+): Promise<boolean> {
+  try {
+    const stat = await fs.lstat(candidate);
+    return stat.isSymbolicLink()
+      ? await symlinkedDirectoryStaysInside(candidate, containingDir)
+      : stat.isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+export async function pathExists(candidate: string): Promise<boolean> {
+  try {
+    await fs.lstat(candidate);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return false;
+    }
+    throw error;
+  }
 }
 
 async function symlinkedDirectoryStaysInside(

--- a/src/core/UnifiedConfigLoader.ts
+++ b/src/core/UnifiedConfigLoader.ts
@@ -45,20 +45,27 @@ function copyAdditionalMcpServerFields(
 
 async function resolveImplicitTomlFile(
   projectRoot: string,
-  rulerDir: string,
+  rulerDir: string | undefined,
   checkGlobal: boolean,
+  includeProjectLocal = true,
 ): Promise<string | undefined> {
-  const localTomlFile = path.join(rulerDir, 'ruler.toml');
-  if (await fileExists(localTomlFile)) {
-    return localTomlFile;
+  let localTomlFile: string | undefined;
+  if (rulerDir) {
+    localTomlFile = path.join(rulerDir, 'ruler.toml');
+    if (await fileExists(localTomlFile)) {
+      return localTomlFile;
+    }
   }
 
-  const projectTomlFile = path.join(projectRoot, '.ruler', 'ruler.toml');
-  if (
-    path.resolve(projectTomlFile) !== path.resolve(localTomlFile) &&
-    (await fileExists(projectTomlFile))
-  ) {
-    return projectTomlFile;
+  if (includeProjectLocal) {
+    const projectTomlFile = path.join(projectRoot, '.ruler', 'ruler.toml');
+    if (
+      (!localTomlFile ||
+        path.resolve(projectTomlFile) !== path.resolve(localTomlFile)) &&
+      (await fileExists(projectTomlFile))
+    ) {
+      return projectTomlFile;
+    }
   }
 
   if (!checkGlobal) {
@@ -69,7 +76,8 @@ async function resolveImplicitTomlFile(
     process.env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config');
   const globalTomlFile = path.join(xdgConfigDir, 'ruler', 'ruler.toml');
   if (
-    path.resolve(globalTomlFile) !== path.resolve(localTomlFile) &&
+    (!localTomlFile ||
+      path.resolve(globalTomlFile) !== path.resolve(localTomlFile)) &&
     (await fileExists(globalTomlFile))
   ) {
     return globalTomlFile;
@@ -94,11 +102,19 @@ export async function loadUnifiedConfig(
   options: UnifiedLoadOptions,
 ): Promise<RulerUnifiedConfig> {
   // Resolve the effective .ruler directory (local or global), mirroring the main loader behavior
-  const resolvedRulerDir =
-    (await FileSystemUtils.findRulerDir(
+  const discoveredRulerDir = await FileSystemUtils.findRulerDir(
+    options.projectRoot,
+    options.checkGlobal ?? true,
+  );
+  const fallbackRulerDir = path.join(options.projectRoot, '.ruler');
+  const unsafeLocalRulerDir =
+    discoveredRulerDir === null &&
+    (await FileSystemUtils.pathExists(fallbackRulerDir)) &&
+    !(await FileSystemUtils.isSafeRulerDirectory(
+      fallbackRulerDir,
       options.projectRoot,
-      options.checkGlobal ?? true,
-    )) || path.join(options.projectRoot, '.ruler');
+    ));
+  const resolvedRulerDir = discoveredRulerDir || fallbackRulerDir;
 
   const meta: ConfigMeta = {
     projectRoot: options.projectRoot,
@@ -113,11 +129,18 @@ export async function loadUnifiedConfig(
   let tomlRaw: unknown = {};
   const tomlFile = options.configPath
     ? path.resolve(options.configPath)
-    : await resolveImplicitTomlFile(
-        options.projectRoot,
-        meta.rulerDir,
-        options.checkGlobal ?? true,
-      );
+    : unsafeLocalRulerDir
+      ? await resolveImplicitTomlFile(
+          options.projectRoot,
+          undefined,
+          options.checkGlobal ?? true,
+          false,
+        )
+      : await resolveImplicitTomlFile(
+          options.projectRoot,
+          meta.rulerDir,
+          options.checkGlobal ?? true,
+        );
   if (tomlFile) {
     try {
       const text = await fs.readFile(tomlFile, 'utf8');
@@ -196,6 +219,9 @@ export async function loadUnifiedConfig(
   // Collect rule markdown files
   let ruleFiles: RuleFile[] = [];
   try {
+    if (unsafeLocalRulerDir) {
+      throw new Error('Unsafe local .ruler directory resolves outside project');
+    }
     const mdFiles = await FileSystemUtils.readMarkdownFiles(meta.rulerDir, {
       includeAgents: includeAgentsInRules,
     });

--- a/tests/unit/core/ConfigLoader.test.ts
+++ b/tests/unit/core/ConfigLoader.test.ts
@@ -93,6 +93,34 @@ describe('ConfigLoader', () => {
     expect(config.nested).toBe(false);
   });
 
+  it('does not read implicit config through an unsafe .ruler symlink', async () => {
+    const externalRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'ruler-external-config-'),
+    );
+
+    try {
+      const externalRulerDir = path.join(externalRoot, '.ruler');
+      await fs.mkdir(externalRulerDir, { recursive: true });
+      await fs.writeFile(
+        path.join(externalRulerDir, 'ruler.toml'),
+        'default_agents = ["claude"]',
+      );
+
+      await fs.rm(rulerDir, { recursive: true, force: true });
+      await fs.symlink(externalRulerDir, rulerDir);
+
+      const config = await loadConfig({
+        projectRoot: tmpDir,
+        checkGlobal: false,
+      });
+
+      expect(config.defaultAgents).toBeUndefined();
+      expect(config.agentConfigs).toEqual({});
+    } finally {
+      await fs.rm(externalRoot, { recursive: true, force: true });
+    }
+  });
+
   it('throws when an existing implicit local config is unreadable', async () => {
     const configPath = path.join(rulerDir, 'ruler.toml');
     await fs.mkdir(configPath);

--- a/tests/unit/core/unified-config-loader.test.ts
+++ b/tests/unit/core/unified-config-loader.test.ts
@@ -58,6 +58,49 @@ describe('UnifiedConfigLoader (basic)', () => {
     );
   });
 
+  test('does not read rules or TOML through an unsafe .ruler symlink', async () => {
+    const projectRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'ruler-unified-project-'),
+    );
+    const externalRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'ruler-unified-external-'),
+    );
+
+    try {
+      const externalRulerDir = path.join(externalRoot, '.ruler');
+      await fs.mkdir(externalRulerDir, { recursive: true });
+      await fs.writeFile(
+        path.join(externalRulerDir, 'ruler.toml'),
+        'default_agents = ["claude"]',
+      );
+      await fs.writeFile(
+        path.join(externalRulerDir, 'AGENTS.md'),
+        '# External Rules',
+      );
+      await fs.symlink(externalRulerDir, path.join(projectRoot, '.ruler'));
+
+      const unified = await loadUnifiedConfig({
+        projectRoot,
+        checkGlobal: false,
+      });
+
+      expect(unified.toml.defaultAgents).toBeUndefined();
+      expect(unified.rules.files).toEqual([]);
+      expect(unified.rules.concatenated).not.toContain('External Rules');
+      expect(unified.diagnostics).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            severity: 'warning',
+            code: 'RULES_READ_ERROR',
+          }),
+        ]),
+      );
+    } finally {
+      await fs.rm(projectRoot, { recursive: true, force: true });
+      await fs.rm(externalRoot, { recursive: true, force: true });
+    }
+  });
+
   afterAll(async () => {
     await fs.rm(tmpRoot, { recursive: true, force: true });
   });

--- a/tests/unit/invalid-agent.test.ts
+++ b/tests/unit/invalid-agent.test.ts
@@ -49,6 +49,8 @@ jest.mock('../../src/core/FileSystemUtils', () => {
   const pathModule = jest.requireActual('path');
   return {
     findRulerDir: jest.fn().mockResolvedValue('/test/.ruler'),
+    isSafeRulerDirectory: jest.fn().mockResolvedValue(true),
+    pathExists: jest.fn().mockResolvedValue(true),
     resolveProjectRootForRulerDir: jest
       .fn()
       .mockImplementation((requestedProjectRoot, rulerDir) =>


### PR DESCRIPTION
## Summary
- share the safe .ruler directory containment check with config loader paths
- prevent classic and unified config loaders from reading TOML or rules through a local .ruler symlink that resolves outside the project
- add regression tests for both loaders and update the existing FileSystemUtils mock

Fixes #702

## Verification
- env -u npm_config_allow_scripts npm_config_userconfig=/dev/null npx jest tests/unit/invalid-agent.test.ts tests/unit/core/ConfigLoader.test.ts tests/unit/core/unified-config-loader.test.ts tests/unit/core/FileSystemUtils.test.ts --runInBand --coverage=false
- env -u npm_config_allow_scripts npm_config_userconfig=/dev/null sh -c 'set -e; npm run check:package-lock; npm run format:check; npm run lint; npm test; npm run build; npm audit --omit=dev --audit-level=moderate; npm audit --audit-level=moderate; npm pack --dry-run'