### PR TITLE
Surface apply MCP diagnostics

### DIFF
--- a/src/core/ConfigLoader.ts
+++ b/src/core/ConfigLoader.ts
@@ -14,6 +14,7 @@ import {
 } from '../types';
 import { createRulerError, logWarn } from '../constants';
 import { isSafeRulerDirectory, pathExists } from './FileSystemUtils';
+import type { ConfigDiagnostic } from './UnifiedConfigTypes';
 
 // One-shot guard so the deprecation message fires once per process even when
 // `loadConfig` is called multiple times (e.g. nested mode walks every
@@ -165,36 +166,104 @@ export interface IAgentConfig {
 
 function parseAgentMcpServers(
   sectionObj: Record<string, unknown>,
-): Record<string, Record<string, unknown>> | undefined {
+  agentName: string,
+  configFile: string | undefined,
+): {
+  servers?: Record<string, Record<string, unknown>>;
+  diagnostics: ConfigDiagnostic[];
+} {
   if (
     !sectionObj.mcp_servers ||
     typeof sectionObj.mcp_servers !== 'object' ||
     Array.isArray(sectionObj.mcp_servers)
   ) {
-    return undefined;
+    return { diagnostics: [] };
   }
 
   const servers: Record<string, Record<string, unknown>> = {};
+  const diagnostics: ConfigDiagnostic[] = [];
   for (const [name, def] of Object.entries(
     sectionObj.mcp_servers as Record<string, unknown>,
   )) {
     if (def && typeof def === 'object' && !Array.isArray(def)) {
-      const server = normalizeAgentMcpServer(def as Record<string, unknown>);
-      if (server.command || server.url) {
+      const { server, diagnostics: serverDiagnostics } =
+        normalizeAgentMcpServer(
+          def as Record<string, unknown>,
+          name,
+          agentName,
+          configFile,
+        );
+      diagnostics.push(...serverDiagnostics);
+      if (server && (server.command || server.url)) {
         servers[name] = server;
       }
     }
   }
 
-  return Object.keys(servers).length > 0 ? servers : undefined;
+  return {
+    servers: Object.keys(servers).length > 0 ? servers : undefined,
+    diagnostics,
+  };
 }
 
 function normalizeAgentMcpServer(
   def: Record<string, unknown>,
-): Record<string, unknown> {
+  serverName: string,
+  agentName: string,
+  configFile: string | undefined,
+): {
+  server?: Record<string, unknown>;
+  diagnostics: ConfigDiagnostic[];
+} {
   const server = { ...def };
   const hasCommand = typeof server.command === 'string';
   const hasUrl = typeof server.url === 'string';
+  const hasCommandField = Object.prototype.hasOwnProperty.call(
+    server,
+    'command',
+  );
+  const hasUrlField = Object.prototype.hasOwnProperty.call(server, 'url');
+  const diagnostics: ConfigDiagnostic[] = [];
+
+  if (!hasCommand && !hasUrl) {
+    diagnostics.push({
+      severity: 'warning',
+      code: 'MCP_AGENT_INVALID_SERVER',
+      message:
+        hasCommandField || hasUrlField
+          ? `MCP server '${serverName}' for agent '${agentName}' must have a string command or url`
+          : `MCP server '${serverName}' for agent '${agentName}' must have at least one of command or url`,
+      file: configFile,
+    });
+    return { diagnostics };
+  }
+
+  if (hasCommand && hasUrl) {
+    diagnostics.push({
+      severity: 'warning',
+      code: 'MCP_AGENT_FIELD_CONFLICT',
+      message: `MCP server '${serverName}' for agent '${agentName}' has both command and url - using url (remote)`,
+      file: configFile,
+    });
+  }
+
+  if (hasCommand && server.headers && typeof server.headers === 'object') {
+    diagnostics.push({
+      severity: 'warning',
+      code: 'MCP_AGENT_FIELD_CONFLICT',
+      message: `MCP server '${serverName}' for agent '${agentName}' has headers with command (should be used with url only)`,
+      file: configFile,
+    });
+  }
+
+  if (hasUrl && server.env && typeof server.env === 'object') {
+    diagnostics.push({
+      severity: 'warning',
+      code: 'MCP_AGENT_FIELD_CONFLICT',
+      message: `MCP server '${serverName}' for agent '${agentName}' has env with url (should be used with command only)`,
+      file: configFile,
+    });
+  }
 
   if (!hasCommand) {
     delete server.command;
@@ -220,7 +289,7 @@ function normalizeAgentMcpServer(
     server.type = 'stdio';
   }
 
-  return server;
+  return { server, diagnostics };
 }
 
 /**
@@ -247,6 +316,8 @@ export interface LoadedConfig {
   nested?: boolean;
   /** Whether the nested option was explicitly provided in the config. */
   nestedDefined?: boolean;
+  /** Non-fatal diagnostics collected while parsing configuration. */
+  diagnostics?: ConfigDiagnostic[];
 }
 
 /**
@@ -293,6 +364,7 @@ export async function loadConfig(
       ? (raw.agents as Record<string, unknown>)
       : {};
   const agentConfigs: Record<string, IAgentConfig> = {};
+  const diagnostics: ConfigDiagnostic[] = [];
   for (const [name, section] of Object.entries(agentsSection)) {
     // Reserved subagent-control keys live alongside per-agent records in
     // the same `[agents]` table; skip them here so we only process actual
@@ -343,7 +415,9 @@ export async function loadConfig(
         }
         cfg.mcp = mcpCfg;
       }
-      cfg.mcpServers = parseAgentMcpServers(sectionObj);
+      const agentMcp = parseAgentMcpServers(sectionObj, name, configFile);
+      cfg.mcpServers = agentMcp.servers;
+      diagnostics.push(...agentMcp.diagnostics);
       agentConfigs[name] = cfg;
     }
   }
@@ -453,6 +527,7 @@ export async function loadConfig(
     subagents: subagentsConfig,
     nested,
     nestedDefined,
+    diagnostics,
   };
 }
 

--- a/src/core/apply-engine.ts
+++ b/src/core/apply-engine.ts
@@ -31,6 +31,7 @@ import {
   logWarn,
 } from '../constants';
 import { McpStrategy } from '../types';
+import type { ConfigDiagnostic } from './UnifiedConfigTypes';
 
 /**
  * Configuration data loaded from the ruler setup
@@ -40,6 +41,7 @@ export interface RulerConfiguration {
   concatenatedRules: string;
   rulerMcpJson: Record<string, unknown> | null;
   projectRoot: string;
+  diagnostics?: ConfigDiagnostic[];
 }
 
 /**
@@ -175,6 +177,7 @@ async function createHierarchicalConfiguration(
     concatenatedRules,
     rulerMcpJson,
     projectRoot: directoryRoot,
+    diagnostics: collectConfigDiagnostics(config, unifiedConfig.diagnostics),
   };
 }
 
@@ -244,7 +247,15 @@ function cloneLoadedConfig(config: LoadedConfig): LoadedConfig {
     subagents: config.subagents ? { ...config.subagents } : undefined,
     nested: config.nested,
     nestedDefined: config.nestedDefined,
+    diagnostics: config.diagnostics ? [...config.diagnostics] : undefined,
   };
+}
+
+function collectConfigDiagnostics(
+  config: LoadedConfig,
+  diagnostics: ConfigDiagnostic[],
+): ConfigDiagnostic[] {
+  return [...(config.diagnostics ?? []), ...diagnostics];
 }
 
 /**
@@ -360,6 +371,7 @@ async function loadSingleConfiguration(
     concatenatedRules,
     rulerMcpJson,
     projectRoot: effectiveProjectRoot,
+    diagnostics: collectConfigDiagnostics(config, unifiedConfig.diagnostics),
   };
 }
 

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import { IAgent, IAgentConfig } from './agents/IAgent';
 import { allAgents } from './agents';
 import { McpStrategy } from './types';
-import { logVerbose, logWarn } from './constants';
+import { logError, logVerbose, logWarn } from './constants';
 import {
   loadSingleConfiguration,
   processHierarchicalConfigurations,
@@ -10,8 +10,10 @@ import {
   updateGitignore,
   loadNestedConfigurations,
   HierarchicalRulerConfiguration,
+  RulerConfiguration,
 } from './core/apply-engine';
 import { type LoadedConfig } from './core/ConfigLoader';
+import type { ConfigDiagnostic } from './core/UnifiedConfigTypes';
 import { mapRawAgentConfigs } from './core/config-utils';
 import { resolveSelectedAgents } from './core/agent-selection';
 
@@ -75,6 +77,48 @@ function resolveSubagentsCleanupOrphaned(
   return configSetting === true;
 }
 
+function emitConfigDiagnostics(
+  configurations: Array<Pick<RulerConfiguration, 'diagnostics'>>,
+  dryRun: boolean,
+): void {
+  const emitted = new Set<string>();
+
+  for (const configuration of configurations) {
+    for (const diagnostic of configuration.diagnostics ?? []) {
+      if (diagnostic.code === 'MCP_JSON_DEPRECATED') {
+        continue;
+      }
+
+      const key = JSON.stringify({
+        code: diagnostic.code,
+        message: diagnostic.message,
+        file: diagnostic.file,
+        detail: diagnostic.detail,
+      });
+      if (emitted.has(key)) {
+        continue;
+      }
+      emitted.add(key);
+
+      const message = formatConfigDiagnostic(diagnostic);
+      if (diagnostic.severity === 'error') {
+        logError(message, dryRun);
+      } else {
+        logWarn(message, dryRun);
+      }
+    }
+  }
+}
+
+function formatConfigDiagnostic(diagnostic: ConfigDiagnostic): string {
+  const details = [
+    diagnostic.file ? `File: ${diagnostic.file}` : undefined,
+    diagnostic.detail ? `Detail: ${diagnostic.detail}` : undefined,
+  ].filter(Boolean);
+  const suffix = details.length > 0 ? ` (${details.join(', ')})` : '';
+  return `Configuration ${diagnostic.severity} [${diagnostic.code}]: ${diagnostic.message}${suffix}`;
+}
+
 /**
  * Applies ruler configurations for all supported AI agents.
  * @param projectRoot Root directory of the project
@@ -129,6 +173,8 @@ export async function applyAllAgentConfigs(
     if (hierarchicalConfigs.length === 0) {
       throw new Error('No .ruler directories found');
     }
+
+    emitConfigDiagnostics(hierarchicalConfigs, dryRun);
 
     logWarn(
       'Nested mode is experimental and may change in future releases.',
@@ -236,6 +282,8 @@ export async function applyAllAgentConfigs(
     );
     const singleProjectRoot = singleConfig.projectRoot;
     outputProjectRoot = singleProjectRoot;
+
+    emitConfigDiagnostics([singleConfig], dryRun);
 
     loadedConfig = singleConfig.config;
     gitignoreConfigurations.push({

--- a/tests/apply-mcp-diagnostics.test.ts
+++ b/tests/apply-mcp-diagnostics.test.ts
@@ -1,0 +1,87 @@
+import { setupTestProject, teardownTestProject, runRulerAll } from './harness';
+
+describe('apply MCP diagnostics', () => {
+  let testProject: { projectRoot: string } | undefined;
+
+  afterEach(async () => {
+    if (testProject) {
+      await teardownTestProject(testProject.projectRoot);
+      testProject = undefined;
+    }
+  });
+
+  it('prints unified MCP diagnostics while applying', async () => {
+    testProject = await setupTestProject({
+      '.ruler/AGENTS.md': '# Rules',
+      '.ruler/ruler.toml': `[mcp]
+enabled = true
+
+[mcp_servers.bad_toml]
+args = ["missing-command"]
+`,
+      '.ruler/mcp.json': JSON.stringify({
+        mcpServers: {
+          bad_json: {
+            args: ['missing-command'],
+          },
+        },
+      }),
+    });
+
+    const output = runRulerAll(
+      'apply --agents claude',
+      testProject.projectRoot,
+    );
+
+    expect(output).toContain('MCP_TOML_INVALID_SERVER');
+    expect(output).toContain(
+      "MCP server 'bad_toml' must have at least one of command or url",
+    );
+    expect(output).toContain('MCP_JSON_INVALID_SERVER');
+    expect(output).toContain(
+      "MCP server 'bad_json' must have at least one of command or url",
+    );
+    expect(
+      output.match(/\[ruler\] Warning: Using legacy \.ruler\/mcp\.json/g),
+    ).toHaveLength(1);
+  });
+
+  it('prints agent-scoped MCP diagnostics while applying', async () => {
+    testProject = await setupTestProject({
+      '.ruler/AGENTS.md': '# Rules',
+      '.ruler/ruler.toml': `default_agents = ["cursor"]
+
+[agents.cursor.mcp_servers.bad_command]
+command = 123
+
+[agents.cursor.mcp_servers.command_with_headers]
+command = "node"
+headers = { Authorization = "Bearer token" }
+
+[agents.cursor.mcp_servers.url_with_env]
+url = "https://example.com/mcp"
+env = { API_KEY = "secret" }
+
+[agents.cursor.mcp_servers.missing_target]
+args = ["missing-command"]
+`,
+    });
+
+    const output = runRulerAll('apply', testProject.projectRoot);
+
+    expect(output).toContain('MCP_AGENT_INVALID_SERVER');
+    expect(output).toContain(
+      "MCP server 'bad_command' for agent 'cursor' must have a string command or url",
+    );
+    expect(output).toContain(
+      "MCP server 'missing_target' for agent 'cursor' must have at least one of command or url",
+    );
+    expect(output).toContain('MCP_AGENT_FIELD_CONFLICT');
+    expect(output).toContain(
+      "MCP server 'command_with_headers' for agent 'cursor' has headers with command",
+    );
+    expect(output).toContain(
+      "MCP server 'url_with_env' for agent 'cursor' has env with url",
+    );
+  });
+});


### PR DESCRIPTION
Fixes #717

## Summary
- print non-deprecation unified config diagnostics during apply
- collect warnings for invalid agent-scoped MCP server definitions instead of silently dropping them
- add apply-level coverage for unified and agent-scoped MCP diagnostic output

## Testing
- env -u npm_config_allow_scripts npm_config_userconfig=/dev/null npm run format
- env -u npm_config_allow_scripts npm_config_userconfig=/dev/null npm run format:check
- env -u npm_config_allow_scripts npm_config_userconfig=/dev/null npm run lint
- env -u npm_config_allow_scripts npm_config_userconfig=/dev/null npx jest --runTestsByPath tests/apply-mcp-diagnostics.test.ts tests/mcp-warning-deduplication.test.ts tests/cli-mcp-legacy-warning.test.ts tests/mcp-invalid-fields.test.ts tests/unit/core/ConfigLoader.test.ts tests/unit/core/apply-engine.test.ts tests/unit/core/unified-config-loader.test.ts --runInBand --coverage=false
- env -u npm_config_allow_scripts npm_config_userconfig=/dev/null npm run build
- env -u npm_config_allow_scripts npm_config_userconfig=/dev/null npm test