### PR TITLE
Avoid recursive empty-directory cleanup during revert

### DIFF
--- a/src/core/revert-engine.ts
+++ b/src/core/revert-engine.ts
@@ -29,6 +29,7 @@ const RULER_SOURCE_MARKER_PREFIXES = [
   '<!-- Source: .ruler/',
   '<!-- Source: ruler/',
 ];
+const DIRECTORY_CLEANUP_MISS_CODES = new Set(['ENOTEMPTY', 'EEXIST', 'ENOENT']);
 
 /**
  * Result of reverting an agent configuration
@@ -368,6 +369,43 @@ async function isDirectoryTreeEmpty(dirPath: string): Promise<boolean> {
   }
 }
 
+function isDirectoryCleanupMiss(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null || !('code' in error)) {
+    return false;
+  }
+
+  const code = (error as { code?: unknown }).code;
+  return typeof code === 'string' && DIRECTORY_CLEANUP_MISS_CODES.has(code);
+}
+
+async function removeEmptyDirectoryTree(dirPath: string): Promise<boolean> {
+  const entries = await fs.readdir(dirPath);
+
+  for (const entry of entries) {
+    const entryPath = path.join(dirPath, entry);
+    const entryStat = await fs.lstat(entryPath);
+
+    if (entryStat.isFile()) {
+      return false;
+    } else if (entryStat.isDirectory()) {
+      const childRemoved = await removeEmptyDirectoryTree(entryPath);
+      if (!childRemoved) {
+        return false;
+      }
+    }
+  }
+
+  try {
+    await fs.rmdir(dirPath);
+    return true;
+  } catch (error) {
+    if (isDirectoryCleanupMiss(error)) {
+      return false;
+    }
+    throw error;
+  }
+}
+
 /**
  * Helper function to execute directory removal with consistent dry-run handling and logging.
  */
@@ -386,7 +424,10 @@ async function executeDirectoryAction(
       verbose,
     );
   } else {
-    await fs.rm(dirPath, { recursive: true });
+    const removed = await removeEmptyDirectoryTree(dirPath);
+    if (!removed) {
+      return false;
+    }
     logVerbose(`${prefix} Removed empty ${actionText}: ${dirPath}`, verbose);
   }
   return true;

--- a/tests/unit/core/revert-engine.test.ts
+++ b/tests/unit/core/revert-engine.test.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs/promises';
+import * as nodeFs from 'fs';
 import * as path from 'path';
 import os from 'os';
 
@@ -511,6 +512,72 @@ describe('revert-engine', () => {
         await fs.rm(outsideDir, { recursive: true, force: true });
       }
     });
+
+    it('should preserve files added after empty directory checks', async () => {
+      const geminiDir = path.join(tmpDir, '.gemini');
+      const lateFile = path.join(geminiDir, 'user-settings.json');
+      const actualReaddir = nodeFs.promises.readdir;
+
+      await fs.mkdir(geminiDir, { recursive: true });
+
+      const readdirSpy = jest
+        .spyOn(nodeFs.promises, 'readdir')
+        .mockImplementation(async (dirPath, options) => {
+          if (dirPath === geminiDir) {
+            await fs.writeFile(lateFile, '{"user": true}');
+            return [];
+          }
+
+          return actualReaddir(dirPath, options as never) as never;
+        });
+
+      try {
+        const result = await cleanUpAuxiliaryFiles(tmpDir, false, false);
+
+        expect(result.directoriesRemoved).toBe(0);
+        await expect(fs.readFile(lateFile, 'utf8')).resolves.toBe(
+          '{"user": true}',
+        );
+      } finally {
+        readdirSpy.mockRestore();
+      }
+    });
+
+    it.each(['ENOTEMPTY', 'EEXIST', 'ENOENT'])(
+      'should treat %s during empty directory removal as a cleanup miss',
+      async (code) => {
+        const geminiDir = path.join(tmpDir, '.gemini');
+        const actualRmdir = nodeFs.promises.rmdir;
+
+        await fs.mkdir(geminiDir, { recursive: true });
+
+        const rmdirSpy = jest
+          .spyOn(nodeFs.promises, 'rmdir')
+          .mockImplementation(async (dirPath) => {
+            if (dirPath === geminiDir) {
+              if (code === 'ENOENT') {
+                await actualRmdir(geminiDir);
+              }
+              throw Object.assign(new Error(code), { code });
+            }
+
+            return actualRmdir(dirPath);
+          });
+
+        try {
+          const result = await cleanUpAuxiliaryFiles(tmpDir, false, false);
+
+          expect(result.directoriesRemoved).toBe(0);
+          if (code === 'ENOENT') {
+            await expect(fs.access(geminiDir)).rejects.toThrow();
+          } else {
+            await expect(fs.access(geminiDir)).resolves.toBeUndefined();
+          }
+        } finally {
+          rmdirSpy.mockRestore();
+        }
+      },
+    );
   });
 
   describe('dry-run logging patterns', () => {


### PR DESCRIPTION
## Summary
- replace recursive empty-directory cleanup with bottom-up non-recursive directory removal
- treat `ENOTEMPTY`, `EEXIST`, and `ENOENT` races as cleanup misses
- add regression tests for late file creation and directory-removal race errors

Fixes #757

## Verification
- `env -u npm_config_allow_scripts -u NPM_CONFIG_ALLOW_SCRIPTS npm ci`
- `npx jest tests/unit/core/revert-engine.test.ts tests/integration/revert-agents.test.ts tests/integration/revert-cli.test.ts --runInBand`
- `npm run lint`
- `npm run build`
