### PR TITLE
Protect critical coverage thresholds

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -23,6 +23,48 @@ module.exports = {
       functions: 100,
       lines: 100,
     },
+    './src/core/**/*.ts': {
+      statements: 80,
+      branches: 72,
+      functions: 78,
+      lines: 80,
+    },
+    './src/mcp/**/*.ts': {
+      statements: 96,
+      branches: 79,
+      functions: 100,
+      lines: 96,
+    },
+    './src/agents/AiderAgent.ts': {
+      statements: 97,
+      branches: 93,
+      functions: 87,
+      lines: 97,
+    },
+    './src/agents/FirebenderAgent.ts': {
+      statements: 98,
+      branches: 92,
+      functions: 100,
+      lines: 98,
+    },
+    './src/agents/QwenCodeAgent.ts': {
+      statements: 87,
+      branches: 81,
+      functions: 77,
+      lines: 87,
+    },
+    './src/agents/RooCodeAgent.ts': {
+      statements: 100,
+      branches: 100,
+      functions: 100,
+      lines: 100,
+    },
+    './src/agents/ZedAgent.ts': {
+      statements: 97,
+      branches: 84,
+      functions: 100,
+      lines: 97,
+    },
   },
   // Build the project once before all tests run to prevent race conditions
   globalSetup: './jest.setup.js',

--- a/tests/unit/agents/ZedAgent.test.ts
+++ b/tests/unit/agents/ZedAgent.test.ts
@@ -200,6 +200,73 @@ describe('ZedAgent', () => {
     }
   });
 
+  it('throws when existing .zed/settings.json is invalid JSON', async () => {
+    const { projectRoot } = await setupTestProject({
+      '.ruler/AGENTS.md': 'Test rules',
+    });
+
+    try {
+      const zedDir = path.join(projectRoot, '.zed');
+      await fs.mkdir(zedDir, { recursive: true });
+      const zedSettingsPath = path.join(zedDir, 'settings.json');
+      await fs.writeFile(zedSettingsPath, '{ invalid json');
+
+      const agent = new ZedAgent();
+
+      await expect(
+        agent.applyRulerConfig('Test rules content', projectRoot, {
+          mcpServers: {
+            'new-server': {
+              type: 'stdio',
+              command: 'pwd',
+            },
+          },
+        }),
+      ).rejects.toThrow(SyntaxError);
+    } finally {
+      await teardownTestProject(projectRoot);
+    }
+  });
+
+  it('leaves .zed/settings.json untouched when transformed MCP settings are unchanged', async () => {
+    const { projectRoot } = await setupTestProject({
+      '.ruler/AGENTS.md': 'Test rules',
+    });
+
+    try {
+      const zedDir = path.join(projectRoot, '.zed');
+      await fs.mkdir(zedDir, { recursive: true });
+      const zedSettingsPath = path.join(zedDir, 'settings.json');
+      const existingSettings = {
+        context_servers: {
+          'new-server': {
+            command: 'pwd',
+            source: 'custom',
+          },
+        },
+      };
+      const originalContent = JSON.stringify(existingSettings, null, 2);
+      await fs.writeFile(zedSettingsPath, originalContent);
+
+      const agent = new ZedAgent();
+      await agent.applyRulerConfig('Test rules content', projectRoot, {
+        mcpServers: {
+          'new-server': {
+            type: 'stdio',
+            command: 'pwd',
+          },
+        },
+      });
+
+      await expect(fs.readFile(zedSettingsPath, 'utf8')).resolves.toBe(
+        originalContent,
+      );
+      await expect(fs.access(`${zedSettingsPath}.bak`)).rejects.toThrow();
+    } finally {
+      await teardownTestProject(projectRoot);
+    }
+  });
+
   it('does not back up existing .zed/settings.json when backups are disabled', async () => {
     const { projectRoot } = await setupTestProject({
       '.ruler/AGENTS.md': 'Test rules',

--- a/tests/unit/core/apply-engine.test.ts
+++ b/tests/unit/core/apply-engine.test.ts
@@ -17,6 +17,8 @@ import { CopilotAgent } from '../../../src/agents/CopilotAgent';
 import { JunieAgent } from '../../../src/agents/JunieAgent';
 import { AiderAgent } from '../../../src/agents/AiderAgent';
 import { CodexCliAgent } from '../../../src/agents/CodexCliAgent';
+import { AgentsMdAgent } from '../../../src/agents/AgentsMdAgent';
+import { JulesAgent } from '../../../src/agents/JulesAgent';
 import { LoadedConfig } from '../../../src/core/ConfigLoader';
 import * as FileSystemUtils from '../../../src/core/FileSystemUtils';
 import * as Constants from '../../../src/constants';
@@ -627,6 +629,69 @@ command = "sub-cmd"
       expect(result).toContain(path.join(tmpDir, '.aider.conf.yml'));
       expect(result).not.toContain(path.join(tmpDir, '.mcp.json'));
       expect(result).not.toContain(path.join(tmpDir, '.codex', 'config.toml'));
+    });
+
+    it('skips a second shared AGENTS.md writer after the first one runs', async () => {
+      class RecordingAgentsMdAgent extends AgentsMdAgent {
+        applyCount = 0;
+
+        async applyRulerConfig(
+          rules: string,
+          projectRoot: string,
+          mcpJson: Record<string, unknown> | null,
+          agentConfig?: any,
+          backup?: boolean,
+        ): Promise<void> {
+          this.applyCount += 1;
+          await super.applyRulerConfig(
+            rules,
+            projectRoot,
+            mcpJson,
+            agentConfig,
+            backup,
+          );
+        }
+      }
+
+      class RecordingJulesAgent extends JulesAgent {
+        applyCount = 0;
+
+        async applyRulerConfig(
+          rules: string,
+          projectRoot: string,
+          mcpJson: Record<string, unknown> | null,
+          agentConfig?: any,
+          backup?: boolean,
+        ): Promise<void> {
+          this.applyCount += 1;
+          await super.applyRulerConfig(
+            rules,
+            projectRoot,
+            mcpJson,
+            agentConfig,
+            backup,
+          );
+        }
+      }
+
+      const agentsMd = new RecordingAgentsMdAgent();
+      const jules = new RecordingJulesAgent();
+
+      await applyConfigurationsToAgents(
+        [agentsMd, jules],
+        '# Test rules',
+        null,
+        { agentConfigs: {} },
+        tmpDir,
+        false,
+        false,
+        true,
+        undefined,
+        false,
+      );
+
+      expect(agentsMd.applyCount).toBe(1);
+      expect(jules.applyCount).toBe(0);
     });
 
     it('logs warning and strips MCP timeouts for agents without timeout support', async () => {

--- a/tests/unit/coverage-threshold-policy.test.ts
+++ b/tests/unit/coverage-threshold-policy.test.ts
@@ -1,0 +1,81 @@
+type CoverageMetric = 'statements' | 'branches' | 'functions' | 'lines';
+
+type CoverageThreshold = Record<CoverageMetric, number>;
+
+interface JestCoverageConfig {
+  coverageThreshold?: Record<string, Partial<CoverageThreshold>>;
+}
+
+const jestConfig = require('../../jest.config') as JestCoverageConfig;
+
+const requiredCoverageThresholds: Record<string, CoverageThreshold> = {
+  global: {
+    statements: 90,
+    branches: 80,
+    functions: 90,
+    lines: 90,
+  },
+  './src/core/**/*.ts': {
+    statements: 80,
+    branches: 72,
+    functions: 78,
+    lines: 80,
+  },
+  './src/mcp/**/*.ts': {
+    statements: 96,
+    branches: 79,
+    functions: 100,
+    lines: 96,
+  },
+  './src/agents/AiderAgent.ts': {
+    statements: 97,
+    branches: 93,
+    functions: 87,
+    lines: 97,
+  },
+  './src/agents/FirebenderAgent.ts': {
+    statements: 98,
+    branches: 92,
+    functions: 100,
+    lines: 98,
+  },
+  './src/agents/QwenCodeAgent.ts': {
+    statements: 87,
+    branches: 81,
+    functions: 77,
+    lines: 87,
+  },
+  './src/agents/RooCodeAgent.ts': {
+    statements: 100,
+    branches: 100,
+    functions: 100,
+    lines: 100,
+  },
+  './src/agents/ZedAgent.ts': {
+    statements: 97,
+    branches: 84,
+    functions: 100,
+    lines: 97,
+  },
+};
+
+describe('coverage threshold policy', () => {
+  it('keeps critical source areas protected by scoped thresholds', () => {
+    const configuredThresholds = jestConfig.coverageThreshold ?? {};
+
+    for (const [scope, minimums] of Object.entries(
+      requiredCoverageThresholds,
+    )) {
+      const configuredMinimums = configuredThresholds[scope] ?? {};
+
+      for (const [metric, expectedMinimum] of Object.entries(minimums) as [
+        CoverageMetric,
+        number,
+      ][]) {
+        expect(configuredMinimums[metric]).toBeGreaterThanOrEqual(
+          expectedMinimum,
+        );
+      }
+    }
+  });
+});

--- a/tests/unit/lib-diagnostics.test.ts
+++ b/tests/unit/lib-diagnostics.test.ts
@@ -1,0 +1,58 @@
+import { applyAllAgentConfigs } from '../../src/lib';
+import * as ApplyEngine from '../../src/core/apply-engine';
+import * as Constants from '../../src/constants';
+
+describe('applyAllAgentConfigs diagnostics', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('emits formatted non-deprecation diagnostics once', async () => {
+    jest.spyOn(ApplyEngine, 'loadSingleConfiguration').mockResolvedValue({
+      config: {
+        agentConfigs: {},
+        defaultAgents: ['claude'],
+      },
+      concatenatedRules: '# Rules',
+      rulerMcpJson: null,
+      projectRoot: '/tmp/project',
+      diagnostics: [
+        {
+          severity: 'error',
+          code: 'TEST_DIAGNOSTIC',
+          message: 'Broken config',
+          file: '/tmp/ruler.toml',
+          detail: 'bad syntax',
+        },
+        {
+          severity: 'error',
+          code: 'TEST_DIAGNOSTIC',
+          message: 'Broken config',
+          file: '/tmp/ruler.toml',
+          detail: 'bad syntax',
+        },
+        {
+          severity: 'warning',
+          code: 'MCP_JSON_DEPRECATED',
+          message: 'Legacy MCP JSON',
+        },
+      ],
+    });
+    jest.spyOn(ApplyEngine, 'processSingleConfiguration').mockResolvedValue([]);
+    jest.spyOn(ApplyEngine, 'updateGitignore').mockResolvedValue();
+    const logErrorSpy = jest.spyOn(Constants, 'logError').mockImplementation();
+    const logWarnSpy = jest.spyOn(Constants, 'logWarn').mockImplementation();
+
+    await applyAllAgentConfigs('/tmp/project', ['claude']);
+
+    expect(logErrorSpy).toHaveBeenCalledTimes(1);
+    expect(logErrorSpy).toHaveBeenCalledWith(
+      'Configuration error [TEST_DIAGNOSTIC]: Broken config (File: /tmp/ruler.toml, Detail: bad syntax)',
+      false,
+    );
+    expect(logWarnSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('MCP_JSON_DEPRECATED'),
+      expect.any(Boolean),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add scoped Jest coverage thresholds for critical core and MCP source areas
- add per-file thresholds for key agent writer modules
- add a unit guard so the threshold policy cannot be silently weakened

Fixes #709

## Verification
- env -u npm_config_allow_scripts npm_config_userconfig=/dev/null npm ci
- env -u npm_config_allow_scripts npm_config_userconfig=/dev/null npx jest tests/unit/coverage-threshold-policy.test.ts --runInBand --coverage=false (failed before config change, then passed)
- env -u npm_config_allow_scripts npm_config_userconfig=/dev/null npm run format
- env -u npm_config_allow_scripts npm_config_userconfig=/dev/null npm run format:check
- env -u npm_config_allow_scripts npm_config_userconfig=/dev/null npm run lint
- env -u npm_config_allow_scripts npm_config_userconfig=/dev/null npm test
- env -u npm_config_allow_scripts npm_config_userconfig=/dev/null npm run build