### PR TITLE
Harden GitHub Actions release safety

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ jobs:
       matrix:
         node-version: ['20.19.0', '22.12.0', '24.x']
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,12 +22,13 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
           ref: ${{ github.event.release.tag_name || inputs.release_tag || github.ref }}
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org/'

--- a/.github/workflows/ruler.yml
+++ b/.github/workflows/ruler.yml
@@ -17,12 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 'lts/*'
           check-latest: true

--- a/.github/workflows/this-codebase-smells.yml
+++ b/.github/workflows/this-codebase-smells.yml
@@ -33,12 +33,12 @@ jobs:
             echo "Not 16:00 Europe/Zurich; skipping subsequent steps."
           fi
 
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         if: ${{ steps.gate.outputs.run != 'false' }}
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         if: ${{ steps.gate.outputs.run != 'false' }}
         with:
           node-version: '22'

--- a/.github/workflows/writeme.yml
+++ b/.github/workflows/writeme.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 

--- a/tests/unit/workflows/action-pins.test.ts
+++ b/tests/unit/workflows/action-pins.test.ts
@@ -19,10 +19,23 @@ describe('GitHub Actions pins', () => {
 
     expect(mutableActionUses).toEqual([]);
     expect(workflowText).toContain(
-      'actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0',
+      'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1',
     );
     expect(workflowText).toContain(
-      'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e',
+      'actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38',
     );
+  });
+
+  it('configures Dependabot to refresh pinned GitHub Actions', () => {
+    const dependabotPath = path.join(
+      process.cwd(),
+      '.github',
+      'dependabot.yml',
+    );
+    const dependabotConfig = fs.readFileSync(dependabotPath, 'utf8');
+
+    expect(dependabotConfig).toContain('package-ecosystem: github-actions');
+    expect(dependabotConfig).toContain('directory: /');
+    expect(dependabotConfig).toContain('interval: weekly');
   });
 });

--- a/tests/unit/workflows/release-workflow.test.ts
+++ b/tests/unit/workflows/release-workflow.test.ts
@@ -32,6 +32,18 @@ describe('release workflow', () => {
     expect(validateIndex).toBeLessThan(npmCiIndex);
   });
 
+  it('does not persist checkout credentials for release publishing', () => {
+    const workflowPath = path.join(
+      process.cwd(),
+      '.github',
+      'workflows',
+      'release.yml',
+    );
+    const workflow = fs.readFileSync(workflowPath, 'utf8');
+
+    expect(workflow).toContain('persist-credentials: false');
+  });
+
   it('fails GitHub prereleases before publishing to npm latest', () => {
     const workflowPath = path.join(
       process.cwd(),


### PR DESCRIPTION
## Summary
- refresh pinned `actions/checkout` and `actions/setup-node` SHAs to the current tagged releases
- disable persisted checkout credentials in the npm release workflow
- add Dependabot coverage for pinned GitHub Actions
- extend workflow tests for pin freshness policy and release checkout credential handling

Fixes #756

## Verification
- `env -u npm_config_allow_scripts -u NPM_CONFIG_ALLOW_SCRIPTS npm ci`
- `env -u npm_config_allow_scripts -u NPM_CONFIG_ALLOW_SCRIPTS npx jest tests/unit/workflows --runInBand`
- `env -u npm_config_allow_scripts -u NPM_CONFIG_ALLOW_SCRIPTS npm run format:check`
- `env -u npm_config_allow_scripts -u NPM_CONFIG_ALLOW_SCRIPTS npm run lint`
- `env -u npm_config_allow_scripts -u NPM_CONFIG_ALLOW_SCRIPTS npm run build`
- `env -u npm_config_allow_scripts -u NPM_CONFIG_ALLOW_SCRIPTS npm test -- --runInBand`
