### PR TITLE
Guard CLI tests against missing build output

### DIFF
--- a/tests/harness.ts
+++ b/tests/harness.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'fs';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import os from 'os';
@@ -50,7 +51,7 @@ export async function teardownTestProject(projectRoot: string): Promise<void> {
  * @returns Standard output from the command
  */
 export function runRuler(command: string, projectRoot: string): string {
-  const fullCommand = `node dist/cli/index.js ${command} --project-root ${projectRoot}`;
+  const fullCommand = `node ${getBuiltCliPath()} ${command} --project-root ${projectRoot}`;
   return execSync(fullCommand, {
     stdio: 'pipe',
     encoding: 'utf8',
@@ -63,7 +64,7 @@ export function runRuler(command: string, projectRoot: string): string {
 export function runRulerAll(command: string, projectRoot: string): string {
   // NOTE: execSync only returns stdout. console.warn writes to stderr.
   // We redirect stderr (2) to stdout (1) so legacy warnings emitted via console.warn are captured.
-  const fullCommand = `node dist/cli/index.js ${command} --project-root ${projectRoot} 2>&1`;
+  const fullCommand = `node ${getBuiltCliPath()} ${command} --project-root ${projectRoot} 2>&1`;
   return execSync(fullCommand, {
     stdio: ['pipe', 'pipe', 'pipe'],
     encoding: 'utf8',
@@ -79,6 +80,16 @@ export function runRulerWithInheritedStdio(
   command: string,
   projectRoot: string,
 ): void {
-  const fullCommand = `node dist/cli/index.js ${command} --project-root ${projectRoot}`;
+  const fullCommand = `node ${getBuiltCliPath()} ${command} --project-root ${projectRoot}`;
   execSync(fullCommand, { stdio: 'inherit' });
+}
+
+function getBuiltCliPath(): string {
+  const cliPath = path.resolve('dist/cli/index.js');
+  if (!existsSync(cliPath)) {
+    throw new Error(
+      `Built Ruler CLI not found at ${cliPath}. Run npm run build, or use Jest's global setup, before running CLI integration helpers.`,
+    );
+  }
+  return JSON.stringify(cliPath);
 }

--- a/tests/mcp-invalid-fields.test.ts
+++ b/tests/mcp-invalid-fields.test.ts
@@ -1,6 +1,5 @@
-import * as fs from 'fs/promises';
-import * as path from 'path';
 import { setupTestProject, teardownTestProject } from './harness';
+import { loadUnifiedConfig } from '../src/core/UnifiedConfigLoader';
 
 describe('mcp-invalid-fields', () => {
   let testProject: { projectRoot: string };
@@ -25,15 +24,14 @@ url = "https://example.com"
     });
 
     const { projectRoot } = testProject;
-    const { loadUnifiedConfig } = require('../dist/core/UnifiedConfigLoader');
     const config = await loadUnifiedConfig({ projectRoot });
 
     const fieldConflictError = config.diagnostics.find(
       (d: any) => d.code === 'MCP_TOML_FIELD_CONFLICT',
     );
     expect(fieldConflictError).toBeTruthy();
-    expect(fieldConflictError.severity).toBe('warning');
-    expect(fieldConflictError.message).toContain('both command and url');
+    expect(fieldConflictError!.severity).toBe('warning');
+    expect(fieldConflictError!.message).toContain('both command and url');
   });
 
   it('handles headers with command (validation error)', async () => {
@@ -50,15 +48,14 @@ headers = { Authorization = "Bearer token" }
     });
 
     const { projectRoot } = testProject;
-    const { loadUnifiedConfig } = require('../dist/core/UnifiedConfigLoader');
     const config = await loadUnifiedConfig({ projectRoot });
 
     const fieldConflictError = config.diagnostics.find(
       (d: any) => d.code === 'MCP_TOML_FIELD_CONFLICT',
     );
     expect(fieldConflictError).toBeTruthy();
-    expect(fieldConflictError.severity).toBe('warning');
-    expect(fieldConflictError.message).toContain('headers');
+    expect(fieldConflictError!.severity).toBe('warning');
+    expect(fieldConflictError!.message).toContain('headers');
   });
 
   it('handles env with url (validation error)', async () => {
@@ -75,15 +72,14 @@ env = { API_KEY = "secret" }
     });
 
     const { projectRoot } = testProject;
-    const { loadUnifiedConfig } = require('../dist/core/UnifiedConfigLoader');
     const config = await loadUnifiedConfig({ projectRoot });
 
     const fieldConflictError = config.diagnostics.find(
       (d: any) => d.code === 'MCP_TOML_FIELD_CONFLICT',
     );
     expect(fieldConflictError).toBeTruthy();
-    expect(fieldConflictError.severity).toBe('warning');
-    expect(fieldConflictError.message).toContain('env');
+    expect(fieldConflictError!.severity).toBe('warning');
+    expect(fieldConflictError!.message).toContain('env');
   });
 
   it('handles server with neither command nor url', async () => {
@@ -99,15 +95,14 @@ args = ["some", "args"]
     });
 
     const { projectRoot } = testProject;
-    const { loadUnifiedConfig } = require('../dist/core/UnifiedConfigLoader');
     const config = await loadUnifiedConfig({ projectRoot });
 
     const invalidServerError = config.diagnostics.find(
       (d: any) => d.code === 'MCP_TOML_INVALID_SERVER',
     );
     expect(invalidServerError).toBeTruthy();
-    expect(invalidServerError.severity).toBe('warning');
-    expect(invalidServerError.message).toContain(
+    expect(invalidServerError!.severity).toBe('warning');
+    expect(invalidServerError!.message).toContain(
       'must have at least one of command or url',
     );
   });
@@ -129,16 +124,15 @@ args = ["some", "args"]
     });
 
     const { projectRoot } = testProject;
-    const { loadUnifiedConfig } = require('../dist/core/UnifiedConfigLoader');
     const config = await loadUnifiedConfig({ projectRoot });
 
     const fieldConflictError = config.diagnostics.find(
       (d: any) => d.code === 'MCP_JSON_FIELD_CONFLICT',
     );
     expect(fieldConflictError).toBeTruthy();
-    expect(fieldConflictError.severity).toBe('warning');
-    expect(fieldConflictError.message).toContain('both command and url');
-    expect(config.mcp.servers.invalid).toEqual({
+    expect(fieldConflictError!.severity).toBe('warning');
+    expect(fieldConflictError!.message).toContain('both command and url');
+    expect(config.mcp!.servers.invalid).toEqual({
       url: 'https://example.com',
       type: 'remote',
     });
@@ -160,17 +154,16 @@ args = ["some", "args"]
     });
 
     const { projectRoot } = testProject;
-    const { loadUnifiedConfig } = require('../dist/core/UnifiedConfigLoader');
     const config = await loadUnifiedConfig({ projectRoot });
 
     const invalidServerError = config.diagnostics.find(
       (d: any) => d.code === 'MCP_JSON_INVALID_SERVER',
     );
     expect(invalidServerError).toBeTruthy();
-    expect(invalidServerError.severity).toBe('warning');
-    expect(invalidServerError.message).toContain(
+    expect(invalidServerError!.severity).toBe('warning');
+    expect(invalidServerError!.message).toContain(
       'must have at least one of command or url',
     );
-    expect(config.mcp.servers).toEqual({});
+    expect(config.mcp!.servers).toEqual({});
   });
 });

--- a/tests/unified-config.mcp-json-invalid-warning.test.ts
+++ b/tests/unified-config.mcp-json-invalid-warning.test.ts
@@ -1,4 +1,5 @@
 import { setupTestProject, teardownTestProject } from './harness';
+import { loadUnifiedConfig } from '../src/core/UnifiedConfigLoader';
 
 /**
  * Ensures diagnostic still appears for legacy mcp.json even if file contains invalid JSON.
@@ -19,14 +20,13 @@ describe('legacy mcp.json invalid still warns', () => {
 
   it('creates diagnostic even with invalid JSON', async () => {
     const { projectRoot } = testProject;
-    const { loadUnifiedConfig } = require('../dist/core/UnifiedConfigLoader');
     const config = await loadUnifiedConfig({ projectRoot });
 
     const deprecationDiagnostic = config.diagnostics.find(
       (d: any) => d.code === 'MCP_JSON_DEPRECATED',
     );
     expect(deprecationDiagnostic).toBeTruthy();
-    expect(deprecationDiagnostic.severity).toBe('warning');
-    expect(deprecationDiagnostic.message).toContain('mcp.json detected');
+    expect(deprecationDiagnostic!.severity).toBe('warning');
+    expect(deprecationDiagnostic!.message).toContain('mcp.json detected');
   });
 });

--- a/tests/unified-config.mcp-json-warning.test.ts
+++ b/tests/unified-config.mcp-json-warning.test.ts
@@ -1,5 +1,5 @@
-import * as path from 'path';
 import { setupTestProject, teardownTestProject } from './harness';
+import { loadUnifiedConfig } from '../src/core/UnifiedConfigLoader';
 
 /**
  * Verifies that using legacy .ruler/mcp.json creates a structured diagnostic warning
@@ -24,14 +24,13 @@ describe('legacy mcp.json warning', () => {
 
   it('creates structured diagnostic for legacy mcp.json', async () => {
     const { projectRoot } = testProject;
-    const { loadUnifiedConfig } = require('../dist/core/UnifiedConfigLoader');
     const config = await loadUnifiedConfig({ projectRoot });
 
     const deprecationDiagnostic = config.diagnostics.find(
       (d: any) => d.code === 'MCP_JSON_DEPRECATED',
     );
     expect(deprecationDiagnostic).toBeTruthy();
-    expect(deprecationDiagnostic.severity).toBe('warning');
-    expect(deprecationDiagnostic.message).toContain('mcp.json detected');
+    expect(deprecationDiagnostic!.severity).toBe('warning');
+    expect(deprecationDiagnostic!.message).toContain('mcp.json detected');
   });
 });

--- a/tests/unified-config.mcp-toml-load.test.ts
+++ b/tests/unified-config.mcp-toml-load.test.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { setupTestProject, teardownTestProject, runRuler } from './harness';
+import { loadUnifiedConfig } from '../src/core/UnifiedConfigLoader';
 
 describe('unified-config.mcp-toml-load', () => {
   let testProject: { projectRoot: string };
@@ -44,15 +45,12 @@ timeout = 15
   it('loads unified config with merged TOML and JSON MCP servers', async () => {
     const { projectRoot } = testProject;
 
-    // Import the loadUnifiedConfig function
-    const { loadUnifiedConfig } = require('../dist/core/UnifiedConfigLoader');
-
     const config = await loadUnifiedConfig({ projectRoot });
 
     // Should have merged servers from both TOML and JSON
     expect(config.mcp).toBeTruthy();
-    expect(config.mcp.servers).toHaveProperty('filesystem');
-    expect(config.mcp.servers.filesystem).toEqual({
+    expect(config.mcp!.servers).toHaveProperty('filesystem');
+    expect(config.mcp!.servers.filesystem).toEqual({
       type: 'stdio',
       command: 'npx',
       args: [
@@ -63,16 +61,16 @@ timeout = 15
       timeout: 30,
     });
 
-    expect(config.mcp.servers).toHaveProperty('remote_api');
-    expect(config.mcp.servers.remote_api).toEqual({
+    expect(config.mcp!.servers).toHaveProperty('remote_api');
+    expect(config.mcp!.servers.remote_api).toEqual({
       type: 'remote',
       url: 'https://api.example.com',
       headers: { Authorization: 'Bearer secret' },
       timeout: 15,
     });
 
-    expect(config.mcp.servers).toHaveProperty('git');
-    expect(config.mcp.servers.git).toEqual({
+    expect(config.mcp!.servers).toHaveProperty('git');
+    expect(config.mcp!.servers.git).toEqual({
       type: 'stdio',
       command: 'uvx',
       args: ['mcp-git'],
@@ -83,14 +81,13 @@ timeout = 15
   it('includes deprecation warning when mcp.json exists', async () => {
     const { projectRoot } = testProject;
 
-    const { loadUnifiedConfig } = require('../dist/core/UnifiedConfigLoader');
     const config = await loadUnifiedConfig({ projectRoot });
 
     const deprecationWarning = config.diagnostics.find(
       (d: any) => d.code === 'MCP_JSON_DEPRECATED',
     );
     expect(deprecationWarning).toBeTruthy();
-    expect(deprecationWarning.severity).toBe('warning');
-    expect(deprecationWarning.message).toContain('mcp.json');
+    expect(deprecationWarning!.severity).toBe('warning');
+    expect(deprecationWarning!.message).toContain('mcp.json');
   });
 });


### PR DESCRIPTION
## Summary
- import unified config tests from TypeScript source instead of mutable dist output
- add an explicit shared CLI helper guard when built dist/cli/index.js is missing
- keep CLI-facing integration tests build-dependent, but fail with a clear setup error instead of module resolution noise

Fixes #710

## Verification
- env -u npm_config_allow_scripts npm_config_userconfig=/dev/null npm run format:check
- env -u npm_config_allow_scripts npm_config_userconfig=/dev/null npm run lint
- env -u npm_config_allow_scripts npm_config_userconfig=/dev/null npx jest tests/unified-config.mcp-json-invalid-warning.test.ts tests/unified-config.mcp-json-warning.test.ts tests/unified-config.mcp-toml-load.test.ts tests/mcp-invalid-fields.test.ts --runInBand --coverage=false
- env -u npm_config_allow_scripts npm_config_userconfig=/dev/null sh -c 'set -e; npm run format:check; npm run lint; npm test; npm run build'