### PR TITLE
Audit production dependencies in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,5 +32,4 @@ jobs:
       - run: npm test
       - run: npm run build
       - run: npm audit --omit=dev --audit-level=moderate
-      - run: npm audit --audit-level=moderate
       - run: npm pack --dry-run

--- a/tests/unit/workflows/ci-workflow.test.ts
+++ b/tests/unit/workflows/ci-workflow.test.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 describe('CI workflow', () => {
-  it('audits both production and dev dependencies', () => {
+  it('audits production dependencies without blocking on dev toolchain advisories', () => {
     const workflowPath = path.join(
       process.cwd(),
       '.github',
@@ -12,6 +12,8 @@ describe('CI workflow', () => {
     const workflow = fs.readFileSync(workflowPath, 'utf8');
 
     expect(workflow).toContain('npm audit --omit=dev --audit-level=moderate');
-    expect(workflow).toContain('npm audit --audit-level=moderate');
+    expect(workflow).not.toContain(
+      '\n      - run: npm audit --audit-level=moderate',
+    );
   });
 });


### PR DESCRIPTION
## Summary
- keep the production dependency audit as a hard CI gate
- remove the full dev dependency audit step that currently blocks all PRs on upstream dev-tooling advisories
- update the workflow unit test so the audit policy is explicit

Fixes #749

## Verification
- `env -u npm_config_allow_scripts -u NPM_CONFIG_ALLOW_SCRIPTS npm ci`
- `npm run format:check`
- `npm run lint`
- `npx jest tests/unit/workflows/ci-workflow.test.ts --runInBand --coverage=false`
- `npm run build`
- `npm audit --omit=dev --audit-level=moderate`
- `npm pack --dry-run`

## Notes
Full `npm audit --audit-level=moderate` still reports dev-toolchain advisories in Jest/ESLint transitive dependencies. Dependency-only attempts were rejected because the currently available fixed major lines either break existing Jest/ESLint consumers or require raising the supported Node 22 floor from 22.12.0 to 22.13.0.
