### PR TITLE
Harden CLI integration test coverage

### DIFF
--- a/tests/e2e/ruler.integration.test.ts
+++ b/tests/e2e/ruler.integration.test.ts
@@ -223,8 +223,8 @@ File: extra-rules.md
     // Step 6: Inspect all generated files
     integrationLog('\n6. Inspecting and verifying all generated files...');
 
-    // List of expected generated files - comprehensive list for all agents
-    const expectedFiles = [
+    // List of expected primary generated files - comprehensive list for all agents
+    const expectedPrimaryFiles = [
       // Markdown rule files
       'AGENTS.md', // Root level concatenated file
       'CLAUDE.md', // Claude-specific file
@@ -284,16 +284,60 @@ File: extra-rules.md
       '.gitignore', // Updated gitignore
     ];
 
-    const generatedFiles: string[] = [];
+    const expectedGeneratedFiles = [
+      '.aiassistant/rules/AGENTS.md',
+      '.aider.conf.yml',
+      '.aider.conf.yml.ruler-generated',
+      '.augment/rules/ruler_augment_instructions.md',
+      '.clinerules',
+      '.codex/config.toml',
+      '.codex/config.toml.ruler-generated',
+      '.crush.json',
+      '.cursor/mcp.json',
+      '.cursor/mcp.json.ruler-generated',
+      '.gemini/settings.json',
+      '.gemini/settings.json.ruler-generated',
+      '.gitignore',
+      '.goosehints',
+      '.junie/guidelines.md',
+      '.junie/mcp/mcp.json',
+      '.junie/mcp/mcp.json.ruler-generated',
+      '.kilocode/mcp.json',
+      '.kilocode/mcp.json.ruler-generated',
+      '.mcp.json',
+      '.mcp.json.bak',
+      '.mcp.json.bak.ruler-generated',
+      '.mcp.json.ruler-generated',
+      '.openhands/microagents/repo.md',
+      '.qwen/settings.json',
+      '.qwen/settings.json.bak',
+      '.qwen/settings.json.bak.ruler-generated',
+      '.qwen/settings.json.ruler-generated',
+      '.windsurf/mcp_config.json',
+      '.windsurf/mcp_config.json.ruler-generated',
+      '.zed/settings.json',
+      'AGENTS.md',
+      'AGENTS.md.bak',
+      'AGENTS.md.bak.ruler-generated',
+      'CLAUDE.md',
+      'CRUSH.md',
+      'config.toml',
+      'config.toml.ruler-generated',
+      'opencode.json',
+      'opencode.json.ruler-generated',
+    ];
+
+    const actualGeneratedFiles = await listGeneratedProjectFiles(projectRoot);
+    expect(actualGeneratedFiles).toEqual(expectedGeneratedFiles);
+
     const fileContents: Record<string, string> = {};
 
     // Check each expected file
-    for (const expectedFile of expectedFiles) {
+    for (const expectedFile of expectedPrimaryFiles) {
       const filePath = path.join(projectRoot, expectedFile);
       const stat = await fs.stat(filePath);
       expect(stat.isFile()).toBe(true);
 
-      generatedFiles.push(expectedFile);
       const content = await fs.readFile(filePath, 'utf8');
       fileContents[expectedFile] = content;
       integrationLog(
@@ -549,14 +593,52 @@ File: extra-rules.md
     integrationLog('─'.repeat(50));
 
     // Final verification - should have generated significantly more files than the basic test
-    expect(generatedFiles).toEqual(expectedFiles);
     integrationLog(
       `\n✅ COMPREHENSIVE INTEGRATION TEST COMPLETED SUCCESSFULLY!`,
     );
-    integrationLog(`Generated ${generatedFiles.length} files total`);
+    integrationLog(`Generated ${actualGeneratedFiles.length} files total`);
     integrationLog(
-      `Files generated: ${generatedFiles.slice(0, 10).join(', ')}${generatedFiles.length > 10 ? `, and ${generatedFiles.length - 10} more...` : ''}`,
+      `Files generated: ${actualGeneratedFiles.slice(0, 10).join(', ')}${actualGeneratedFiles.length > 10 ? `, and ${actualGeneratedFiles.length - 10} more...` : ''}`,
     );
     integrationLog('='.repeat(80));
   }, 60000); // 60 second timeout for the comprehensive test
 });
+
+async function listGeneratedProjectFiles(
+  projectRoot: string,
+): Promise<string[]> {
+  const files: string[] = [];
+
+  async function walk(directory: string): Promise<void> {
+    const entries = await fs.readdir(directory, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const fullPath = path.join(directory, entry.name);
+      const relativePath = path
+        .relative(projectRoot, fullPath)
+        .split(path.sep)
+        .join('/');
+
+      if (
+        relativePath === '.ruler' ||
+        relativePath.startsWith('.ruler/') ||
+        relativePath === '.git' ||
+        relativePath.startsWith('.git/')
+      ) {
+        continue;
+      }
+
+      if (entry.isDirectory()) {
+        await walk(fullPath);
+        continue;
+      }
+
+      if (entry.isFile()) {
+        files.push(relativePath);
+      }
+    }
+  }
+
+  await walk(projectRoot);
+  return files.sort();
+}

--- a/tests/e2e/ruler.integration.test.ts
+++ b/tests/e2e/ruler.integration.test.ts
@@ -317,8 +317,6 @@ File: extra-rules.md
       '.windsurf/mcp_config.json.ruler-generated',
       '.zed/settings.json',
       'AGENTS.md',
-      'AGENTS.md.bak',
-      'AGENTS.md.bak.ruler-generated',
       'CLAUDE.md',
       'CRUSH.md',
       'config.toml',

--- a/tests/e2e/ruler.test.ts
+++ b/tests/e2e/ruler.test.ts
@@ -6,6 +6,7 @@ import { execFileSync, execSync } from 'child_process';
 import {
   setupTestProject,
   teardownTestProject,
+  runRulerArgsWithInheritedStdio,
   runRulerWithInheritedStdio,
 } from '../harness';
 
@@ -184,14 +185,14 @@ describe('End-to-End Ruler CLI', () => {
   });
 
   it('uses custom config file via --config', async () => {
-    const alt = path.join(testProject.projectRoot, 'custom.toml');
+    const alt = path.join(testProject.projectRoot, "custom config $&;'[].toml");
     const toml = `default_agents = ["Cursor"]
 [agents.Cursor]
 output_path = "custom_cursor.md"
 `;
     await fs.writeFile(alt, toml);
-    runRulerWithInheritedStdio(
-      `apply --config ${alt}`,
+    runRulerArgsWithInheritedStdio(
+      ['apply', '--config', alt],
       testProject.projectRoot,
     );
     await expect(

--- a/tests/harness.ts
+++ b/tests/harness.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'fs';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import os from 'os';
-import { execSync } from 'child_process';
+import { execFileSync, execSync, spawnSync } from 'child_process';
 
 export interface TestProject {
   projectRoot: string;
@@ -72,6 +72,67 @@ export function runRulerAll(command: string, projectRoot: string): string {
 }
 
 /**
+ * Executes a Ruler CLI command using argv arrays, avoiding shell parsing.
+ * @param args CLI arguments (e.g., ['apply', '--agents', 'copilot'])
+ * @param projectRoot Path to the test project directory
+ * @returns Standard output from the command
+ */
+export function runRulerArgs(args: string[], projectRoot: string): string {
+  return execFileSync(
+    'node',
+    [getBuiltCliFilePath(), ...args, '--project-root', projectRoot],
+    {
+      stdio: 'pipe',
+      encoding: 'utf8',
+    },
+  );
+}
+
+/**
+ * Runs the CLI with argv arrays and returns combined stdout+stderr.
+ */
+export function runRulerArgsAll(args: string[], projectRoot: string): string {
+  const result = spawnSync(
+    'node',
+    [getBuiltCliFilePath(), ...args, '--project-root', projectRoot],
+    {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      encoding: 'utf8',
+    },
+  );
+
+  const output = `${result.stdout ?? ''}${result.stderr ?? ''}`;
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (result.status !== 0) {
+    throw new Error(output);
+  }
+
+  return output;
+}
+
+/**
+ * Executes a Ruler CLI command using argv arrays with inherited stdio.
+ * @param args CLI arguments (e.g., ['apply', '--agents', 'copilot'])
+ * @param projectRoot Path to the test project directory
+ */
+export function runRulerArgsWithInheritedStdio(
+  args: string[],
+  projectRoot: string,
+): void {
+  execFileSync(
+    'node',
+    [getBuiltCliFilePath(), ...args, '--project-root', projectRoot],
+    {
+      stdio: 'inherit',
+    },
+  );
+}
+
+/**
  * Executes a Ruler CLI command against a test project with inherited stdio
  * @param command Command string (e.g., 'apply --agents copilot')
  * @param projectRoot Path to the test project directory
@@ -85,11 +146,15 @@ export function runRulerWithInheritedStdio(
 }
 
 function getBuiltCliPath(): string {
+  return JSON.stringify(getBuiltCliFilePath());
+}
+
+function getBuiltCliFilePath(): string {
   const cliPath = path.resolve('dist/cli/index.js');
   if (!existsSync(cliPath)) {
     throw new Error(
       `Built Ruler CLI not found at ${cliPath}. Run npm run build, or use Jest's global setup, before running CLI integration helpers.`,
     );
   }
-  return JSON.stringify(cliPath);
+  return cliPath;
 }

--- a/tests/integration/cli-version.test.ts
+++ b/tests/integration/cli-version.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
 
-describe('packaged CLI version', () => {
+describe('packaged CLI', () => {
   let tmpDir: string;
   let npmUserConfigPath: string;
   let tarballPath: string | undefined;
@@ -22,7 +22,7 @@ describe('packaged CLI version', () => {
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
-  it('reports the package version from a packed install', async () => {
+  it('reports the package version and runs the installed lifecycle commands', async () => {
     const originalAllowScripts = process.env.npm_config_allow_scripts;
 
     try {
@@ -59,13 +59,56 @@ describe('packaged CLI version', () => {
         env: npmEnv,
       });
 
-      const output = execFileSync(
-        path.join(tmpDir, 'node_modules', '.bin', 'ruler'),
-        ['--version'],
-        { encoding: 'utf8' },
-      ).trim();
+      const installedCliPath = path.join(
+        tmpDir,
+        'node_modules',
+        '.bin',
+        'ruler',
+      );
+      const output = execFileSync(installedCliPath, ['--version'], {
+        encoding: 'utf8',
+      }).trim();
 
       expect(output).toBe(packageJson.version);
+
+      const projectRoot = path.join(tmpDir, "project with spaces $&;'[]");
+      await fs.mkdir(projectRoot);
+
+      execFileSync(installedCliPath, ['init', '--project-root', projectRoot], {
+        encoding: 'utf8',
+      });
+
+      await expect(
+        fs.readFile(path.join(projectRoot, '.ruler', 'AGENTS.md'), 'utf8'),
+      ).resolves.toMatch(/^# AGENTS\.md/);
+
+      await fs.writeFile(
+        path.join(projectRoot, '.ruler', 'AGENTS.md'),
+        '# Packaged CLI rule\n',
+      );
+
+      execFileSync(
+        installedCliPath,
+        ['apply', '--agents', 'codex', '--project-root', projectRoot],
+        { encoding: 'utf8' },
+      );
+
+      await expect(
+        fs.readFile(path.join(projectRoot, 'AGENTS.md'), 'utf8'),
+      ).resolves.toContain('Packaged CLI rule');
+
+      execFileSync(
+        installedCliPath,
+        ['revert', '--agents', 'codex', '--project-root', projectRoot],
+        { encoding: 'utf8' },
+      );
+
+      await expect(
+        fs.stat(path.join(projectRoot, 'AGENTS.md')),
+      ).rejects.toThrow();
+      await expect(
+        fs.readFile(path.join(projectRoot, '.ruler', 'AGENTS.md'), 'utf8'),
+      ).resolves.toContain('Packaged CLI rule');
 
       const extractedCliPath = path.join(
         extractedDir,

--- a/tests/unit/harness.test.ts
+++ b/tests/unit/harness.test.ts
@@ -1,6 +1,11 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
-import { setupTestProject, teardownTestProject, runRuler } from '../harness';
+import {
+  setupTestProject,
+  teardownTestProject,
+  runRuler,
+  runRulerArgs,
+} from '../harness';
 
 describe('Test Harness', () => {
   describe('setupTestProject', () => {
@@ -141,6 +146,25 @@ describe('Test Harness', () => {
 
       expect(output).toBeDefined();
       expect(typeof output).toBe('string');
+    });
+
+    it('supports shell-sensitive project paths with argv arguments', async () => {
+      const shellSensitiveRoot = path.join(
+        path.dirname(testProject.projectRoot),
+        `ruler argv path with spaces $&;'[]-${Date.now()}`,
+      );
+      await fs.rename(testProject.projectRoot, shellSensitiveRoot);
+      testProject.projectRoot = shellSensitiveRoot;
+
+      const output = runRulerArgs(
+        ['apply', '--agents', 'codex'],
+        shellSensitiveRoot,
+      );
+
+      expect(output).toBeDefined();
+      await expect(
+        fs.readFile(path.join(shellSensitiveRoot, 'AGENTS.md'), 'utf8'),
+      ).resolves.toContain('# Test Rule');
     });
 
     it('throws on invalid commands', () => {


### PR DESCRIPTION
## Summary
- add argv-based CLI test helpers to avoid shell parsing of project paths
- cover shell-sensitive project and config paths
- extend packaged CLI coverage beyond `--version` through init, apply, and revert
- make the comprehensive e2e output inventory assert the actual generated file list

Fixes #755

## Verification
- `env -u npm_config_allow_scripts -u NPM_CONFIG_ALLOW_SCRIPTS npm ci`
- `./node_modules/.bin/jest tests/unit/harness.test.ts tests/e2e/ruler.test.ts tests/e2e/ruler.integration.test.ts tests/integration/cli-version.test.ts --runInBand --coverage=false`
- `npm run format:check`
- `git diff --check`
