### PR TITLE
Normalise MCP transport-specific fields

### DIFF
--- a/src/core/UnifiedConfigLoader.ts
+++ b/src/core/UnifiedConfigLoader.ts
@@ -43,6 +43,24 @@ function copyAdditionalMcpServerFields(
   );
 }
 
+function normalizeMcpServerTransportFields(server: McpServerDef): void {
+  if (server.url) {
+    delete server.command;
+    delete server.args;
+    delete server.env;
+    server.type = 'remote';
+    return;
+  }
+
+  if (server.command) {
+    delete server.url;
+    delete server.headers;
+    delete server.auth;
+    delete server.oauth;
+    server.type = 'stdio';
+  }
+}
+
 async function resolveImplicitTomlFile(
   projectRoot: string,
   rulerDir: string | undefined,
@@ -349,18 +367,7 @@ export async function loadUnifiedConfig(
           });
         }
 
-        if (hasCommand && hasUrl) {
-          delete server.command;
-          delete server.args;
-          delete server.env;
-        }
-
-        // Derive type - remote takes precedence if both are present
-        if (server.url) {
-          server.type = 'remote';
-        } else if (server.command) {
-          server.type = 'stdio';
-        }
+        normalizeMcpServerTransportFields(server);
 
         tomlMcpServers[name] = server;
       }
@@ -512,15 +519,7 @@ export async function loadUnifiedConfig(
             });
           }
 
-          if (hasCommand && hasUrl) {
-            delete server.command;
-            delete server.args;
-            delete server.env;
-          }
-
-          // Derive type
-          if (server.url) server.type = 'remote';
-          else if (server.command) server.type = 'stdio';
+          normalizeMcpServerTransportFields(server);
           jsonMcpServers[name] = server;
         }
       }

--- a/tests/mcp-invalid-fields.test.ts
+++ b/tests/mcp-invalid-fields.test.ts
@@ -1,4 +1,6 @@
-import { setupTestProject, teardownTestProject } from './harness';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { setupTestProject, teardownTestProject, runRuler } from './harness';
 import { loadUnifiedConfig } from '../src/core/UnifiedConfigLoader';
 
 describe('mcp-invalid-fields', () => {
@@ -58,6 +60,38 @@ headers = { Authorization = "Bearer token" }
     expect(fieldConflictError!.message).toContain('headers');
   });
 
+  it('normalizes stdio servers by removing remote-only fields after diagnostics', async () => {
+    const toml = `[mcp]
+enabled = true
+
+[mcp_servers.invalid]
+command = "node"
+args = ["server.js"]
+headers = { Authorization = "Bearer token" }
+auth = { token = "remote-auth" }
+oauth = { clientId = "remote-oauth" }
+`;
+
+    testProject = await setupTestProject({
+      '.ruler/ruler.toml': toml,
+    });
+
+    const { projectRoot } = testProject;
+    const config = await loadUnifiedConfig({ projectRoot });
+
+    const fieldConflictError = config.diagnostics.find(
+      (d: any) => d.code === 'MCP_TOML_FIELD_CONFLICT',
+    );
+    expect(fieldConflictError).toBeTruthy();
+    expect(fieldConflictError!.severity).toBe('warning');
+    expect(fieldConflictError!.message).toContain('headers');
+    expect(config.mcp!.servers.invalid).toEqual({
+      command: 'node',
+      args: ['server.js'],
+      type: 'stdio',
+    });
+  });
+
   it('handles env with url (validation error)', async () => {
     const toml = `[mcp]
 enabled = true
@@ -80,6 +114,37 @@ env = { API_KEY = "secret" }
     expect(fieldConflictError).toBeTruthy();
     expect(fieldConflictError!.severity).toBe('warning');
     expect(fieldConflictError!.message).toContain('env');
+  });
+
+  it('normalizes remote servers by removing stdio-only fields after diagnostics', async () => {
+    const toml = `[mcp]
+enabled = true
+
+[mcp_servers.invalid]
+url = "https://example.com"
+args = ["server.js"]
+env = { API_KEY = "secret" }
+headers = { Authorization = "Bearer token" }
+`;
+
+    testProject = await setupTestProject({
+      '.ruler/ruler.toml': toml,
+    });
+
+    const { projectRoot } = testProject;
+    const config = await loadUnifiedConfig({ projectRoot });
+
+    const fieldConflictError = config.diagnostics.find(
+      (d: any) => d.code === 'MCP_TOML_FIELD_CONFLICT',
+    );
+    expect(fieldConflictError).toBeTruthy();
+    expect(fieldConflictError!.severity).toBe('warning');
+    expect(fieldConflictError!.message).toContain('env');
+    expect(config.mcp!.servers.invalid).toEqual({
+      url: 'https://example.com',
+      headers: { Authorization: 'Bearer token' },
+      type: 'remote',
+    });
   });
 
   it('handles server with neither command nor url', async () => {
@@ -134,6 +199,92 @@ args = ["some", "args"]
     expect(fieldConflictError!.message).toContain('both command and url');
     expect(config.mcp!.servers.invalid).toEqual({
       url: 'https://example.com',
+      type: 'remote',
+    });
+  });
+
+  it('normalizes legacy JSON servers by transport after diagnostics', async () => {
+    testProject = await setupTestProject({
+      '.ruler/mcp.json': JSON.stringify(
+        {
+          mcpServers: {
+            stdio_invalid: {
+              command: 'node',
+              args: ['server.js'],
+              headers: { Authorization: 'Bearer token' },
+              auth: { token: 'remote-auth' },
+              oauth: { clientId: 'remote-oauth' },
+            },
+            remote_invalid: {
+              url: 'https://example.com',
+              args: ['server.js'],
+              env: { API_KEY: 'secret' },
+              headers: { Authorization: 'Bearer token' },
+            },
+          },
+        },
+        null,
+        2,
+      ),
+    });
+
+    const { projectRoot } = testProject;
+    const config = await loadUnifiedConfig({ projectRoot });
+
+    expect(
+      config.diagnostics.filter(
+        (d: any) => d.code === 'MCP_JSON_FIELD_CONFLICT',
+      ),
+    ).toHaveLength(2);
+    expect(config.mcp!.servers.stdio_invalid).toEqual({
+      command: 'node',
+      args: ['server.js'],
+      type: 'stdio',
+    });
+    expect(config.mcp!.servers.remote_invalid).toEqual({
+      url: 'https://example.com',
+      headers: { Authorization: 'Bearer token' },
+      type: 'remote',
+    });
+  });
+
+  it('writes generated MCP config without transport-incompatible fields', async () => {
+    const toml = `[mcp]
+enabled = true
+
+[mcp_servers.stdio_invalid]
+command = "node"
+args = ["server.js"]
+headers = { Authorization = "Bearer token" }
+auth = { token = "remote-auth" }
+oauth = { clientId = "remote-oauth" }
+
+[mcp_servers.remote_invalid]
+url = "https://example.com"
+args = ["server.js"]
+env = { API_KEY = "secret" }
+headers = { Authorization = "Bearer token" }
+`;
+
+    testProject = await setupTestProject({
+      '.ruler/AGENTS.md': '# Rules',
+      '.ruler/ruler.toml': toml,
+    });
+
+    const { projectRoot } = testProject;
+    runRuler('apply --agents cursor --no-backup --no-gitignore', projectRoot);
+
+    const cursorMcp = JSON.parse(
+      await fs.readFile(path.join(projectRoot, '.cursor', 'mcp.json'), 'utf8'),
+    );
+    expect(cursorMcp.mcpServers.stdio_invalid).toEqual({
+      command: 'node',
+      args: ['server.js'],
+      type: 'stdio',
+    });
+    expect(cursorMcp.mcpServers.remote_invalid).toEqual({
+      url: 'https://example.com',
+      headers: { Authorization: 'Bearer token' },
       type: 'remote',
     });
   });


### PR DESCRIPTION
## Summary
- centralise MCP transport normalisation after existing diagnostics
- remove remote-only fields from stdio servers and stdio-only fields from remote servers
- cover TOML, legacy JSON, and generated Cursor MCP output regressions

Fixes #753

## Verification
- `env -u npm_config_allow_scripts -u NPM_CONFIG_ALLOW_SCRIPTS npm ci`
- `npx jest tests/mcp-invalid-fields.test.ts --runInBand`
- `npx jest tests/mcp-invalid-fields.test.ts tests/apply-mcp-diagnostics.test.ts tests/apply-mcp.toml-json-merge.test.ts tests/agent-mcp-servers.test.ts tests/remote-to-stdio-transformation.test.ts --runInBand`
- `npm run lint`
- `npm run build`
- `npm test -- --runInBand`
