### PR TITLE
feat(kiro): propagate skills to .kiro/skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Ruler solves this by providing a **single source of truth** for all your AI agen
 | Zed                    | `AGENTS.md`                                    | `.zed/settings.json` (project root, never $HOME) | `.agents/skills/`         | -                            |
 | Trae AI                | `.trae/rules/project_rules.md`                 | -                                                | -                         | -                            |
 | Warp                   | `WARP.md`                                      | -                                                | -                         | -                            |
-| Kiro                   | `.kiro/steering/ruler_kiro_instructions.md`    | `.kiro/settings/mcp.json`                        | -                         | -                            |
+| Kiro                   | `.kiro/steering/ruler_kiro_instructions.md`    | `.kiro/settings/mcp.json`                        | `.kiro/skills/`           | -                            |
 | Firebender             | `firebender.json`                              | `firebender.json` (rules and MCP in same file)   | -                         | -                            |
 | Factory Droid          | `AGENTS.md`                                    | `.factory/mcp.json`                              | `.factory/skills/`        | -                            |
 | Mistral Vibe           | `AGENTS.md`                                    | `.vibe/config.toml`                              | `.vibe/skills/`           | -                            |
@@ -622,6 +622,7 @@ Skills are specialized knowledge packages that extend AI agent capabilities with
   - **Junie**: `.junie/skills/`
   - **Cursor**: `.cursor/skills/`
   - **Windsurf**: `.windsurf/skills/`
+  - **Kiro**: `.kiro/skills/`
 
 ### Skills Directory Structure
 
@@ -688,12 +689,13 @@ When skills support is enabled and gitignore integration is active, Ruler automa
 - `.junie/skills/` (for Junie)
 - `.cursor/skills/` (for Cursor)
 - `.windsurf/skills/` (for Windsurf)
+- `.kiro/skills/` (for Kiro)
 
 to your `.gitignore` file within the managed Ruler block.
 
 ### Requirements
 
-- **For agents with native skills support** (Claude Code, GitHub Copilot, Kilo Code, OpenAI Codex CLI, OpenCode, Pi Coding Agent, Goose, Amp, Zed, Antigravity, Factory Droid, Mistral Vibe, Roo Code, Gemini CLI, Junie, Cursor, Windsurf): No additional requirements.
+- **For agents with native skills support** (Claude Code, GitHub Copilot, Kilo Code, OpenAI Codex CLI, OpenCode, Pi Coding Agent, Goose, Amp, Zed, Antigravity, Factory Droid, Mistral Vibe, Roo Code, Gemini CLI, Junie, Cursor, Windsurf, Kiro): No additional requirements.
 
 ### Validation
 
@@ -748,6 +750,7 @@ ruler apply
 #    - Junie: .junie/skills/my-skill/
 #    - Cursor: .cursor/skills/my-skill/
 #    - Windsurf: .windsurf/skills/my-skill/
+#    - Kiro: .kiro/skills/my-skill/
 ```
 
 ## Subagents Support (Experimental)
@@ -1185,7 +1188,7 @@ A: Ruler writes `.zed/settings.json` inside the project root (not the user home 
 A: `ruler init` now only adds example MCP server sections to `ruler.toml` instead of creating `.ruler/mcp.json`. The JSON file is still consumed if present, but TOML servers win on name conflicts.
 
 **Q: Is Kiro supported?**
-A: Yes. Kiro receives concatenated rules at `.kiro/steering/ruler_kiro_instructions.md`.
+A: Yes. Kiro receives concatenated rules at `.kiro/steering/ruler_kiro_instructions.md`, MCP servers at `.kiro/settings/mcp.json`, and skills at `.kiro/skills/`.
 
 ## Development
 

--- a/src/agents/KiroAgent.ts
+++ b/src/agents/KiroAgent.ts
@@ -26,4 +26,8 @@ export class KiroAgent extends AbstractAgent {
   supportsMcpRemote(): boolean {
     return true;
   }
+
+  supportsNativeSkills(): boolean {
+    return true;
+  }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -68,6 +68,7 @@ export const CURSOR_SKILLS_PATH = '.cursor/skills';
 export const WINDSURF_SKILLS_PATH = '.windsurf/skills';
 export const FACTORY_SKILLS_PATH = '.factory/skills';
 export const ANTIGRAVITY_SKILLS_PATH = '.agent/skills';
+export const KIRO_SKILLS_PATH = '.kiro/skills';
 export const SKILL_MD_FILENAME = 'SKILL.md';
 
 // Subagents-related constants

--- a/src/core/SkillsProcessor.ts
+++ b/src/core/SkillsProcessor.ts
@@ -16,6 +16,7 @@ import {
   WINDSURF_SKILLS_PATH,
   FACTORY_SKILLS_PATH,
   ANTIGRAVITY_SKILLS_PATH,
+  KIRO_SKILLS_PATH,
   logWarn,
   logVerboseInfo,
 } from '../constants';
@@ -100,6 +101,7 @@ export async function getSkillsGitignorePaths(
     windsurf: WINDSURF_SKILLS_PATH,
     factory: FACTORY_SKILLS_PATH,
     antigravity: ANTIGRAVITY_SKILLS_PATH,
+    kiro: KIRO_SKILLS_PATH,
   };
 
   const managedEntries = await getSourceTopLevelEntries(skillsDir);
@@ -154,7 +156,8 @@ type SkillTarget =
   | 'cursor'
   | 'windsurf'
   | 'factory'
-  | 'antigravity';
+  | 'antigravity'
+  | 'kiro';
 
 const SKILL_TARGET_TO_IDENTIFIERS = new Map<SkillTarget, readonly string[]>([
   ['claude', ['claude', 'copilot', 'kilocode']],
@@ -170,6 +173,7 @@ const SKILL_TARGET_TO_IDENTIFIERS = new Map<SkillTarget, readonly string[]>([
   ['windsurf', ['windsurf']],
   ['factory', ['factory']],
   ['antigravity', ['antigravity']],
+  ['kiro', ['kiro']],
 ]);
 
 const SKILL_TARGET_PATHS: readonly string[] = Array.from(
@@ -187,6 +191,7 @@ const SKILL_TARGET_PATHS: readonly string[] = Array.from(
     WINDSURF_SKILLS_PATH,
     FACTORY_SKILLS_PATH,
     ANTIGRAVITY_SKILLS_PATH,
+    KIRO_SKILLS_PATH,
   ]),
 );
 
@@ -691,6 +696,15 @@ export async function propagateSkills(
     await propagateSkillsForAntigravity(projectRoot, { dryRun });
   }
 
+  if (selectedTargets.has('kiro')) {
+    logVerboseInfo(
+      `Copying skills to ${KIRO_SKILLS_PATH} for Kiro`,
+      verbose,
+      dryRun,
+    );
+    await propagateSkillsForKiro(projectRoot, { dryRun });
+  }
+
   // No MCP-based propagation; only native skills are supported.
 }
 
@@ -1067,6 +1081,35 @@ export async function propagateSkillsForAntigravity(
   }
 
   await syncSkillsDirectory(skillsDir, antigravitySkillsPath, projectRoot);
+
+  return [];
+}
+
+/**
+ * Propagates skills for Kiro by copying .ruler/skills to .kiro/skills.
+ * Updates only Ruler-managed entries so existing native skills are preserved.
+ * Returns dry-run steps if dryRun is true, otherwise returns empty array.
+ */
+export async function propagateSkillsForKiro(
+  projectRoot: string,
+  options: { dryRun: boolean },
+): Promise<string[]> {
+  const skillsDir = path.join(projectRoot, RULER_SKILLS_PATH);
+  const kiroSkillsPath = path.join(projectRoot, KIRO_SKILLS_PATH);
+
+  // Check if source skills directory exists
+  try {
+    await fs.access(skillsDir);
+  } catch {
+    // No skills directory - return empty
+    return [];
+  }
+
+  if (options.dryRun) {
+    return [`Copy skills from ${RULER_SKILLS_PATH} to ${KIRO_SKILLS_PATH}`];
+  }
+
+  await syncSkillsDirectory(skillsDir, kiroSkillsPath, projectRoot);
 
   return [];
 }

--- a/tests/skills-propagation.test.ts
+++ b/tests/skills-propagation.test.ts
@@ -7,6 +7,7 @@ import {
   ANTIGRAVITY_SKILLS_PATH,
   CLAUDE_SKILLS_PATH,
   JUNIE_SKILLS_PATH,
+  KIRO_SKILLS_PATH,
   WINDSURF_SKILLS_PATH,
   SKILL_MD_FILENAME,
 } from '../src/constants';
@@ -136,6 +137,23 @@ describe('Skills Discovery and Validation', () => {
       expect(paths).toEqual([
         path.join(tmpDir, ANTIGRAVITY_SKILLS_PATH, managedManifest),
         path.join(tmpDir, ANTIGRAVITY_SKILLS_PATH, 'skill1'),
+      ]);
+    });
+
+    it('returns kiro skills path for kiro agent', async () => {
+      const { getSkillsGitignorePaths } = await import(
+        '../src/core/SkillsProcessor'
+      );
+      const { KiroAgent } = await import('../src/agents/KiroAgent');
+      const skillsDir = path.join(tmpDir, '.ruler', 'skills');
+
+      await fs.mkdir(path.join(skillsDir, 'skill1'), { recursive: true });
+
+      const paths = await getSkillsGitignorePaths(tmpDir, [new KiroAgent()]);
+
+      expect(paths).toEqual([
+        path.join(tmpDir, KIRO_SKILLS_PATH, managedManifest),
+        path.join(tmpDir, KIRO_SKILLS_PATH, 'skill1'),
       ]);
     });
 
@@ -1366,7 +1384,108 @@ describe('Skills Discovery and Validation', () => {
     });
   });
 
+  describe('propagateSkillsForKiro', () => {
+    it('copies .ruler/skills to .kiro/skills preserving structure', async () => {
+      const { propagateSkillsForKiro } = await import(
+        '../src/core/SkillsProcessor'
+      );
+      const skillsDir = path.join(tmpDir, '.ruler', 'skills');
+      const skill1 = path.join(skillsDir, 'skill1');
+
+      await fs.mkdir(skill1, { recursive: true });
+      await fs.writeFile(path.join(skill1, SKILL_MD_FILENAME), '# Skill 1');
+
+      await propagateSkillsForKiro(tmpDir, { dryRun: false });
+
+      const copiedSkill = path.join(
+        tmpDir,
+        KIRO_SKILLS_PATH,
+        'skill1',
+        SKILL_MD_FILENAME,
+      );
+      expect(await fs.readFile(copiedSkill, 'utf8')).toBe('# Skill 1');
+    });
+
+    it('preserves skills that Ruler does not manage', async () => {
+      const { propagateSkillsForKiro } = await import(
+        '../src/core/SkillsProcessor'
+      );
+      const rulerSkill = path.join(tmpDir, '.ruler', 'skills', 'ruler-skill');
+      const nativeSkill = path.join(tmpDir, KIRO_SKILLS_PATH, 'native-skill');
+
+      await fs.mkdir(rulerSkill, { recursive: true });
+      await fs.writeFile(
+        path.join(rulerSkill, SKILL_MD_FILENAME),
+        '# Ruler Skill',
+      );
+      await fs.mkdir(nativeSkill, { recursive: true });
+      await fs.writeFile(
+        path.join(nativeSkill, SKILL_MD_FILENAME),
+        '# Native Skill',
+      );
+
+      await propagateSkillsForKiro(tmpDir, { dryRun: false });
+
+      expect(
+        await fs.readFile(path.join(nativeSkill, SKILL_MD_FILENAME), 'utf8'),
+      ).toBe('# Native Skill');
+    });
+
+    it('includes operations in dry-run preview without executing', async () => {
+      const { propagateSkillsForKiro } = await import(
+        '../src/core/SkillsProcessor'
+      );
+      const skill1 = path.join(tmpDir, '.ruler', 'skills', 'skill1');
+
+      await fs.mkdir(skill1, { recursive: true });
+      await fs.writeFile(path.join(skill1, SKILL_MD_FILENAME), '# Skill 1');
+
+      const steps = await propagateSkillsForKiro(tmpDir, { dryRun: true });
+
+      expect(steps.length).toBeGreaterThan(0);
+      expect(steps.some((step) => step.includes('.kiro/skills'))).toBe(true);
+
+      // Should not have actually copied
+      await expect(
+        fs.access(path.join(tmpDir, KIRO_SKILLS_PATH)),
+      ).rejects.toThrow();
+    });
+
+    it('no-ops gracefully when .ruler/skills does not exist', async () => {
+      const { propagateSkillsForKiro } = await import(
+        '../src/core/SkillsProcessor'
+      );
+
+      const steps = await propagateSkillsForKiro(tmpDir, { dryRun: true });
+
+      expect(steps).toHaveLength(0);
+    });
+  });
+
   describe('propagateSkills - selected agents', () => {
+    it('propagates skills to .kiro/skills for Kiro only', async () => {
+      const { propagateSkills } = await import('../src/core/SkillsProcessor');
+      const { KiroAgent } = await import('../src/agents/KiroAgent');
+      const skillsDir = path.join(tmpDir, '.ruler', 'skills', 'skill1');
+
+      await fs.mkdir(skillsDir, { recursive: true });
+      await fs.writeFile(path.join(skillsDir, SKILL_MD_FILENAME), '# Skill 1');
+
+      await propagateSkills(tmpDir, [new KiroAgent()], true, false, false);
+
+      const kiroSkill = path.join(
+        tmpDir,
+        KIRO_SKILLS_PATH,
+        'skill1',
+        SKILL_MD_FILENAME,
+      );
+
+      expect(await fs.readFile(kiroSkill, 'utf8')).toBe('# Skill 1');
+      await expect(
+        fs.access(path.join(tmpDir, CLAUDE_SKILLS_PATH)),
+      ).rejects.toThrow();
+    });
+
     it('only propagates skills for selected agent destinations', async () => {
       const { propagateSkills } = await import('../src/core/SkillsProcessor');
       const { AntigravityAgent } = await import(

--- a/tests/unit/agents/KiroAgent.test.ts
+++ b/tests/unit/agents/KiroAgent.test.ts
@@ -34,6 +34,11 @@ describe('KiroAgent', () => {
     expect(agent.supportsMcpRemote()).toBe(true);
   });
 
+  it('should support native skills', () => {
+    const agent = new KiroAgent();
+    expect(agent.supportsNativeSkills()).toBe(true);
+  });
+
   it('should have the correct default output path', () => {
     const agent = new KiroAgent();
     const projectRoot = '/test/project';


### PR DESCRIPTION
## Rationale

Kiro supports native skills: it reads `.kiro/skills/<name>/SKILL.md` in the workspace (and `~/.kiro/skills/` for user-level skills), with the same directory layout and the same `name` / `description` frontmatter that Ruler already emits for Claude, Cursor, Windsurf and the other native-skill targets. See https://kiro.dev/docs/skills/.

`KiroAgent` never overrode `supportsNativeSkills()`, so it inherited `false` from `AbstractAgent`. As a result `ruler apply --agents kiro` warned that Kiro does not support native skills and skipped skill propagation entirely, even though no format conversion is needed — the files can simply be copied.

## Changes

- `src/agents/KiroAgent.ts`: override `supportsNativeSkills()` to return `true`.
- `src/constants.ts`: add `KIRO_SKILLS_PATH = '.kiro/skills'`.
- `src/core/SkillsProcessor.ts`: wire up a `kiro` skill target exactly like the existing ones —
  - add `'kiro'` to the `SkillTarget` union and to `SKILL_TARGET_TO_IDENTIFIERS`,
  - add the path to `SKILL_TARGET_PATHS` so `--no-skills` cleans it up,
  - add it to `targetPaths` so `getSkillsGitignorePaths` covers it,
  - dispatch to a new `propagateSkillsForKiro()` which uses `syncSkillsDirectory` and therefore honours the `.ruler-managed.json` manifest — hand-written skills already living in `.kiro/skills/` are preserved.
- `README.md`: fill in the Skills column for Kiro in the agent table, list `.kiro/skills/` under native skills / gitignore paths / requirements / the example workflow, and answer it in the Kiro FAQ entry.

## Tests

- `tests/unit/agents/KiroAgent.test.ts`: `supportsNativeSkills()` returns `true`.
- `tests/skills-propagation.test.ts`: new `propagateSkillsForKiro` suite covering copy-with-structure, preservation of skills Ruler does not manage, dry-run (returns a step, writes nothing), and no-op when `.ruler/skills` is absent; plus a `getSkillsGitignorePaths` assertion and a `propagateSkills` selected-agent test verifying `[new KiroAgent()]` populates `.kiro/skills/` and does not touch `.claude/skills/`.

Written test-first: the new tests fail on `main` (the propagation function does not exist and the capability flag is `false`) and pass with this change.

## Verification

Ran the CI equivalents locally, all green:

- `npm ci`
- `npm run check:package-lock`
- `npm run format:check` (and `npm run format` produced no changes)
- `npm run lint`
- `npm test` — 158 suites / 1228 tests passed, coverage thresholds met
- `npm run test:integration` — 27 suites / 139 tests passed
- `npm run build`

Also smoke-tested the built CLI in a scratch project: `apply --agents kiro --verbose` logs `[ruler] Copying skills to .kiro/skills for Kiro` (the "does not support native skills" warning is gone) and produces `.kiro/skills/.ruler-managed.json` plus `.kiro/skills/<name>/SKILL.md`. A follow-up `apply --no-skills` removed only the Ruler-managed entries and left a hand-written `.kiro/skills/hand-written/SKILL.md` untouched.
