### PR TITLE
Respect nested config default agents

### DIFF
--- a/src/core/apply-engine.ts
+++ b/src/core/apply-engine.ts
@@ -394,6 +394,7 @@ export async function processHierarchicalConfigurations(
   cliMcpEnabled: boolean,
   cliMcpStrategy?: McpStrategy,
   backup = true,
+  selectedAgentsByRulerDir?: Map<string, IAgent[]>,
 ): Promise<string[]> {
   const allGeneratedPaths: string[] = [];
 
@@ -404,8 +405,10 @@ export async function processHierarchicalConfigurations(
       dryRun,
     );
     const rulerRoot = path.dirname(config.rulerDir);
+    const selectedAgents =
+      selectedAgentsByRulerDir?.get(config.rulerDir) ?? agents;
     const paths = await applyConfigurationsToAgents(
-      agents,
+      selectedAgents,
       config.concatenatedRules,
       config.rulerMcpJson,
       config.config,

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -160,6 +160,7 @@ export async function applyAllAgentConfigs(
   const gitignoreConfigurations: Array<{
     projectRoot: string;
     config: LoadedConfig;
+    selectedAgents?: IAgent[];
   }> = [];
 
   if (nested) {
@@ -181,14 +182,12 @@ export async function applyAllAgentConfigs(
       dryRun,
     );
 
-    // Use the root config for agent selection (all levels share the same agent settings)
     const rootConfigEntry = selectRootConfiguration(
       hierarchicalConfigs,
       projectRoot,
     );
     const rootConfig = rootConfigEntry.config;
     loadedConfig = rootConfig;
-    rootConfig.cliAgents = includedAgents;
 
     logVerbose(
       `Loaded ${hierarchicalConfigs.length} .ruler directory configurations`,
@@ -199,13 +198,22 @@ export async function applyAllAgentConfigs(
       verbose,
     );
 
+    const selectedAgentsByRulerDir = new Map<string, IAgent[]>();
     for (const configEntry of hierarchicalConfigs) {
+      configEntry.config.cliAgents = includedAgents;
       normalizeAgentConfigs(configEntry.config, agents);
+      const configSelectedAgents = resolveSelectedAgents(
+        configEntry.config,
+        agents,
+      );
+      selectedAgentsByRulerDir.set(configEntry.rulerDir, configSelectedAgents);
     }
 
-    selectedAgents = resolveSelectedAgents(rootConfig, agents);
+    selectedAgents =
+      selectedAgentsByRulerDir.get(rootConfigEntry.rulerDir) ??
+      resolveSelectedAgents(rootConfig, agents);
     logVerbose(
-      `Selected ${selectedAgents.length} agents: ${selectedAgents.map((a) => a.getName()).join(', ')}`,
+      `Selected ${selectedAgents.length} agents for root configuration: ${selectedAgents.map((a) => a.getName()).join(', ')}`,
       verbose,
     );
 
@@ -213,9 +221,12 @@ export async function applyAllAgentConfigs(
     // Propagate or clean up skills for each nested .ruler directory.
     for (const configEntry of hierarchicalConfigs) {
       const nestedRoot = path.dirname(configEntry.rulerDir);
+      const configSelectedAgents =
+        selectedAgentsByRulerDir.get(configEntry.rulerDir) ?? selectedAgents;
       gitignoreConfigurations.push({
         projectRoot: nestedRoot,
         config: configEntry.config,
+        selectedAgents: configSelectedAgents,
       });
       const skillsEnabledResolved = resolveSkillsEnabled(
         skillsEnabled,
@@ -227,7 +238,7 @@ export async function applyAllAgentConfigs(
       );
       await propagateSkills(
         nestedRoot,
-        selectedAgents,
+        configSelectedAgents,
         skillsEnabledResolved,
         verbose,
         dryRun,
@@ -250,13 +261,15 @@ export async function applyAllAgentConfigs(
       const { propagateSubagents } = await import('./core/SubagentsProcessor');
       for (const configEntry of hierarchicalConfigs) {
         const nestedRoot = path.dirname(configEntry.rulerDir);
+        const configSelectedAgents =
+          selectedAgentsByRulerDir.get(configEntry.rulerDir) ?? selectedAgents;
         logVerbose(
           `Propagating subagents for nested directory: ${nestedRoot}`,
           verbose,
         );
         await propagateSubagents(
           nestedRoot,
-          selectedAgents,
+          configSelectedAgents,
           subagentsEnabledResolved,
           subagentsCleanupOrphaned,
           verbose,
@@ -273,6 +286,7 @@ export async function applyAllAgentConfigs(
       cliMcpEnabled,
       cliMcpStrategy,
       backupEnabledResolved,
+      selectedAgentsByRulerDir,
     );
   } else {
     const singleConfig = await loadSingleConfiguration(
@@ -370,7 +384,7 @@ export async function applyAllAgentConfigs(
     for (const entry of skillsEnabledGitignoreConfigurations) {
       const skillsPaths = await getSkillsGitignorePaths(
         entry.projectRoot,
-        selectedAgents,
+        entry.selectedAgents ?? selectedAgents,
       );
       allGeneratedPaths = [...allGeneratedPaths, ...skillsPaths];
     }

--- a/tests/integration/nested-config-cli.test.ts
+++ b/tests/integration/nested-config-cli.test.ts
@@ -74,4 +74,74 @@ describe('CLI nested toggle precedence', () => {
       fs.readFile(path.join(projectRoot, 'module', 'CLAUDE.md'), 'utf8'),
     ).resolves.toContain('Module Rules');
   });
+
+  it('respects child default_agents when applying nested configs', async () => {
+    const rootRulerDir = path.join(projectRoot, '.ruler');
+    const moduleDir = path.join(projectRoot, 'module');
+    const moduleRulerDir = path.join(moduleDir, '.ruler');
+
+    await fs.mkdir(rootRulerDir, { recursive: true });
+    await fs.mkdir(moduleRulerDir, { recursive: true });
+    await fs.writeFile(
+      path.join(rootRulerDir, 'AGENTS.md'),
+      '# Root Rules\n\nThese apply at the root.',
+    );
+    await fs.writeFile(
+      path.join(rootRulerDir, 'ruler.toml'),
+      'default_agents = ["claude"]\nnested = true\n',
+    );
+    await fs.writeFile(
+      path.join(moduleRulerDir, 'AGENTS.md'),
+      '# Module Rules\n\nThese apply inside module.',
+    );
+    await fs.writeFile(
+      path.join(moduleRulerDir, 'ruler.toml'),
+      'default_agents = ["windsurf"]\n',
+    );
+
+    runRulerWithInheritedStdio('apply', projectRoot);
+
+    await expect(
+      fs.readFile(path.join(projectRoot, 'CLAUDE.md'), 'utf8'),
+    ).resolves.toContain('Root Rules');
+    await expect(
+      fs.stat(path.join(projectRoot, 'AGENTS.md')),
+    ).rejects.toThrow();
+    await expect(
+      fs.readFile(path.join(moduleDir, 'AGENTS.md'), 'utf8'),
+    ).resolves.toContain('Module Rules');
+    await expect(fs.stat(path.join(moduleDir, 'CLAUDE.md'))).rejects.toThrow();
+  });
+
+  it('lets CLI --agents override child default_agents in nested configs', async () => {
+    const rootRulerDir = path.join(projectRoot, '.ruler');
+    const moduleDir = path.join(projectRoot, 'module');
+    const moduleRulerDir = path.join(moduleDir, '.ruler');
+
+    await fs.mkdir(rootRulerDir, { recursive: true });
+    await fs.mkdir(moduleRulerDir, { recursive: true });
+    await fs.writeFile(
+      path.join(rootRulerDir, 'AGENTS.md'),
+      '# Root Rules\n\nThese apply at the root.',
+    );
+    await fs.writeFile(
+      path.join(rootRulerDir, 'ruler.toml'),
+      'default_agents = ["claude"]\nnested = true\n',
+    );
+    await fs.writeFile(
+      path.join(moduleRulerDir, 'AGENTS.md'),
+      '# Module Rules\n\nThese apply inside module.',
+    );
+    await fs.writeFile(
+      path.join(moduleRulerDir, 'ruler.toml'),
+      'default_agents = ["windsurf"]\n',
+    );
+
+    runRulerWithInheritedStdio('apply --agents claude', projectRoot);
+
+    await expect(
+      fs.readFile(path.join(moduleDir, 'CLAUDE.md'), 'utf8'),
+    ).resolves.toContain('Module Rules');
+    await expect(fs.stat(path.join(moduleDir, 'AGENTS.md'))).rejects.toThrow();
+  });
 });


### PR DESCRIPTION
## Summary
- Resolve selected agents independently for each nested `.ruler` configuration.
- Preserve CLI `--agents` as an override across all nested levels.
- Add nested CLI regression coverage for child `default_agents` and CLI override precedence.

Fixes #697

## Verification
- `env -u npm_config_allow_scripts npm_config_userconfig=/dev/null npx jest tests/integration/nested-config-cli.test.ts --runInBand --coverage=false`
- `env -u npm_config_allow_scripts npm_config_userconfig=/dev/null npm run format`
- `env -u npm_config_allow_scripts npm_config_userconfig=/dev/null npx jest tests/unit/core/apply-engine.test.ts tests/integration/nested-config-cli.test.ts --runInBand --coverage=false`
- `env -u npm_config_allow_scripts npm_config_userconfig=/dev/null npm run format:check`
- `env -u npm_config_allow_scripts npm_config_userconfig=/dev/null npm run lint`
- `env -u npm_config_allow_scripts npm_config_userconfig=/dev/null npm run build`
- `env -u npm_config_allow_scripts npm_config_userconfig=/dev/null npm test -- --runInBand`